### PR TITLE
Feat: 친구 관리 화면 구현 #17

### DIFF
--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -44,8 +44,8 @@
 | Place | 친구 추가 | `/places/new/friends` | `#2-2-2-2 장소 등록-친구 추가 (기존 친구x) 과정1` | `1:3351` | 검색 결과 | #25 | 검색어 `커먼` 입력 상태 |
 | Place | 친구 추가 | `/places/new/friends` | `#2-2-2-2 장소 등록-친구 추가 (기존 친구x) 과정2` | `1:3660` | 친구 선택 후 | #29 | 검색어 `커먼` 입력 후 선택 친구 마크 표시 |
 | Place | 장소 수정 | `/places/:placeId/edit` | `#2-2-2 장소 수정` | `1:4220` | 기본 | #31 | 중복 후보 `1:6261`보다 최신 위치의 프레임 우선 |
-| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리` | `1:3417` | 기본 | 대기 |  |
-| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿 (리더` | `1:3491` | alert | 대기 | 친구 삭제 확인 dialog |
+| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리` | `1:3417` | 기본 | #32 |  |
+| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿 (리더` | `1:3491` | alert | #32 | 친구 삭제 확인 dialog |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 리더화면` | 확인 필요 | 리더 | 대기 |  |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 팀원화면` | 확인 필요 | 팀원 | 대기 |  |
 | Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | 확인 필요 | 기본 | 대기 |  |

