### PR TITLE
Docs: 배포 전략 문서 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@
 
 - Flutter 명령은 `fvm flutter ...` 또는 `fvm dart ...` 형태로 실행한다.
 - `main`과 `develop`에는 직접 작업하지 않는다.
-- 새 feature 브랜치는 `develop`에서 생성한다.
+- 모든 일반 작업 브랜치는 `develop`에서 생성한다.
+- `main`은 publish/production 브랜치로만 사용한다.
+- 운영 긴급 수정이 아닌 경우 `main`에서 브랜치를 파생하지 않는다.
 - 화면 구현 전 공통 위젯과 디자인 토큰 재사용 가능 여부를 먼저 확인한다.
 - API 응답 파싱, 비즈니스 로직, 비동기 상태 처리를 화면 위젯에 직접 넣지 않는다.
 - 결정되지 않은 정책은 임의로 확정하지 않고 사용자에게 질문한다.
@@ -27,6 +29,7 @@
 | form validation, helper/error message | `docs/form-validation-error-guide.md` |
 | unit/widget test 추가 또는 수정 | `docs/testing-guide.md` |
 | 브랜치, 커밋, PR | `docs/git-workflow.md` |
+| 배포, 릴리즈, 스토어 자동화 | `docs/release-workflow.md` |
 
 작업 시작 시 참고한 문서를 짧게 언급한다.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ lib/
 
 ## 확정된 협업 및 기술 기준
 
-- 브랜치는 `develop`을 통합 기준으로 사용하고, 각 feature 브랜치는 `develop`에서 생성합니다.
+- 브랜치는 `develop`을 통합 기준으로 사용하고, 각 작업 브랜치는 `develop`에서 생성합니다.
+- `main`은 실제 publish/production 브랜치로 사용하고 직접 작업하지 않습니다.
+- 배포 후보는 `develop`에서 `release/*` 브랜치를 생성해 안정화한 뒤 `main`으로 PR을 보냅니다.
+- 운영 긴급 수정만 예외적으로 `main`에서 `hotfix/*` 브랜치를 생성하고, 배포 후 `develop`에 되돌려 반영합니다.
 - HTTP 클라이언트는 API 연동 시점에 `dio`를 기준으로 도입합니다.
 - API 모델은 `freezed`와 `json_serializable` 기반 생성을 기본 방향으로 삼되, 실제 패키지 추가는 첫 API 연동 PR에서 함께 진행합니다.
 - 인증 토큰은 `flutter_secure_storage` 기반 보관을 기본 방향으로 합니다.
@@ -138,6 +141,7 @@ lib/
 | [폼 검증 및 에러 메시지 작성 기준](docs/form-validation-error-guide.md) | 입력 검증 위치, helper/error 메시지, 서버 에러 처리 기준 |
 | [테스트 작성 기준](docs/testing-guide.md) | unit/widget test 작성 기준, 실행 명령, CI/pre-commit 연계 |
 | [Git 브랜치 및 커밋 전략](docs/git-workflow.md) | 브랜치 전략, 커밋 메시지, PR 체크리스트 |
+| [배포 및 릴리즈 자동화 전략](docs/release-workflow.md) | `main` publish 전략, release 브랜치, Android/iOS 자동화 단계 |
 
 ## 품질 게이트
 
@@ -180,3 +184,4 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 
 - [ ] 백엔드 에러 코드와 사용자 메시지 매핑표
 - [ ] Golden test 및 integration test 도입 범위
+- [ ] Android/iOS 스토어 계정, signing secret, 배포 대상

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,16 +1,18 @@
 # Git 브랜치 및 커밋 전략
 
