### PR TITLE
Feat: 주소 검색 화면 구현 #17

### DIFF
--- a/lib/features/place/presentation/pages/address_search_page.dart
+++ b/lib/features/place/presentation/pages/address_search_page.dart
@@ -1,12 +1,17 @@
-import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/common/presentation/widgets/phase0_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
-import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+
+const double _addressSearchResultHeight = 72;
+const double _addressSearchResultGap = 4;
+const double _addressSearchButtonWidth = 73;
+const double _addressSearchButtonHeight = 36;
+const double _addressSearchResultTextWidth = 219;
 
 class AddressSearchPage extends StatefulWidget {
   const AddressSearchPage({super.key});
@@ -16,12 +21,57 @@ class AddressSearchPage extends StatefulWidget {
 }
 
 class _AddressSearchPageState extends State<AddressSearchPage> {
-  final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _searchController = TextEditingController(
+    text: '신도림역',
+  );
 
-  static const List<String> _addresses = [
-    '서울시 노원구 광운로 20',
-    '서울시 성동구 연무장길 12',
-    '서울시 마포구 월드컵북로 10',
+  static const List<_AddressSearchResult> _addresses = [
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '1호선',
+      address: '서울 구로구 경인로 688',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+      highlighted: true,
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
+    _AddressSearchResult(
+      titlePrefix: '신도림역',
+      titleSuffix: '2호선',
+      address: '서울 구로구 새말로 지하 117-21',
+    ),
   ];
 
   @override
@@ -35,45 +85,91 @@ class _AddressSearchPageState extends State<AddressSearchPage> {
     final query = _searchController.text.trim();
     final results = query.isEmpty
         ? _addresses
-        : _addresses.where((address) => address.contains(query)).toList();
+        : _addresses
+              .where(
+                (result) =>
+                    result.title.contains(query) ||
+                    result.address.contains(query),
+              )
+              .toList();
 
-    return CommonScaffold(
-      title: '주소 검색',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          CommonSearchTextField(
-            controller: _searchController,
-            hintText: '주소를 입력해 주세요.',
-            onChanged: (_) => setState(() {}),
-          ),
-          const SizedBox(height: AppSpacing.x24),
-          if (results.isEmpty)
-            const Phase0EmptyState(
-              title: '검색 결과가 없어요',
-              description: '도로명이나 건물명을 다시 입력해 주세요.',
-              icon: CommonSvgIcon(
-                AppIconAssets.placeEmpty,
-                height: 72,
-                semanticsLabel: '주소 없음',
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            CommonNavigationBar(
+              title: '주소 검색',
+              titleStyle: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+                fontWeight: FontWeight.w700,
               ),
-            )
-          else
-            for (final address in results) ...[
-              Phase0Surface(
-                onTap: () => Navigator.of(context).maybePop(),
+            ),
+            CommonSearchTextField(
+              controller: _searchController,
+              hintText: '주소를 입력해 주세요.',
+              horizontalPadding: AppSpacing.x20,
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: _addressSearchResultGap),
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.only(
+                  bottom: AppSpacing.x40 + AppSizes.navigationBarHeight,
+                ),
+                itemCount: results.length,
+                separatorBuilder: (_, _) =>
+                    const SizedBox(height: _addressSearchResultGap),
+                itemBuilder: (context, index) {
+                  final result = results[index];
+
+                  return _AddressSearchResultTile(
+                    result: result,
+                    onSelect: () => Navigator.of(context).maybePop(),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddressSearchResultTile extends StatelessWidget {
+  const _AddressSearchResultTile({
+    required this.result,
+    required this.onSelect,
+  });
+
+  final _AddressSearchResult result;
+  final VoidCallback onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: result.highlighted ? AppColors.surfaceDisabled : AppColors.white,
+      child: SizedBox(
+        height: _addressSearchResultHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x20,
+            vertical: AppSpacing.x12,
+          ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: _addressSearchResultTextWidth,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      address,
-                      style: AppTextStyles.size16Bold.copyWith(
-                        color: AppColors.textStrong,
-                      ),
-                    ),
+                    _AddressSearchResultTitle(result: result),
                     const SizedBox(height: AppSpacing.x4),
                     Text(
-                      '건물명 · 커먼플랜트 샘플 주소',
+                      result.address,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: AppTextStyles.size14Medium.copyWith(
                         color: AppColors.textBody,
                       ),
@@ -81,10 +177,92 @@ class _AddressSearchPageState extends State<AddressSearchPage> {
                   ],
                 ),
               ),
-              const SizedBox(height: AppSpacing.x12),
+              const Spacer(),
+              _AddressSearchSelectButton(onPressed: onSelect),
             ],
-        ],
+          ),
+        ),
       ),
     );
   }
+}
+
+class _AddressSearchResultTitle extends StatelessWidget {
+  const _AddressSearchResultTitle({required this.result});
+
+  final _AddressSearchResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: '${result.titlePrefix} ',
+            style: AppTextStyles.size18Medium.copyWith(
+              color: AppColors.brandStrong,
+            ),
+          ),
+          TextSpan(
+            text: result.titleSuffix,
+            style: AppTextStyles.size18Medium.copyWith(
+              color: AppColors.textHeadline,
+            ),
+          ),
+        ],
+      ),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
+class _AddressSearchSelectButton extends StatelessWidget {
+  const _AddressSearchSelectButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: _addressSearchButtonWidth,
+      height: _addressSearchButtonHeight,
+      child: OutlinedButton(
+        onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          backgroundColor: AppColors.white,
+          foregroundColor: AppColors.textStrong,
+          padding: EdgeInsets.zero,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          side: const BorderSide(color: AppColors.borderMuted),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.xSmall),
+          ),
+          textStyle: AppTextStyles.size14Medium,
+        ),
+        child: Text(
+          '선택',
+          style: AppTextStyles.size14Medium.copyWith(
+            color: AppColors.textStrong,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddressSearchResult {
+  const _AddressSearchResult({
+    required this.titlePrefix,
+    required this.titleSuffix,
+    required this.address,
+    this.highlighted = false,
+  });
+
+  final String titlePrefix;
+  final String titleSuffix;
+  final String address;
+  final bool highlighted;
+
+  String get title => '$titlePrefix $titleSuffix';
 }

--- a/lib/features/place/presentation/pages/address_search_page.dart
+++ b/lib/features/place/presentation/pages/address_search_page.dart
@@ -11,6 +11,7 @@ const double _addressSearchResultHeight = 72;
 const double _addressSearchResultGap = 4;
 const double _addressSearchButtonWidth = 73;
 const double _addressSearchButtonHeight = 36;
+const double _addressSearchResultVerticalPadding = AppSpacing.x10;
 const double _addressSearchResultTextWidth = 219;
 
 class AddressSearchPage extends StatefulWidget {
@@ -155,7 +156,7 @@ class _AddressSearchResultTile extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(
             horizontal: AppSpacing.x20,
-            vertical: AppSpacing.x12,
+            vertical: _addressSearchResultVerticalPadding,
           ),
           child: Row(
             children: [
@@ -163,6 +164,7 @@ class _AddressSearchResultTile extends StatelessWidget {
                 width: _addressSearchResultTextWidth,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     _AddressSearchResultTitle(result: result),
                     const SizedBox(height: AppSpacing.x4),

--- a/lib/shared/widgets/common_search_text_field.dart
+++ b/lib/shared/widgets/common_search_text_field.dart
@@ -14,6 +14,7 @@ class CommonSearchTextField extends StatefulWidget {
     this.hintText = '식물을 입력해 주세요.',
     this.onChanged,
     this.enabled = true,
+    this.horizontalPadding = 0,
   });
 
   final TextEditingController? controller;
@@ -21,6 +22,7 @@ class CommonSearchTextField extends StatefulWidget {
   final String hintText;
   final ValueChanged<String>? onChanged;
   final bool enabled;
+  final double horizontalPadding;
 
   @override
   State<CommonSearchTextField> createState() => _CommonSearchTextFieldState();
@@ -84,40 +86,43 @@ class _CommonSearchTextFieldState extends State<CommonSearchTextField> {
       child: SizedBox(
         width: double.infinity,
         height: AppSizes.searchTextFieldHeight,
-        child: Row(
-          children: [
-            const CommonSvgIcon(
-              AppIconAssets.search,
-              width: AppSizes.searchTextFieldIconSize,
-              height: AppSizes.searchTextFieldIconSize,
-              semanticsLabel: '검색',
-            ),
-            const SizedBox(width: AppSpacing.x16),
-            Expanded(
-              child: TextField(
-                controller: _controller,
-                focusNode: _focusNode,
-                enabled: widget.enabled,
-                onChanged: widget.onChanged,
-                style: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.textHeadline,
-                ),
-                decoration: InputDecoration(
-                  hintText: widget.hintText,
-                  hintStyle: AppTextStyles.size18Medium.copyWith(
-                    color: AppColors.textDisabled,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: widget.horizontalPadding),
+          child: Row(
+            children: [
+              const CommonSvgIcon(
+                AppIconAssets.search,
+                width: AppSizes.searchTextFieldIconSize,
+                height: AppSizes.searchTextFieldIconSize,
+                semanticsLabel: '검색',
+              ),
+              const SizedBox(width: AppSpacing.x16),
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  enabled: widget.enabled,
+                  onChanged: widget.onChanged,
+                  style: AppTextStyles.size18Medium.copyWith(
+                    color: AppColors.textHeadline,
                   ),
-                  border: InputBorder.none,
-                  contentPadding: EdgeInsets.zero,
-                  isDense: true,
+                  decoration: InputDecoration(
+                    hintText: widget.hintText,
+                    hintStyle: AppTextStyles.size18Medium.copyWith(
+                      color: AppColors.textDisabled,
+                    ),
+                    border: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    isDense: true,
+                  ),
                 ),
               ),
-            ),
-            if (_hasText) ...[
-              const SizedBox(width: AppSpacing.x16),
-              _SearchTextFieldClearButton(onPressed: _clearText),
+              if (_hasText) ...[
+                const SizedBox(width: AppSpacing.x16),
+                _SearchTextFieldClearButton(onPressed: _clearText),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -284,7 +284,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('주소 검색'), findsOneWidget);
-    expect(find.text('서울시 노원구 광운로 20'), findsOneWidget);
+    expect(find.text('신도림역'), findsOneWidget);
+    expect(find.text('신도림역 1호선', findRichText: true), findsOneWidget);
 
     router.pop();
     await tester.pumpAndSettle();

--- a/test/features/place/presentation/pages/address_search_page_test.dart
+++ b/test/features/place/presentation/pages/address_search_page_test.dart
@@ -13,11 +13,13 @@ void main() {
     expect(find.text('신도림역 1호선', findRichText: true), findsOneWidget);
     expect(find.text('서울 구로구 경인로 688'), findsOneWidget);
     expect(find.text('선택'), findsWidgets);
+    expect(tester.takeException(), isNull);
 
     await tester.drag(find.byType(ListView), const Offset(0, -260));
     await tester.pumpAndSettle();
 
     expect(find.text('선택'), findsWidgets);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('주소 검색 결과를 선택하면 이전 화면으로 돌아간다', (WidgetTester tester) async {

--- a/test/features/place/presentation/pages/address_search_page_test.dart
+++ b/test/features/place/presentation/pages/address_search_page_test.dart
@@ -1,0 +1,57 @@
+import 'package:commonplant_frontend/features/place/presentation/pages/address_search_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('주소 검색 화면은 Figma 기준 검색어와 결과 목록을 표시한다', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: AddressSearchPage()));
+
+    expect(find.text('주소 검색'), findsOneWidget);
+    expect(find.text('신도림역'), findsOneWidget);
+    expect(find.text('신도림역 1호선', findRichText: true), findsOneWidget);
+    expect(find.text('서울 구로구 경인로 688'), findsOneWidget);
+    expect(find.text('선택'), findsWidgets);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -260));
+    await tester.pumpAndSettle();
+
+    expect(find.text('선택'), findsWidgets);
+  });
+
+  testWidgets('주소 검색 결과를 선택하면 이전 화면으로 돌아간다', (WidgetTester tester) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const AddressSearchPage(),
+                    ),
+                  );
+                },
+                child: const Text('주소 검색 열기'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('주소 검색 열기'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('선택').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('주소 검색 열기'), findsOneWidget);
+    expect(navigatorKey.currentState?.canPop(), isFalse);
+  });
+}


### PR DESCRIPTION
## 관련 이슈
- #17

## 구현 범위
- Figma `node-id=1:4151` 기준 주소 검색 화면 구현
- 검색어 입력 상태와 주소 검색 결과 리스트 구성
- 결과 선택 버튼 탭 시 이전 화면으로 돌아가는 mock 흐름 유지

## 주요 변경사항
- 주소 검색 화면을 Figma 구조에 맞게 상단 검색 필드 + 결과 리스트로 재구성
- `CommonSearchTextField`에 full-width 화면 대응용 horizontal padding 옵션 추가
- 주소 검색 화면 렌더링/스크롤/선택 동작 테스트 추가
- 장소 등록 -> 주소 검색 라우팅 테스트 기대값 갱신

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`

## 문서 반영 여부
- 기존 화면 퍼블리싱/공용 검색 필드 규칙 내 옵션 확장이라 별도 문서 수정 없음

## Breaking change
- 없음