--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -45,7 +45,7 @@
 | Place | 친구 추가 | `/places/new/friends` | `#2-2-2-2 장소 등록-친구 추가 (기존 친구x) 과정2` | `1:3660` | 친구 선택 후 | #29 | 검색어 `커먼` 입력 후 선택 친구 마크 표시 |
 | Place | 장소 수정 | `/places/:placeId/edit` | `#2-2-2 장소 수정` | `1:4220` | 기본 | #31 | 중복 후보 `1:6261`보다 최신 위치의 프레임 우선 |
 | Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리` | `1:3417` | 기본 | 대기 |  |
-| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿` | 확인 필요 | alert | 대기 | 친구 관리 구현 전 확인 |
+| Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿 (리더` | `1:3491` | alert | 대기 | 친구 삭제 확인 dialog |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 리더화면` | 확인 필요 | 리더 | 대기 |  |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 팀원화면` | 확인 필요 | 팀원 | 대기 |  |
 | Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | 확인 필요 | 기본 | 대기 |  |

--- a/lib/features/place/presentation/pages/friend_management_page.dart
+++ b/lib/features/place/presentation/pages/friend_management_page.dart
@@ -1,12 +1,17 @@
+import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/common/presentation/widgets/phase0_widgets.dart';
-import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+const double _friendManagementSelectedMarkHeight = 57;
+const double _friendManagementSelectedMarkGap = 4;
 
 class FriendManagementPage extends StatefulWidget {
   const FriendManagementPage({super.key, required this.placeId});
@@ -19,10 +24,15 @@ class FriendManagementPage extends StatefulWidget {
 
 class _FriendManagementPageState extends State<FriendManagementPage> {
   final TextEditingController _searchController = TextEditingController();
-  final List<_PlaceMember> _members = [
-    const _PlaceMember(name: '커먼 파파', role: '리더'),
-    const _PlaceMember(name: '초록이', role: '팀원'),
-    const _PlaceMember(name: '식집사', role: '팀원'),
+  final Set<String> _selectedIds = <String>{'friend-1', 'friend-2'};
+
+  static const List<PlaceFriendProfile> _friends = [
+    PlaceFriendProfile(
+      id: 'friend-1',
+      name: '커먼맘',
+      imageAsset: AppImageAssets.placeFriendAddCommonMom,
+    ),
+    PlaceFriendProfile(id: 'friend-2', name: '커먼 파파'),
   ];
 
   @override
@@ -31,11 +41,28 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
     super.dispose();
   }
 
-  void _showDeleteDialog(_PlaceMember member) {
+  void _toggleFriend(String friendId) {
+    final friend = _friends.firstWhere((friend) => friend.id == friendId);
+
+    if (_selectedIds.contains(friendId)) {
+      _showDeleteDialog(friend);
+      return;
+    }
+
+    setState(() => _selectedIds.add(friendId));
+  }
+
+  void _removeFriend(String friendId) {
+    final friend = _friends.firstWhere((friend) => friend.id == friendId);
+    _showDeleteDialog(friend);
+  }
+
+  void _showDeleteDialog(PlaceFriendProfile friend) {
     showCommonDialog<void>(
       context: context,
+      barrierColor: AppColors.textHeadline.withValues(alpha: 0.6),
       child: CommonDialogCard(
-        title: member.name,
+        title: friend.name,
         message: '님을 친구 목록에서 삭제하시겠습니까?',
         actions: [
           CommonDialogActionButton(
@@ -45,9 +72,8 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
           ),
           CommonDialogActionButton.confirm(
             label: '삭제',
-            foregroundColor: AppColors.danger,
             onPressed: () {
-              setState(() => _members.remove(member));
+              setState(() => _selectedIds.remove(friend.id));
               Navigator.of(context).pop();
             },
           ),
@@ -56,77 +82,87 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
     );
   }
 
+  void _leavePage() {
+    final navigator = Navigator.of(context);
+
+    if (navigator.canPop()) {
+      navigator.maybePop();
+      return;
+    }
+
+    final router = GoRouter.maybeOf(context);
+    if (router == null) {
+      return;
+    }
+
+    if (widget.placeId.isEmpty) {
+      router.go(AppRoutePaths.home);
+      return;
+    }
+
+    router.go(AppRoutePaths.placeDetailLocation(widget.placeId));
+  }
+
   @override
   Widget build(BuildContext context) {
     final query = _searchController.text.trim();
     final results = query.isEmpty
-        ? _members
-        : _members.where((member) => member.name.contains(query)).toList();
+        ? _friends
+        : _friends.where((friend) => friend.name.contains(query)).toList();
+    final selectedFriends = _friends
+        .where((friend) => _selectedIds.contains(friend.id))
+        .toList();
 
-    return CommonScaffold(
-      title: '친구 관리',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          CommonSearchTextField(
-            controller: _searchController,
-            hintText: '친구 닉네임을 입력해 주세요.',
-            onChanged: (_) => setState(() {}),
-          ),
-          const SizedBox(height: AppSpacing.x24),
-          for (final member in results) ...[
-            Phase0Surface(
-              child: Row(
-                children: [
-                  Phase0UserAvatar(label: member.name.characters.first),
-                  const SizedBox(width: AppSpacing.x12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          member.name,
-                          style: AppTextStyles.size16Bold.copyWith(
-                            color: AppColors.textStrong,
-                          ),
-                        ),
-                        Text(
-                          member.role,
-                          style: AppTextStyles.size14Medium.copyWith(
-                            color: member.role == '리더'
-                                ? AppColors.brandStrong
-                                : AppColors.textBody,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (member.role != '리더')
-                    CommonButton.text(
-                      label: '삭제',
-                      size: CommonButtonSize.medium,
-                      foregroundColor: AppColors.danger,
-                      onPressed: () => _showDeleteDialog(member),
-                    ),
-                ],
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '친구 관리',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.x12),
-          ],
-          const SizedBox(height: AppSpacing.x16),
-          CommonButton(
-            label: '친구 추가',
-            onPressed: () => Navigator.of(context).maybePop(),
+              if (selectedFriends.isNotEmpty)
+                PlaceSelectedFriendMarkStrip(
+                  friends: selectedFriends,
+                  onRemove: _removeFriend,
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x16,
+                    AppSpacing.x20,
+                    0,
+                  ),
+                  height: _friendManagementSelectedMarkHeight,
+                  separatorWidth: _friendManagementSelectedMarkGap,
+                ),
+              CommonSearchTextField(
+                controller: _searchController,
+                hintText: '닉네임 검색',
+                horizontalPadding: AppSpacing.x16,
+                onChanged: (_) => setState(() {}),
+              ),
+              Expanded(
+                child: PlaceFriendCandidateList(
+                  friends: results,
+                  selectedIds: _selectedIds,
+                  topPadding: 0,
+                  onToggle: _toggleFriend,
+                ),
+              ),
+              PlaceFriendBottomActions(
+                onCancel: _leavePage,
+                onComplete: _leavePage,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
-}
-
-class _PlaceMember {
-  const _PlaceMember({required this.name, required this.role});
-
-  final String name;
-  final String role;
 }

--- a/lib/features/place/presentation/pages/place_friend_add_page.dart
+++ b/lib/features/place/presentation/pages/place_friend_add_page.dart
@@ -1,26 +1,15 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
-import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-const double _friendAddResultTileHeight = 56;
-const double _friendAddAvatarSize = 40;
-const double _friendAddSelectedMarkWidth = 56;
-const double _friendAddSelectedMarkHeight = 56;
-const double _friendAddSelectedAvatarSize = 36;
-const double _friendAddSelectedDeleteSize = 18;
-const double _friendAddSelectedDeleteTop = -12;
-const double _friendAddSelectedDeleteRight = -8;
-const double _friendAddActionGap = 8;
 const double _friendAddTrailingWidth = 81;
 
 class PlaceFriendAddPage extends StatefulWidget {
@@ -34,28 +23,28 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
   final TextEditingController _searchController = TextEditingController();
   final Set<String> _selectedIds = <String>{};
 
-  static const List<_FriendCandidate> _friends = [
-    _FriendCandidate(
+  static const List<PlaceFriendProfile> _friends = [
+    PlaceFriendProfile(
       id: 'friend-1',
       name: '커먼맘',
       imageAsset: AppImageAssets.placeFriendAddCommonMom,
     ),
-    _FriendCandidate(
+    PlaceFriendProfile(
       id: 'friend-2',
       name: '커먼인척',
       imageAsset: AppImageAssets.placeFriendAddCommonFake,
     ),
-    _FriendCandidate(
+    PlaceFriendProfile(
       id: 'friend-3',
       name: '커먼일뻔',
       imageAsset: AppImageAssets.placeFriendAddCommonAlmost,
     ),
-    _FriendCandidate(
+    PlaceFriendProfile(
       id: 'friend-4',
       name: '커먼일지도',
       imageAsset: AppImageAssets.placeFriendAddCommonMaybe,
     ),
-    _FriendCandidate(id: 'friend-5', name: '커먼 파파'),
+    PlaceFriendProfile(id: 'friend-5', name: '커먼 파파'),
   ];
 
   @override
@@ -93,7 +82,7 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
   Widget build(BuildContext context) {
     final query = _searchController.text.trim();
     final results = query.isEmpty
-        ? const <_FriendCandidate>[]
+        ? const <PlaceFriendProfile>[]
         : _friends.where((friend) => friend.name.contains(query)).toList();
     final selectedFriends = _friends
         .where((friend) => _selectedIds.contains(friend.id))
@@ -116,7 +105,7 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
                 trailing: _FriendAddSkipButton(onPressed: _complete),
               ),
               if (selectedFriends.isNotEmpty)
-                _SelectedFriendMarkStrip(
+                PlaceSelectedFriendMarkStrip(
                   friends: selectedFriends,
                   onRemove: _toggle,
                 ),
@@ -127,13 +116,16 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
                 onChanged: (_) => setState(() {}),
               ),
               Expanded(
-                child: _FriendCandidateList(
+                child: PlaceFriendCandidateList(
                   friends: results,
                   selectedIds: _selectedIds,
                   onToggle: _toggle,
                 ),
               ),
-              _FriendAddBottomActions(onCancel: _cancel, onComplete: _complete),
+              PlaceFriendBottomActions(
+                onCancel: _cancel,
+                onComplete: _complete,
+              ),
             ],
           ),
         ),
@@ -170,339 +162,4 @@ class _FriendAddSkipButton extends StatelessWidget {
       ),
     );
   }
-}
-
-class _SelectedFriendMarkStrip extends StatelessWidget {
-  const _SelectedFriendMarkStrip({
-    required this.friends,
-    required this.onRemove,
-  });
-
-  final List<_FriendCandidate> friends;
-  final ValueChanged<String> onRemove;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        AppSpacing.x16,
-        AppSpacing.x20,
-        AppSpacing.x8,
-      ),
-      child: SizedBox(
-        width: double.infinity,
-        height: _friendAddSelectedMarkHeight,
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          padding: EdgeInsets.zero,
-          itemCount: friends.length,
-          separatorBuilder: (context, index) =>
-              const SizedBox(width: AppSpacing.x12),
-          itemBuilder: (context, index) {
-            final friend = friends[index];
-
-            return _SelectedFriendMark(
-              key: ValueKey('selected-friend-${friend.id}'),
-              friend: friend,
-              onRemove: () => onRemove(friend.id),
-            );
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _SelectedFriendMark extends StatelessWidget {
-  const _SelectedFriendMark({
-    super.key,
-    required this.friend,
-    required this.onRemove,
-  });
-
-  final _FriendCandidate friend;
-  final VoidCallback onRemove;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      container: true,
-      label: '선택된 친구 ${friend.name}',
-      child: SizedBox(
-        width: _friendAddSelectedMarkWidth,
-        height: _friendAddSelectedMarkHeight,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SizedBox(
-              width: _friendAddSelectedMarkWidth,
-              height: _friendAddAvatarSize,
-              child: Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  Positioned(
-                    left: AppSpacing.x10,
-                    top: AppSpacing.x4,
-                    child: _FriendAvatar(
-                      friend: friend,
-                      dimension: _friendAddSelectedAvatarSize,
-                    ),
-                  ),
-                  Positioned(
-                    top: _friendAddSelectedDeleteTop,
-                    right: _friendAddSelectedDeleteRight,
-                    child: _SelectedFriendRemoveButton(
-                      friendId: friend.id,
-                      friendName: friend.name,
-                      onPressed: onRemove,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Text(
-              friend.name,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: AppTextStyles.size12Medium.copyWith(
-                color: AppColors.iconInactive,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SelectedFriendRemoveButton extends StatelessWidget {
-  const _SelectedFriendRemoveButton({
-    required this.friendId,
-    required this.friendName,
-    required this.onPressed,
-  });
-
-  final String friendId;
-  final String friendName;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: AppSizes.iconButtonSize,
-      child: IconButton(
-        key: ValueKey('selected-friend-remove-$friendId'),
-        onPressed: onPressed,
-        tooltip: '$friendName 선택 해제',
-        padding: EdgeInsets.zero,
-        constraints: const BoxConstraints.tightFor(
-          width: AppSizes.iconButtonSize,
-          height: AppSizes.iconButtonSize,
-        ),
-        style: IconButton.styleFrom(
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        ),
-        icon: const CommonSvgIcon(
-          AppIconAssets.delete,
-          width: _friendAddSelectedDeleteSize,
-          height: _friendAddSelectedDeleteSize,
-          color: AppColors.textBody,
-          semanticsLabel: '선택 친구 삭제',
-        ),
-      ),
-    );
-  }
-}
-
-class _FriendCandidateList extends StatelessWidget {
-  const _FriendCandidateList({
-    required this.friends,
-    required this.selectedIds,
-    required this.onToggle,
-  });
-
-  final List<_FriendCandidate> friends;
-  final Set<String> selectedIds;
-  final ValueChanged<String> onToggle;
-
-  @override
-  Widget build(BuildContext context) {
-    if (friends.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    return ListView.builder(
-      padding: const EdgeInsets.only(
-        top: AppSpacing.x8,
-        bottom: AppSpacing.x24,
-      ),
-      itemExtent: _friendAddResultTileHeight,
-      itemCount: friends.length,
-      itemBuilder: (context, index) {
-        final friend = friends[index];
-        final isSelected = selectedIds.contains(friend.id);
-
-        return _FriendCandidateTile(
-          friend: friend,
-          isSelected: isSelected,
-          onTap: () => onToggle(friend.id),
-        );
-      },
-    );
-  }
-}
-
-class _FriendCandidateTile extends StatelessWidget {
-  const _FriendCandidateTile({
-    required this.friend,
-    required this.isSelected,
-    required this.onTap,
-  });
-
-  final _FriendCandidate friend;
-  final bool isSelected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      selected: isSelected,
-      label: '${friend.name} ${isSelected ? '선택됨' : '선택 안됨'}',
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.x20,
-            vertical: AppSpacing.x8,
-          ),
-          child: Row(
-            children: [
-              _FriendAvatar(friend: friend),
-              const SizedBox(width: AppSpacing.x16),
-              Expanded(
-                child: Text(
-                  friend.name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyles.size16Medium.copyWith(
-                    color: AppColors.textStrong,
-                  ),
-                ),
-              ),
-              const SizedBox(width: AppSpacing.x16),
-              _FriendSelectionIcon(isSelected: isSelected),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _FriendAvatar extends StatelessWidget {
-  const _FriendAvatar({
-    required this.friend,
-    this.dimension = _friendAddAvatarSize,
-  });
-
-  final _FriendCandidate friend;
-  final double dimension;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: dimension,
-      child: ClipOval(
-        child: friend.imageAsset == null
-            ? ColoredBox(
-                color: AppColors.borderDefault,
-                child: Center(
-                  child: CommonSvgIcon(
-                    AppIconAssets.addPerson,
-                    width: dimension * 0.7,
-                    height: dimension * 0.7,
-                    color: AppColors.white,
-                    semanticsLabel: '기본 프로필',
-                  ),
-                ),
-              )
-            : Image.asset(friend.imageAsset!, fit: BoxFit.cover),
-      ),
-    );
-  }
-}
-
-class _FriendSelectionIcon extends StatelessWidget {
-  const _FriendSelectionIcon({required this.isSelected});
-
-  final bool isSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return Icon(
-      isSelected ? Icons.check_circle : Icons.radio_button_unchecked,
-      size: AppSizes.iconMedium,
-      color: isSelected ? AppColors.brandAccent : AppColors.textDisabled,
-    );
-  }
-}
-
-class _FriendAddBottomActions extends StatelessWidget {
-  const _FriendAddBottomActions({
-    required this.onCancel,
-    required this.onComplete,
-  });
-
-  final VoidCallback onCancel;
-  final VoidCallback onComplete;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        0,
-        AppSpacing.x20,
-        AppSpacing.x16,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: CommonButton.dark(
-              label: '취소',
-              size: CommonButtonSize.medium,
-              backgroundColor: AppColors.textBody,
-              foregroundColor: AppColors.white,
-              onPressed: onCancel,
-            ),
-          ),
-          const SizedBox(width: _friendAddActionGap),
-          Expanded(
-            child: CommonButton(
-              label: '완료',
-              size: CommonButtonSize.medium,
-              backgroundColor: AppColors.brandAccent,
-              foregroundColor: AppColors.white,
-              onPressed: onComplete,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _FriendCandidate {
-  const _FriendCandidate({
-    required this.id,
-    required this.name,
-    this.imageAsset,
-  });
-
-  final String id;
-  final String name;
-  final String? imageAsset;
 }

--- a/lib/features/place/presentation/widgets/place_friend_selection_widgets.dart
+++ b/lib/features/place/presentation/widgets/place_friend_selection_widgets.dart
@@ -1,0 +1,366 @@
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:flutter/material.dart';
+
+const double placeFriendResultTileHeight = 56;
+const double placeFriendAvatarSize = 40;
+const double placeFriendSelectedMarkWidth = 56;
+const double placeFriendSelectedMarkHeight = 56;
+const double placeFriendSelectedAvatarSize = 36;
+const double placeFriendSelectedDeleteSize = 18;
+const double placeFriendSelectedDeleteTop = -12;
+const double placeFriendSelectedDeleteRight = -8;
+const double placeFriendActionGap = 8;
+
+class PlaceFriendProfile {
+  const PlaceFriendProfile({
+    required this.id,
+    required this.name,
+    this.imageAsset,
+  });
+
+  final String id;
+  final String name;
+  final String? imageAsset;
+}
+
+class PlaceSelectedFriendMarkStrip extends StatelessWidget {
+  const PlaceSelectedFriendMarkStrip({
+    super.key,
+    required this.friends,
+    required this.onRemove,
+    this.padding = const EdgeInsets.fromLTRB(
+      AppSpacing.x20,
+      AppSpacing.x16,
+      AppSpacing.x20,
+      AppSpacing.x8,
+    ),
+    this.height = placeFriendSelectedMarkHeight,
+    this.separatorWidth = AppSpacing.x12,
+  });
+
+  final List<PlaceFriendProfile> friends;
+  final ValueChanged<String> onRemove;
+  final EdgeInsetsGeometry padding;
+  final double height;
+  final double separatorWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: padding,
+      child: SizedBox(
+        width: double.infinity,
+        height: height,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: EdgeInsets.zero,
+          itemCount: friends.length,
+          separatorBuilder: (context, index) => SizedBox(width: separatorWidth),
+          itemBuilder: (context, index) {
+            final friend = friends[index];
+
+            return _SelectedFriendMark(
+              key: ValueKey('selected-friend-${friend.id}'),
+              friend: friend,
+              height: height,
+              onRemove: () => onRemove(friend.id),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class PlaceFriendCandidateList extends StatelessWidget {
+  const PlaceFriendCandidateList({
+    super.key,
+    required this.friends,
+    required this.selectedIds,
+    required this.onToggle,
+    this.topPadding = AppSpacing.x8,
+    this.bottomPadding = AppSpacing.x24,
+  });
+
+  final List<PlaceFriendProfile> friends;
+  final Set<String> selectedIds;
+  final ValueChanged<String> onToggle;
+  final double topPadding;
+  final double bottomPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    if (friends.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return ListView.builder(
+      padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
+      itemExtent: placeFriendResultTileHeight,
+      itemCount: friends.length,
+      itemBuilder: (context, index) {
+        final friend = friends[index];
+        final isSelected = selectedIds.contains(friend.id);
+
+        return _FriendCandidateTile(
+          friend: friend,
+          isSelected: isSelected,
+          onTap: () => onToggle(friend.id),
+        );
+      },
+    );
+  }
+}
+
+class PlaceFriendAvatar extends StatelessWidget {
+  const PlaceFriendAvatar({
+    super.key,
+    required this.friend,
+    this.dimension = placeFriendAvatarSize,
+  });
+
+  final PlaceFriendProfile friend;
+  final double dimension;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: dimension,
+      child: ClipOval(
+        child: friend.imageAsset == null
+            ? ColoredBox(
+                color: AppColors.borderDefault,
+                child: Center(
+                  child: CommonSvgIcon(
+                    AppIconAssets.addPerson,
+                    width: dimension * 0.7,
+                    height: dimension * 0.7,
+                    color: AppColors.white,
+                    semanticsLabel: '기본 프로필',
+                  ),
+                ),
+              )
+            : Image.asset(friend.imageAsset!, fit: BoxFit.cover),
+      ),
+    );
+  }
+}
+
+class PlaceFriendBottomActions extends StatelessWidget {
+  const PlaceFriendBottomActions({
+    super.key,
+    required this.onCancel,
+    required this.onComplete,
+  });
+
+  final VoidCallback onCancel;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        0,
+        AppSpacing.x20,
+        AppSpacing.x16,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: CommonButton.dark(
+              label: '취소',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.textBody,
+              foregroundColor: AppColors.white,
+              onPressed: onCancel,
+            ),
+          ),
+          const SizedBox(width: placeFriendActionGap),
+          Expanded(
+            child: CommonButton(
+              label: '완료',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.brandAccent,
+              foregroundColor: AppColors.white,
+              onPressed: onComplete,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SelectedFriendMark extends StatelessWidget {
+  const _SelectedFriendMark({
+    super.key,
+    required this.friend,
+    required this.height,
+    required this.onRemove,
+  });
+
+  final PlaceFriendProfile friend;
+  final double height;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      label: '선택된 친구 ${friend.name}',
+      child: SizedBox(
+        width: placeFriendSelectedMarkWidth,
+        height: height,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: placeFriendSelectedMarkWidth,
+              height: placeFriendAvatarSize,
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Positioned(
+                    left: AppSpacing.x10,
+                    top: AppSpacing.x4,
+                    child: PlaceFriendAvatar(
+                      friend: friend,
+                      dimension: placeFriendSelectedAvatarSize,
+                    ),
+                  ),
+                  Positioned(
+                    top: placeFriendSelectedDeleteTop,
+                    right: placeFriendSelectedDeleteRight,
+                    child: _SelectedFriendRemoveButton(
+                      friendId: friend.id,
+                      friendName: friend.name,
+                      onPressed: onRemove,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Text(
+              friend.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size12Medium.copyWith(
+                color: AppColors.iconInactive,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectedFriendRemoveButton extends StatelessWidget {
+  const _SelectedFriendRemoveButton({
+    required this.friendId,
+    required this.friendName,
+    required this.onPressed,
+  });
+
+  final String friendId;
+  final String friendName;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: AppSizes.iconButtonSize,
+      child: IconButton(
+        key: ValueKey('selected-friend-remove-$friendId'),
+        onPressed: onPressed,
+        tooltip: '$friendName 선택 해제',
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints.tightFor(
+          width: AppSizes.iconButtonSize,
+          height: AppSizes.iconButtonSize,
+        ),
+        style: IconButton.styleFrom(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        icon: const CommonSvgIcon(
+          AppIconAssets.delete,
+          width: placeFriendSelectedDeleteSize,
+          height: placeFriendSelectedDeleteSize,
+          color: AppColors.textBody,
+          semanticsLabel: '선택 친구 삭제',
+        ),
+      ),
+    );
+  }
+}
+
+class _FriendCandidateTile extends StatelessWidget {
+  const _FriendCandidateTile({
+    required this.friend,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final PlaceFriendProfile friend;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      label: '${friend.name} ${isSelected ? '선택됨' : '선택 안됨'}',
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x20,
+            vertical: AppSpacing.x8,
+          ),
+          child: Row(
+            children: [
+              PlaceFriendAvatar(friend: friend),
+              const SizedBox(width: AppSpacing.x16),
+              Expanded(
+                child: Text(
+                  friend.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.size16Medium.copyWith(
+                    color: AppColors.textStrong,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.x16),
+              _FriendSelectionIcon(isSelected: isSelected),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FriendSelectionIcon extends StatelessWidget {
+  const _FriendSelectionIcon({required this.isSelected});
+
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      isSelected ? Icons.check_circle : Icons.radio_button_unchecked,
+      size: AppSizes.iconMedium,
+      color: isSelected ? AppColors.brandAccent : AppColors.textDisabled,
+    );
+  }
+}

--- a/test/features/place/presentation/pages/friend_management_page_test.dart
+++ b/test/features/place/presentation/pages/friend_management_page_test.dart
@@ -1,0 +1,74 @@
+import 'package:commonplant_frontend/features/place/presentation/pages/friend_management_page.dart';
+import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('친구 관리 기본 화면은 선택 친구와 검색 결과를 표시한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+    );
+
+    expect(find.text('친구 관리'), findsOneWidget);
+    expect(find.text('닉네임 검색'), findsOneWidget);
+    expect(find.text('취소'), findsOneWidget);
+    expect(find.text('완료'), findsOneWidget);
+    expect(find.text('커먼맘'), findsNWidgets(2));
+    expect(find.text('커먼 파파'), findsNWidgets(2));
+    expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('선택 친구 삭제 버튼은 삭제 확인 알럿을 표시한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('selected-friend-remove-friend-2')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('님을 친구 목록에서 삭제하시겠습니까?'), findsOneWidget);
+    expect(find.widgetWithText(CommonDialogActionButton, '취소'), findsOneWidget);
+    expect(find.widgetWithText(CommonDialogActionButton, '삭제'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('삭제 확인 후 친구 선택 상태를 해제한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('selected-friend-remove-friend-2')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(CommonDialogActionButton, '삭제'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('selected-friend-friend-2')),
+      findsNothing,
+    );
+    expect(find.text('커먼 파파'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('닉네임 검색어로 친구 목록을 필터링한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+    );
+
+    await tester.enterText(find.byType(TextField), '파파');
+    await tester.pumpAndSettle();
+
+    expect(find.text('커먼맘'), findsOneWidget);
+    expect(find.text('커먼 파파'), findsNWidgets(2));
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## 관련 이슈
- #17

## 구현 범위
- Figma `node-id=1:3417` 기준 Place 친구 관리 기본 화면 구현
- Figma `node-id=1:3491` 삭제 확인 알럿 확인 및 dialog 연결
- 친구 추가/친구 관리에서 쓰는 선택 친구 마크, 검색 결과, 하단 액션 UI를 feature 내부 위젯으로 분리

## 검증
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test --concurrency=1 --dds-port=0`

## 문서 반영
- `docs/figma-frame-map.md` 친구 관리 삭제 알럿 node-id 갱신

## 리뷰 포인트
- 친구 관리 삭제 확인 액션은 Figma alert 기준으로 Sea Green 확인 버튼을 유지했습니다.

## Breaking change
- 없음