-커먼플랜트는 기능 단위 브랜치와 작은 커밋을 기준으로 협업합니다. `main`과 `develop`에는 직접 작업하지 않고, 작업 단위별 브랜치에서 PR을 통해 병합합니다.
+커먼플랜트는 기능 단위 브랜치와 작은 커밋을 기준으로 협업합니다. `develop`을 기본 개발 브랜치로 사용하고, `main`은 실제 publish/production 브랜치로만 사용합니다. `main`과 `develop`에는 직접 작업하지 않고, 작업 단위별 브랜치에서 PR을 통해 병합합니다.
 
 ## 브랜치 원칙
 
-- `main`: 배포 가능한 안정 버전
-- `develop`: 다음 배포를 준비하는 통합 브랜치
+- `main`: 실제 publish/production 브랜치
+- `develop`: 기본 개발/통합 브랜치
 - `feature/*`: 기능 개발
 - `fix/*`: 버그 수정
 - `refactor/*`: 구조 개선
 - `docs/*`: 문서 작업
 - `chore/*`: 설정, 빌드, 의존성 등 기타 작업
+- `release/*`: `develop`에서 생성하는 배포 후보 안정화 브랜치
+- `hotfix/*`: 운영 긴급 수정 시에만 `main`에서 생성하는 예외 브랜치
 
 브랜치 이름은 작업 의도를 드러내는 영어 kebab-case를 사용합니다.
 
@@ -20,6 +22,8 @@ feature/place-list
 fix/plant-card-overflow
 docs/project-guides
 chore/update-lefthook
+release/1.0.0
+hotfix/1.0.1
 ```
 
 ## 작업 시작 기준
@@ -36,6 +40,30 @@ git switch -c feature/place-list
 ```
 
 `develop` 브랜치는 다음 배포를 준비하는 통합 브랜치이며, 모든 기능 브랜치는 `develop`에서 시작합니다.
