### PR TITLE
Feat: 장소 등록 화면 구현 #17

### DIFF
--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -1,5 +1,6 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/common/presentation/widgets/phase0_widgets.dart';
@@ -47,6 +48,19 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   Widget build(BuildContext context) {
     final canSubmit = _nameController.text.trim().isNotEmpty;
 
+    if (!widget.isEdit) {
+      return _PlaceCreateScaffold(
+        nameController: _nameController,
+        address: _address,
+        canSubmit: canSubmit,
+        onNameChanged: (_) => setState(() {}),
+        onImageTap: () {},
+        onAddressTap: () => context.push(AppRoutePaths.addressSearch),
+        onAddressClear: () => setState(() => _address = null),
+        onNext: _submit,
+      );
+    }
+
     return CommonScaffold(
       title: widget.isEdit ? '장소 수정' : '장소 등록',
       child: Column(
@@ -64,7 +78,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
           CommonTextField(
             controller: _nameController,
             hintText: '장소 이름을 입력해 주세요',
-            maxLength: 20,
+            maxLength: 10,
             onChanged: (_) => setState(() {}),
           ),
           const SizedBox(height: AppSpacing.x24),
@@ -115,10 +129,101 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
 
     if (widget.placeId case final placeId?) {
       notifier.updatePlace(id: placeId, name: name, address: _address);
+      context.go(AppRoutePaths.home);
     } else {
       notifier.addPlace(name: name, address: _address);
+      context.push(AppRoutePaths.placeFriendAdd);
     }
+  }
+}
 
-    context.go(AppRoutePaths.home);
+class _PlaceCreateScaffold extends StatelessWidget {
+  const _PlaceCreateScaffold({
+    required this.nameController,
+    required this.address,
+    required this.canSubmit,
+    required this.onNameChanged,
+    required this.onImageTap,
+    required this.onAddressTap,
+    required this.onAddressClear,
+    required this.onNext,
+  });
+
+  final TextEditingController nameController;
+  final String? address;
+  final bool canSubmit;
+  final ValueChanged<String> onNameChanged;
+  final VoidCallback onImageTap;
+  final VoidCallback onAddressTap;
+  final VoidCallback onAddressClear;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '장소 등록',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.x20,
+                        AppSpacing.x24,
+                        AppSpacing.x20,
+                        AppSizes.buttonHeight + AppSpacing.x40,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Center(
+                            child: CommonPlaceImageAddButton(onTap: onImageTap),
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonTextField(
+                            controller: nameController,
+                            hintText: '장소의 이름을 입력해 주세요',
+                            maxLength: 10,
+                            onChanged: onNameChanged,
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonAddressOrPlaceField(
+                            label: '주소',
+                            value: address,
+                            onTap: onAddressTap,
+                            onClear: onAddressClear,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Positioned(
+                      left: AppSpacing.x20,
+                      right: AppSpacing.x20,
+                      bottom: AppSpacing.x16,
+                      child: CommonButton(
+                        label: '다음',
+                        onPressed: canSubmit ? onNext : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/place/presentation/pages/place_friend_add_page.dart
+++ b/lib/features/place/presentation/pages/place_friend_add_page.dart
@@ -1,3 +1,4 @@
+import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
@@ -6,6 +7,7 @@ import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class PlaceFriendAddPage extends StatefulWidget {
   const PlaceFriendAddPage({super.key});
@@ -113,7 +115,7 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
             label: '선택 완료',
             onPressed: _selectedIds.isEmpty
                 ? null
-                : () => Navigator.of(context).maybePop(),
+                : () => context.go(AppRoutePaths.home),
           ),
         ],
       ),

--- a/lib/shared/widgets/common_place_image_add_button.dart
+++ b/lib/shared/widgets/common_place_image_add_button.dart
@@ -29,7 +29,7 @@ class CommonPlaceImageAddButton extends StatelessWidget {
               height: AppSizes.placeImageAddInnerSize,
               decoration: BoxDecoration(
                 color: AppColors.borderDefault,
-                borderRadius: BorderRadius.circular(AppRadius.small),
+                borderRadius: BorderRadius.circular(AppRadius.medium),
               ),
               alignment: Alignment.center,
               child: const CommonSvgIcon(

--- a/lib/shared/widgets/common_text_field.dart
+++ b/lib/shared/widgets/common_text_field.dart
@@ -219,7 +219,7 @@ class _CommonTextFieldState extends State<CommonTextField> {
                     counterText: '',
                     border: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
-                      vertical: AppSpacing.x8,
+                      vertical: AppSpacing.x16,
                     ),
                     isDense: true,
                   ),

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -181,10 +181,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('장소 등록'), findsOneWidget);
-    expect(find.text('장소 이름'), findsOneWidget);
+    expect(find.text('장소의 이름을 입력해 주세요'), findsOneWidget);
   });
 
-  testWidgets('장소 등록 후 홈에 장소가 추가되고 식물 추가가 활성화된다', (WidgetTester tester) async {
+  testWidgets('장소 등록 다음 단계 후 홈에 장소가 추가되고 식물 추가가 활성화된다', (
+    WidgetTester tester,
+  ) async {
     final router = createAppRouter(initialLocation: AppRoutePaths.placeCreate);
     addTearDown(router.dispose);
 
@@ -198,8 +200,14 @@ void main() {
 
     await tester.enterText(find.byType(TextField), '옥상 정원');
     await tester.pump();
-    await tester.ensureVisible(find.text('등록'));
-    await tester.tap(find.text('등록'));
+    await tester.ensureVisible(find.text('다음'));
+    await tester.tap(find.text('다음'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('친구 추가'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('선택 완료'));
+    await tester.tap(find.text('선택 완료'));
     await tester.pumpAndSettle();
 
     expect(find.text('My place'), findsOneWidget);
@@ -231,8 +239,11 @@ void main() {
 
     await tester.enterText(find.byType(TextField), '옥상 정원');
     await tester.pump();
-    await tester.ensureVisible(find.text('등록'));
-    await tester.tap(find.text('등록'));
+    await tester.ensureVisible(find.text('다음'));
+    await tester.tap(find.text('다음'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('선택 완료'));
+    await tester.tap(find.text('선택 완료'));
     await tester.pumpAndSettle();
 
     await tester.ensureVisible(find.text('식물 추가하기'));
@@ -278,7 +289,9 @@ void main() {
     router.pop();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('친구 추가하기'));
+    await tester.enterText(find.byType(TextField), '옥상 정원');
+    await tester.pump();
+    await tester.tap(find.text('다음'));
     await tester.pumpAndSettle();
 
     expect(find.text('친구 추가'), findsOneWidget);


### PR DESCRIPTION
## 관련 이슈
- #17

## 구현 범위
- Figma `node-id=1:4132` 기준 장소 등록 화면 구현
- 장소 이미지, 장소명 입력, 주소 선택 필드, 하단 `다음` CTA 구성
- `다음` 이후 기존 mock 친구 추가 화면으로 이어지는 흐름 정리

## 주요 변경사항
- 장소 등록 화면을 Figma 구조에 맞게 별도 scaffold로 구성
- 장소명 최대 길이를 Figma 기준 10자로 조정
- 장소 이미지 추가 버튼 radius와 CommonTextField 높이감을 Figma 입력 필드에 맞게 보정
- 라우팅 테스트를 장소 등록 -> 친구 추가 -> 홈 흐름에 맞게 갱신

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`

## 문서 반영 여부
- 기존 화면 퍼블리싱/공용 위젯 규칙 내 변경이라 별도 문서 수정 없음

## Breaking change
- 없음