+
+## 배포 브랜치 전략
+
+`main`은 실제 배포 가능한 코드만 유지합니다. 일반 기능 개발, 문서 작업, 리팩터링, 설정 변경은 모두 `develop`에서 파생한 브랜치로 진행하고 `develop`에 PR을 보냅니다.
+
+배포가 필요할 때는 아래 흐름을 사용합니다.
+
+```bash
+git switch develop
+git pull --ff-only
+git switch -c release/1.0.0
+```
+
+`release/*` 브랜치에서는 버전, 빌드번호, 릴리즈 노트, 배포 전 QA 수정만 진행합니다. QA가 끝나면 `release/*`에서 `main`으로 PR을 보내고, `main` 병합 후 `vX.Y.Z` 태그를 생성합니다.
+
+운영 배포 후 긴급 수정이 필요한 경우에만 `main`에서 `hotfix/*`를 생성할 수 있습니다.
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c hotfix/1.0.1
+```
+
+`hotfix/*`는 `main`으로 먼저 PR을 보내 배포하고, 동일 수정 사항을 반드시 `develop`에도 반영합니다.
 
 ## 커밋 메시지 규칙
 
@@ -121,6 +149,8 @@ Docs: 프로젝트 작업 가이드 추가
 ## PR 체크리스트
 
 - [ ] 기준 브랜치가 올바른가?
+- [ ] 일반 작업 PR의 base가 `develop`인가?
+- [ ] 배포 PR의 base가 `main`이고 head가 `release/*`인가?
 - [ ] 커밋이 논리적 단위로 정리되었는가?
 - [ ] `fvm dart format --output=none --set-exit-if-changed .`를 통과했는가?
 - [ ] `fvm flutter analyze`를 통과했는가?

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,205 @@
+# 배포 및 릴리즈 자동화 전략
+
+커먼플랜트는 `develop`을 기본 개발/통합 브랜치로 사용하고, `main`을 실제 배포 가능한 publish 브랜치로 사용합니다. 앱 배포 자동화는 Android와 iOS의 서명 정보, 스토어 계정, 심사/승인 정책이 필요하므로 단계적으로 도입합니다.
+
+## 현재 상태
+
+| 항목 | 상태 |
+| --- | --- |
+| 기본 브랜치 | `develop` |
+| 배포 브랜치 | `main` |
+| CI | `.github/workflows/flutter_ci.yml`에서 analyze/test 실행 |
+| Android 배포 자동화 | 미구현 |
+| iOS 배포 자동화 | 미구현 |
+| Store 계정/secret | 미정 |
+
+## 브랜치 전략
+
+모든 일반 작업은 `develop`에서 파생합니다.
+
+```text
+develop
+  ├─ feature/login
+  ├─ feature/place-list
+  ├─ fix/plant-card-overflow
+  ├─ docs/release-workflow
+  └─ release/1.0.0
+
+main
+  └─ v1.0.0
+```
+
+| 브랜치 | 역할 | 생성 기준 | 병합 대상 |
+| --- | --- | --- | --- |
+| `develop` | 기본 개발/통합 브랜치 | 기본 브랜치 | 없음 |
+| `feature/*` | 기능 개발 | `develop` | `develop` |
+| `fix/*` | 일반 버그 수정 | `develop` | `develop` |
+| `docs/*` | 문서 작업 | `develop` | `develop` |
+| `chore/*` | 설정/빌드/의존성 작업 | `develop` | `develop` |
+| `release/*` | 배포 후보 안정화 | `develop` | `main`, 필요 시 `develop` |
+| `hotfix/*` | 운영 긴급 수정 | `main` | `main`, 이후 `develop` |
+| `main` | 실제 publish/production 브랜치 | 직접 작업 금지 | 없음 |
+
+`hotfix/*`는 운영 배포 이후 긴급 수정이 필요한 예외 상황에서만 `main`에서 파생합니다. 일반 기능, 문서, 리팩터링, 설정 작업은 항상 `develop`에서 시작합니다.
+
+## 릴리즈 흐름
+
+1. 일반 작업은 `develop`에서 브랜치를 생성합니다.
+2. PR을 통해 `develop`에 병합합니다.
+3. 배포 후보가 준비되면 `develop`에서 `release/x.y.z` 브랜치를 생성합니다.
+4. `release/x.y.z`에서 버전, 빌드번호, 릴리즈 노트, 스토어 메타데이터를 정리합니다.
+5. QA가 끝나면 `release/x.y.z`를 `main`으로 PR 보냅니다.
+6. `main`에 병합한 뒤 `vX.Y.Z` 태그를 생성합니다.
+7. 태그 또는 `main` push를 기준으로 스토어 배포 workflow를 실행합니다.
+8. release 브랜치에서만 발생한 버전/문서 수정이 있으면 `develop`에도 반영합니다.
+
+## 배포 자동화 단계
+
+한 번에 production 배포까지 자동화하지 않고 아래 순서로 도입합니다.
+
+### 1단계: Release Build 생성
+
+- Android `.aab` 생성
+- iOS archive 생성
+- 빌드 산출물을 GitHub Actions artifact로 보관
+
+목표는 서명과 스토어 업로드 전에 release build가 안정적으로 만들어지는지 확인하는 것입니다.
+
+### 2단계: 내부 테스트 배포
+
+- Android: Google Play Internal testing 또는 Firebase App Distribution
+- iOS: TestFlight
+
+실제 사용자 배포 전 QA용 빌드를 자동으로 배포합니다.
+
+### 3단계: Production 배포 준비
+
+- `main` 또는 `v*` 태그 기준으로 production candidate를 생성합니다.
+- GitHub Environments의 manual approval을 사용해 실수로 운영 배포되는 것을 막습니다.
+- Android production track, App Store 제출은 승인 단계 이후 진행합니다.
+
+### 4단계: Production 배포 자동화
+
+- Android production track 업로드
+- iOS App Store 제출 또는 TestFlight에서 심사 제출
+- 릴리즈 노트와 버전 태그를 함께 관리
+
+초기에는 production 자동 제출보다 internal/test 배포 자동화를 우선합니다.
+
+## 추천 트리거
+
+| 이벤트 | 실행 작업 |
+| --- | --- |
+| PR to `develop` | format, analyze, test |
+| push to `develop` | QA build 또는 내부 테스트 배포 후보 |
+| PR to `main` | release quality gate |
+| push to `main` | publish build 생성 |
+| tag `v*` | 스토어 업로드 workflow 실행 |
+
+운영 배포는 `tag v*` 기준을 추천합니다. `main`에 병합된 모든 커밋이 자동 배포되는 것보다 명시적인 릴리즈 의도가 드러나기 때문입니다.
+
+## 버전 전략
+
+`pubspec.yaml`의 버전은 아래 형식을 따릅니다.
+
+```yaml
+version: 1.0.0+1
+```
+
+| 값 | 의미 | 관리 기준 |
+| --- | --- | --- |
+| `1.0.0` | 사용자에게 보이는 앱 버전 | release 브랜치에서 수동 변경 |
+| `+1` | store build number | 초기에는 수동, 자동화 후 GitHub run number 검토 |
+
+추천 방향:
+
+- 앱 버전은 `release/x.y.z` 브랜치에서 명시적으로 올립니다.
+- build number는 자동화가 안정화되면 GitHub Actions run number 또는 별도 버전 관리 액션으로 전환합니다.
+- 태그는 앱 버전과 맞춰 `v1.0.0` 형식으로 생성합니다.
+
+## Android 자동화 기준
+
+Android 배포 자동화에는 아래가 필요합니다.
+
+| 항목 | 설명 |
+| --- | --- |
+| Keystore | release signing용 keystore |
+| Keystore password | keystore 비밀번호 |
+| Key alias | signing key alias |
+| Key password | signing key 비밀번호 |
+| Google Play service account | Play Console 업로드 권한 JSON |
+| Package name | Android application id |
+
+추천 GitHub Secrets:
+
+```text
+ANDROID_KEYSTORE_BASE64
+ANDROID_KEYSTORE_PASSWORD
+ANDROID_KEY_ALIAS
+ANDROID_KEY_PASSWORD
+GOOGLE_PLAY_SERVICE_ACCOUNT_JSON
+```
+
+초기 workflow는 `fvm flutter build appbundle --release`까지 먼저 자동화하고, 서명/업로드는 secret 준비 후 추가합니다.
+
+## iOS 자동화 기준
+
+iOS 배포 자동화에는 macOS runner와 Apple 서명 자산이 필요합니다.
+
+| 항목 | 설명 |
+| --- | --- |
+| App Store Connect API Key | TestFlight/App Store 업로드 권한 |
+| Certificate | iOS distribution certificate |
+| Provisioning profile | bundle id에 맞는 profile |
+| Bundle identifier | iOS 앱 bundle id |
+| Team ID | Apple Developer Team ID |
+
+추천 방식:
+
+- Fastlane을 사용해 build, signing, TestFlight 업로드를 관리합니다.
+- 인증서/프로비저닝은 Fastlane match 또는 GitHub Secrets 기반으로 관리합니다.
+- 초기에는 TestFlight 업로드까지만 자동화하고, App Store production 제출은 수동 승인 후 진행합니다.
+
+추천 GitHub Secrets:
+
+```text
+APP_STORE_CONNECT_API_KEY_ID
+APP_STORE_CONNECT_ISSUER_ID
+APP_STORE_CONNECT_API_KEY
+APPLE_TEAM_ID
+IOS_BUNDLE_IDENTIFIER
+MATCH_PASSWORD
+```
+
+## Workflow 파일 계획
+
+| 파일 | 목적 | 도입 시점 |
+| --- | --- | --- |
+| `.github/workflows/flutter_ci.yml` | PR/Push 품질 검사 | 이미 사용 중 |
+| `.github/workflows/android_release.yml` | Android release build 및 내부 테스트 업로드 | Android signing 준비 후 |
+| `.github/workflows/ios_testflight.yml` | iOS archive 및 TestFlight 업로드 | Apple signing 준비 후 |
+| `.github/workflows/publish.yml` | `v*` 태그 기반 production 배포 | 내부 배포 안정화 후 |
+
+secret이 준비되기 전에는 release workflow를 추가하지 않습니다. 실패하는 workflow가 기본 브랜치 품질 게이트를 방해할 수 있기 때문입니다.
+
+## 릴리즈 체크리스트
+
+- [ ] `develop`의 주요 PR이 모두 병합되었는가?
+- [ ] `release/x.y.z` 브랜치를 `develop`에서 생성했는가?
+- [ ] `pubspec.yaml` 버전을 갱신했는가?
+- [ ] 릴리즈 노트를 작성했는가?
+- [ ] `fvm flutter analyze`를 통과했는가?
+- [ ] `fvm flutter test`를 통과했는가?
+- [ ] Android release build가 생성되는가?
+- [ ] iOS archive가 생성되는가?
+- [ ] QA 승인 또는 내부 테스트 승인이 완료되었는가?
+- [ ] `main` PR 리뷰가 완료되었는가?
+- [ ] `main` 병합 후 `vX.Y.Z` 태그를 생성했는가?
+
+## 결정 필요
+
+- Android 배포 대상을 Google Play Internal testing으로 할지 Firebase App Distribution으로 할지 정해야 합니다.
+- iOS 인증서 관리를 Fastlane match로 할지 GitHub Secrets로 직접 관리할지 정해야 합니다.
+- dev/staging/prod flavor를 둘지 결정해야 합니다.
+- 앱 버전과 build number 자동 증가 방식을 정해야 합니다.
+- production 배포를 완전 자동화할지, manual approval을 둘지 정해야 합니다.


### PR DESCRIPTION
## 관련 이슈
- 없음

## 구현 범위
- `docs/release-workflow.md`를 추가해 Android/iOS 배포 자동화 도입 전략을 정리했습니다.
- `develop` 기반 작업 브랜치 전략과 `main` publish/production 브랜치 전략을 README, AGENTS, Git workflow 문서에 반영했습니다.
- `release/*`, `hotfix/*`, `v*` 태그 기반 릴리즈 흐름을 문서화했습니다.

## 주요 변경사항
- 모든 일반 작업 브랜치는 `develop`에서 파생하도록 명시했습니다.
- `main`은 직접 작업하지 않는 실제 publish/production 브랜치로 정의했습니다.
- 배포 후보는 `develop`에서 `release/*` 브랜치를 만들고, QA 후 `main`으로 PR을 보내는 흐름으로 정리했습니다.
- 운영 긴급 수정은 예외적으로 `main`에서 `hotfix/*`를 만들고, 배포 후 `develop`에 되돌려 반영하도록 정리했습니다.
- 배포 자동화는 release build 생성 → 내부 테스트 배포 → production 준비 → production 자동화 순서로 단계화했습니다.

## 리뷰 포인트
- `main`을 publish/production 브랜치로 쓰는 전략이 팀 운영 방식에 맞는지 확인 부탁드립니다.
- Android/iOS 배포 자동화 단계와 필요한 secrets 목록이 적절한지 확인 부탁드립니다.
- `release/*`, `hotfix/*`, `v*` 태그 흐름이 과하지 않은지 확인 부탁드립니다.

## 테스트 여부
- [x] `git diff --check` 통과
- [ ] `fvm flutter analyze` 문서 변경만 있어 미실행
- [ ] `fvm flutter test` 문서 변경만 있어 미실행

## 문서 반영 여부
- [x] README 갱신
- [x] AGENTS 갱신
- [x] Git workflow 문서 갱신
- [x] Release workflow 문서 추가

## Breaking change 여부
- 없음
