### PR TITLE
Feat: 식물 등록 화면 #17

### DIFF
--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -50,7 +50,7 @@
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 팀원화면` | `1:2708` | 팀원 | #33 | FAB: 식물 추가하기, 장소 나가기 |
 | Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | `1:4513` | 기본 | #34 | 검색 전 결과 없음 |
 | Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록(검색 후)` | `1:4610` | 검색 결과 | #34 | 검색어 `몬스테라` 입력 상태 |
-| Plant | 식물 등록 정보 입력 | `/plants/new/details` | `#2-2-3-2 식물 등록` | `1:4362` | 기본 | 대기 | 1단계 검색 결과 선택 후 입력 화면 |
+| Plant | 식물 등록 정보 입력 | `/plants/new/details` | `#2-2-3-2 식물 등록` | `1:4362` | 기본 | #34 | 1단계 검색 결과 선택 후 입력 화면 |
 | Plant | 식물 수정 | `/plants/:plantId/edit` | `#2-2-3-3 식물 수정` | 확인 필요 | 기본 | 대기 |  |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | 확인 필요 | 기본 | 대기 |  |
 | Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | 확인 필요 | 기본 | 대기 |  |

--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -48,9 +48,9 @@
 | Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿 (리더` | `1:3491` | alert | #32 | 친구 삭제 확인 dialog |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 리더화면` | `1:2393` | 리더 | #33 | FAB: 식물 추가하기, 장소 수정하기, 장소 나가기 |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 팀원화면` | `1:2708` | 팀원 | #33 | FAB: 식물 추가하기, 장소 나가기 |
-| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | 확인 필요 | 기본 | 대기 |  |
-| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록(검색 후)` | 확인 필요 | 검색 결과 | 대기 | route가 아닌 상태 |
-| Plant | 식물 등록 정보 입력 | `/plants/new/details` | `#2-2-3-2 식물 등록` | 확인 필요 | 기본 | 대기 |  |
+| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | `1:4513` | 기본 | 대기 | 검색 전 결과 없음 |
+| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록(검색 후)` | `1:4610` | 검색 결과 | 대기 | 검색어 `몬스테라` 입력 상태 |
+| Plant | 식물 등록 정보 입력 | `/plants/new/details` | `#2-2-3-2 식물 등록` | `1:4362` | 기본 | 대기 | 1단계 검색 결과 선택 후 입력 화면 |
 | Plant | 식물 수정 | `/plants/:plantId/edit` | `#2-2-3-3 식물 수정` | 확인 필요 | 기본 | 대기 |  |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | 확인 필요 | 기본 | 대기 |  |
 | Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | 확인 필요 | 기본 | 대기 |  |

--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -48,8 +48,8 @@
 | Place | 친구 관리 | `/places/:placeId/friends` | `#2-3-2 친구 관리 - 삭제 알럿 (리더` | `1:3491` | alert | #32 | 친구 삭제 확인 dialog |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 리더화면` | `1:2393` | 리더 | #33 | FAB: 식물 추가하기, 장소 수정하기, 장소 나가기 |
 | Place | 장소 상세 | `/places/:placeId` | `#2-3 My place 팀원화면` | `1:2708` | 팀원 | #33 | FAB: 식물 추가하기, 장소 나가기 |
-| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | `1:4513` | 기본 | 대기 | 검색 전 결과 없음 |
-| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록(검색 후)` | `1:4610` | 검색 결과 | 대기 | 검색어 `몬스테라` 입력 상태 |
+| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록` | `1:4513` | 기본 | #34 | 검색 전 결과 없음 |
+| Plant | 식물 등록 검색 | `/plants/new/search` | `#2-2-3 식물 등록(검색 후)` | `1:4610` | 검색 결과 | #34 | 검색어 `몬스테라` 입력 상태 |
 | Plant | 식물 등록 정보 입력 | `/plants/new/details` | `#2-2-3-2 식물 등록` | `1:4362` | 기본 | 대기 | 1단계 검색 결과 선택 후 입력 화면 |
 | Plant | 식물 수정 | `/plants/:plantId/edit` | `#2-2-3-3 식물 수정` | 확인 필요 | 기본 | 대기 |  |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | 확인 필요 | 기본 | 대기 |  |

--- a/lib/app/router/app_routes.dart
+++ b/lib/app/router/app_routes.dart
@@ -170,7 +170,9 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
       role: placeDetailRoleFromQuery(state.uri.queryParameters['role']),
     ),
     AppRouteNames.plantSearch => const PlantSearchPage(),
-    AppRouteNames.plantCreateDetails => const PlantFormPage(),
+    AppRouteNames.plantCreateDetails => PlantFormPage(
+      initialPlantName: state.uri.queryParameters['name'],
+    ),
     AppRouteNames.plantEdit => PlantFormPage(
       plantId: state.pathParameters['plantId'],
     ),

--- a/lib/core/theme/app_sizes.dart
+++ b/lib/core/theme/app_sizes.dart
@@ -25,6 +25,7 @@ abstract final class AppSizes {
   static const double addressOrPlaceDeleteIconSize = 24;
   static const double searchTextFieldHeight = 64;
   static const double searchTextFieldIconSize = 24;
+  static const double plantSearchResultTileHeight = 42;
   static const double textFieldClearButtonSize = 24;
   static const double textFieldClearIconSize = 16;
   static const double profileImageBoxSize = 100;

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,5 +1,7 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/common/presentation/widgets/phase0_widgets.dart';
@@ -7,6 +9,7 @@ import 'package:commonplant_frontend/features/plant/presentation/providers/plant
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_photo_add_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
 import 'package:flutter/material.dart';
@@ -14,9 +17,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 class PlantFormPage extends ConsumerStatefulWidget {
-  const PlantFormPage({super.key, this.plantId});
+  const PlantFormPage({super.key, this.plantId, this.initialPlantName});
 
   final String? plantId;
+  final String? initialPlantName;
 
   bool get isEdit => plantId != null;
 
@@ -27,18 +31,45 @@ class PlantFormPage extends ConsumerStatefulWidget {
 class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   late final TextEditingController _nameController;
   late final TextEditingController _descriptionController;
+  late final String _selectedPlantName;
   String? _place;
   String? _wateringDate;
+  String? _selectedPlaceId;
+
+  static const List<_PlantRegistrationPlace> _places = [
+    _PlantRegistrationPlace(
+      id: 'place-1',
+      name: '스윗 홈_거실',
+      imageAsset: AppImageAssets.placeEditLivingRoom,
+    ),
+    _PlantRegistrationPlace(
+      id: 'place-2',
+      name: '낫 스윗 회사_가든',
+      imageAsset: AppImageAssets.placeDetailMonstera,
+    ),
+    _PlantRegistrationPlace(
+      id: 'place-3',
+      name: '집_작업실',
+      imageAsset: AppImageAssets.placeEditLivingRoom,
+    ),
+    _PlantRegistrationPlace(
+      id: 'place-4',
+      name: '본가_거실',
+      imageAsset: AppImageAssets.placeDetailMonstera,
+    ),
+  ];
 
   @override
   void initState() {
     super.initState();
+    _selectedPlantName = _normalizedInitialPlantName();
     _nameController = TextEditingController(text: widget.isEdit ? '몬스테라' : '');
     _descriptionController = TextEditingController(
       text: widget.isEdit ? '거실 창가 오른쪽에서 키우는 중' : '',
     );
     _place = widget.isEdit ? '우리집 거실' : null;
     _wateringDate = widget.isEdit ? '2026.05.05' : null;
+    _selectedPlaceId = widget.isEdit ? null : _places.first.id;
   }
 
   @override
@@ -50,6 +81,17 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.isEdit) {
+      return _PlantCreateScaffold(
+        places: _places,
+        selectedPlaceId: _selectedPlaceId,
+        wateringDate: '2023. 01. 30',
+        onPlaceSelected: (place) => setState(() => _selectedPlaceId = place.id),
+        onCancel: _cancelCreate,
+        onSubmit: _submitCreate,
+      );
+    }
+
     final canSubmit = _nameController.text.trim().isNotEmpty && _place != null;
 
     return CommonScaffold(
@@ -135,6 +177,54 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     );
   }
 
+  String _normalizedInitialPlantName() {
+    final plantName = widget.initialPlantName?.trim();
+
+    if (plantName == null || plantName.isEmpty) {
+      return '몬스테라 델리오사';
+    }
+
+    return plantName;
+  }
+
+  _PlantRegistrationPlace? get _selectedPlace {
+    final selectedPlaceId = _selectedPlaceId;
+
+    if (selectedPlaceId == null) {
+      return null;
+    }
+
+    for (final place in _places) {
+      if (place.id == selectedPlaceId) {
+        return place;
+      }
+    }
+
+    return null;
+  }
+
+  void _cancelCreate() {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+
+    context.go(AppRoutePaths.home);
+  }
+
+  void _submitCreate() {
+    final selectedPlace = _selectedPlace;
+
+    if (selectedPlace == null) {
+      return;
+    }
+
+    ref
+        .read(plantListProvider.notifier)
+        .addPlant(name: _selectedPlantName, placeName: selectedPlace.name);
+    context.go(AppRoutePaths.home);
+  }
+
   void _submit() {
     final name = _nameController.text.trim();
     final description = _descriptionController.text.trim();
@@ -161,4 +251,240 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
         );
     context.go(AppRoutePaths.home);
   }
+}
+
+class _PlantCreateScaffold extends StatelessWidget {
+  const _PlantCreateScaffold({
+    required this.places,
+    required this.selectedPlaceId,
+    required this.wateringDate,
+    required this.onPlaceSelected,
+    required this.onCancel,
+    required this.onSubmit,
+  });
+
+  final List<_PlantRegistrationPlace> places;
+  final String? selectedPlaceId;
+  final String wateringDate;
+  final ValueChanged<_PlantRegistrationPlace> onPlaceSelected;
+  final VoidCallback onCancel;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '식물 등록 (2/2)',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _PlantPlacePicker(
+                        places: places,
+                        selectedPlaceId: selectedPlaceId,
+                        onPlaceSelected: onPlaceSelected,
+                      ),
+                      const SizedBox(height: AppSpacing.x32),
+                      _PlantWateringDateField(date: wateringDate),
+                    ],
+                  ),
+                ),
+              ),
+              _PlantFormBottomActions(onCancel: onCancel, onSubmit: onSubmit),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlantPlacePicker extends StatelessWidget {
+  const _PlantPlacePicker({
+    required this.places,
+    required this.selectedPlaceId,
+    required this.onPlaceSelected,
+  });
+
+  final List<_PlantRegistrationPlace> places;
+  final String? selectedPlaceId;
+  final ValueChanged<_PlantRegistrationPlace> onPlaceSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const CommonAddressOrPlaceField(label: '장소 선택'),
+        const SizedBox(height: AppSpacing.x4),
+        SizedBox(
+          height: AppSizes.placeCardHeight,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: places.length,
+            separatorBuilder: (_, _) => const SizedBox(width: AppSpacing.x8),
+            itemBuilder: (context, index) {
+              final place = places[index];
+              final isSelected = place.id == selectedPlaceId;
+
+              return Semantics(
+                selected: isSelected,
+                child: CommonPlaceCard(
+                  title: place.name,
+                  imageProvider: AssetImage(place.imageAsset),
+                  onTap: () => onPlaceSelected(place),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlantWateringDateField extends StatelessWidget {
+  const _PlantWateringDateField({required this.date});
+
+  final String date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        DecoratedBox(
+          decoration: const BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: AppColorPrimitives.grayGray2),
+            ),
+          ),
+          child: SizedBox(
+            width: double.infinity,
+            height: AppSizes.addressOrPlaceFieldHeight,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '마지막으로 물 준 날짜',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.size18Medium.copyWith(
+                      color: AppColors.textStrong,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.x12),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AppColors.surfaceDisabled,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: AppSpacing.x8,
+                    ),
+                    child: Text(
+                      date,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyles.size18Medium.copyWith(
+                        color: AppColors.textStrong,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x4),
+        Text(
+          '선택하지 않을 시, 등록일을 기준으로 설정합니다',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size12Medium.copyWith(
+            color: AppColors.brandStrong,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlantFormBottomActions extends StatelessWidget {
+  const _PlantFormBottomActions({
+    required this.onCancel,
+    required this.onSubmit,
+  });
+
+  final VoidCallback onCancel;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        0,
+        AppSpacing.x20,
+        AppSpacing.x16,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: CommonButton.dark(
+              label: '취소',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.textBody,
+              foregroundColor: AppColors.white,
+              onPressed: onCancel,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.x8),
+          Expanded(
+            child: CommonButton(
+              label: '등록',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.brandAccent,
+              foregroundColor: AppColors.white,
+              onPressed: onSubmit,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlantRegistrationPlace {
+  const _PlantRegistrationPlace({
+    required this.id,
+    required this.name,
+    required this.imageAsset,
+  });
+
+  final String id;
+  final String name;
+  final String imageAsset;
 }

--- a/lib/features/plant/presentation/pages/plant_search_page.dart
+++ b/lib/features/plant/presentation/pages/plant_search_page.dart
@@ -58,8 +58,12 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
               const SizedBox(height: AppSpacing.x8),
               _PlantSearchResultList(
                 plants: results,
-                onSelected: (_) =>
-                    context.push(AppRoutePaths.plantCreateDetails),
+                onSelected: (plant) => context.push(
+                  Uri(
+                    path: AppRoutePaths.plantCreateDetails,
+                    queryParameters: {'name': plant.name},
+                  ).toString(),
+                ),
               ),
             ],
           ],

--- a/lib/features/plant/presentation/pages/plant_search_page.dart
+++ b/lib/features/plant/presentation/pages/plant_search_page.dart
@@ -1,13 +1,10 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/common/presentation/widgets/phase0_widgets.dart';
-import 'package:commonplant_frontend/shared/widgets/common_add_tile.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
-import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -22,9 +19,10 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
   final TextEditingController _searchController = TextEditingController();
 
   static const List<_PlantCandidate> _plants = [
-    _PlantCandidate(name: '몬스테라', species: 'Monstera deliciosa'),
-    _PlantCandidate(name: '스투키', species: 'Sansevieria stuckyi'),
-    _PlantCandidate(name: '아레카야자', species: 'Dypsis lutescens'),
+    _PlantCandidate(name: '몬스테라 델리오사'),
+    _PlantCandidate(name: '몬스테라 알보 바리에가타'),
+    _PlantCandidate(name: '몬스테라 보르시지아나'),
+    _PlantCandidate(name: '무늬 몬스테라'),
   ];
 
   @override
@@ -35,95 +33,124 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    final query = _searchController.text.trim();
-    final results = query.isEmpty
-        ? _plants
-        : _plants
-              .where(
-                (plant) =>
-                    plant.name.contains(query) || plant.species.contains(query),
-              )
-              .toList();
+    final results = _matchingPlants(_searchController.text);
 
     return CommonScaffold(
-      title: '식물 등록',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          CommonSearchTextField(
-            controller: _searchController,
-            hintText: '식물을 입력해 주세요.',
-            onChanged: (_) => setState(() {}),
+      title: '식물 등록  (1/2)',
+      navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
+        color: AppColors.textStrong,
+        fontWeight: FontWeight.w700,
+      ),
+      bodyPadding: EdgeInsets.zero,
+      child: SizedBox(
+        width: double.infinity,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            CommonSearchTextField(
+              controller: _searchController,
+              hintText: '식물을 입력해 주세요.',
+              horizontalPadding: AppSpacing.x20,
+              iconTextSpacing: AppSpacing.x12,
+              onChanged: (_) => setState(() {}),
+            ),
+            if (results.isNotEmpty) ...[
+              const SizedBox(height: AppSpacing.x8),
+              _PlantSearchResultList(
+                plants: results,
+                onSelected: (_) =>
+                    context.push(AppRoutePaths.plantCreateDetails),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<_PlantCandidate> _matchingPlants(String value) {
+    final query = _normalize(value);
+
+    if (query.isEmpty) {
+      return const [];
+    }
+
+    return _plants
+        .where((plant) => _normalize(plant.name).contains(query))
+        .toList(growable: false);
+  }
+
+  String _normalize(String value) {
+    return value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
+  }
+}
+
+class _PlantSearchResultList extends StatelessWidget {
+  const _PlantSearchResultList({
+    required this.plants,
+    required this.onSelected,
+  });
+
+  final List<_PlantCandidate> plants;
+  final ValueChanged<_PlantCandidate> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final entry in plants.indexed)
+          _PlantSearchResultTile(
+            plant: entry.$2,
+            isHighlighted: entry.$1 == 0,
+            onTap: () => onSelected(entry.$2),
           ),
-          const SizedBox(height: AppSpacing.x24),
-          Phase0Section(
-            title: '식물 선택',
-            subtitle: '등록할 식물을 검색하거나 직접 입력할 수 있어요.',
-            child: Column(
-              children: [
-                for (final plant in results) ...[
-                  Phase0Surface(
-                    onTap: () => context.push(AppRoutePaths.plantCreateDetails),
-                    child: Row(
-                      children: [
-                        const CommonSvgIcon(
-                          AppIconAssets.plantEmpty,
-                          height: 56,
-                          semanticsLabel: '식물',
-                        ),
-                        const SizedBox(width: AppSpacing.x16),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                plant.name,
-                                style: AppTextStyles.size16Bold.copyWith(
-                                  color: AppColors.textStrong,
-                                ),
-                              ),
-                              const SizedBox(height: AppSpacing.x4),
-                              Text(
-                                plant.species,
-                                style: AppTextStyles.size14Medium.copyWith(
-                                  color: AppColors.textBody,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const Icon(
-                          Icons.chevron_right,
-                          color: AppColors.textStrong,
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.x12),
-                ],
-                CommonAddTile(
-                  label: '직접 입력하기',
-                  helper: '검색 결과에 없는 식물을 등록해요.',
-                  icon: const CommonSvgIcon(
-                    AppIconAssets.plusGreen,
-                    width: 24,
-                    height: 24,
-                    semanticsLabel: '직접 입력',
-                  ),
-                  onTap: () => context.push(AppRoutePaths.plantCreateDetails),
+      ],
+    );
+  }
+}
+
+class _PlantSearchResultTile extends StatelessWidget {
+  const _PlantSearchResultTile({
+    required this.plant,
+    required this.isHighlighted,
+    required this.onTap,
+  });
+
+  final _PlantCandidate plant;
+  final bool isHighlighted;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: isHighlighted ? AppColors.surfaceDisabled : AppColors.surfaceBase,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          width: double.infinity,
+          height: AppSizes.plantSearchResultTileHeight,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                plant.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.size16Bold.copyWith(
+                  color: AppColors.textHeadline,
                 ),
-              ],
+              ),
             ),
           ),
-        ],
+        ),
       ),
     );
   }
 }
 
 class _PlantCandidate {
-  const _PlantCandidate({required this.name, required this.species});
+  const _PlantCandidate({required this.name});
 
   final String name;
-  final String species;
 }

--- a/lib/shared/widgets/common_search_text_field.dart
+++ b/lib/shared/widgets/common_search_text_field.dart
@@ -15,6 +15,7 @@ class CommonSearchTextField extends StatefulWidget {
     this.onChanged,
     this.enabled = true,
     this.horizontalPadding = 0,
+    this.iconTextSpacing = AppSpacing.x16,
   });
 
   final TextEditingController? controller;
@@ -23,6 +24,7 @@ class CommonSearchTextField extends StatefulWidget {
   final ValueChanged<String>? onChanged;
   final bool enabled;
   final double horizontalPadding;
+  final double iconTextSpacing;
 
   @override
   State<CommonSearchTextField> createState() => _CommonSearchTextFieldState();
@@ -96,7 +98,7 @@ class _CommonSearchTextFieldState extends State<CommonSearchTextField> {
                 height: AppSizes.searchTextFieldIconSize,
                 semanticsLabel: '검색',
               ),
-              const SizedBox(width: AppSpacing.x16),
+              SizedBox(width: widget.iconTextSpacing),
               Expanded(
                 child: TextField(
                   controller: _controller,

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -254,9 +254,6 @@ void main() {
     await tester.tap(find.text('몬스테라 델리오사'));
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField).first, '몬스테라');
-    await tester.tap(find.text('장소'));
-    await tester.pumpAndSettle();
     await tester.ensureVisible(find.text('등록'));
     await tester.tap(find.text('등록'));
     await tester.pumpAndSettle();
@@ -265,7 +262,7 @@ void main() {
     expect(find.text('식물 추가하기'), findsNothing);
     expect(find.bySemanticsLabel('식물 추가'), findsOneWidget);
     expect(tester.getSize(find.bySemanticsLabel('식물 추가')), const Size(24, 24));
-    expect(find.bySemanticsLabel('몬스테라'), findsOneWidget);
+    expect(find.bySemanticsLabel('몬스테라 델리오사'), findsOneWidget);
   });
 
   testWidgets('place form에서 주소 검색과 친구 추가 화면으로 이동한다', (
@@ -365,8 +362,9 @@ void main() {
     await tester.tap(find.text('몬스테라 델리오사'));
     await tester.pumpAndSettle();
 
-    expect(find.text('식물 등록'), findsOneWidget);
-    expect(find.text('식물 이름'), findsOneWidget);
+    expect(find.text('식물 등록 (2/2)'), findsOneWidget);
+    expect(find.text('장소 선택'), findsOneWidget);
+    expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
   });
 
   testWidgets('plant detail에서 식물 수정, 메모 목록, 메모 작성으로 이동한다', (

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -220,7 +220,7 @@ void main() {
     await tester.tap(find.text('식물 추가하기'));
     await tester.pumpAndSettle();
 
-    expect(find.text('식물 등록'), findsOneWidget);
+    expect(find.text('식물 등록  (1/2)'), findsOneWidget);
   });
 
   testWidgets('식물 등록 후 홈에서 식물 추가 카드 대신 헤더 +를 표시한다', (
@@ -249,7 +249,9 @@ void main() {
     await tester.ensureVisible(find.text('식물 추가하기'));
     await tester.tap(find.text('식물 추가하기'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('몬스테라'));
+    await tester.enterText(find.byType(TextField), '몬스테라');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('몬스테라 델리오사'));
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(TextField).first, '몬스테라');
@@ -358,7 +360,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('몬스테라'));
+    await tester.enterText(find.byType(TextField), '몬스테라');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('몬스테라 델리오사'));
     await tester.pumpAndSettle();
 
     expect(find.text('식물 등록'), findsOneWidget);

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -1,0 +1,22 @@
+import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('식물 등록 정보 입력 화면은 Figma 기준 필드를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantFormPage())),
+    );
+
+    expect(find.text('식물 등록 (2/2)'), findsOneWidget);
+    expect(find.text('장소 선택'), findsOneWidget);
+    expect(find.text('스윗 홈_거실'), findsOneWidget);
+    expect(find.text('낫 스윗 회사_가든'), findsOneWidget);
+    expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
+    expect(find.text('2023. 01. 30'), findsOneWidget);
+    expect(find.text('선택하지 않을 시, 등록일을 기준으로 설정합니다'), findsOneWidget);
+    expect(find.text('취소'), findsOneWidget);
+    expect(find.text('등록'), findsOneWidget);
+  });
+}

--- a/test/features/plant/presentation/pages/plant_search_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_search_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:commonplant_frontend/features/plant/presentation/pages/plant_search_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('식물 등록 검색 전에는 결과를 표시하지 않는다', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+
+    expect(find.text('식물 등록  (1/2)'), findsOneWidget);
+    expect(find.text('식물을 입력해 주세요.'), findsOneWidget);
+    expect(find.text('몬스테라 델리오사'), findsNothing);
+  });
+
+  testWidgets('식물 검색어를 입력하면 Figma 기준 결과 목록을 표시한다', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+
+    await tester.enterText(find.byType(TextField), '몬스테라');
+    await tester.pump();
+
+    expect(find.text('몬스테라 델리오사'), findsOneWidget);
+    expect(find.text('몬스테라 알보 바리에가타'), findsOneWidget);
+    expect(find.text('몬스테라 보르시지아나'), findsOneWidget);
+    expect(find.text('무늬 몬스테라'), findsOneWidget);
+  });
+
+  testWidgets('검색어 삭제를 누르면 결과 목록을 닫는다', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+
+    await tester.enterText(find.byType(TextField), '몬스테라');
+    await tester.pump();
+    await tester.tap(find.bySemanticsLabel('검색어 삭제'));
+    await tester.pump();
+
+    expect(find.text('몬스테라 델리오사'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 작업 내용
- Figma `1:4513`, `1:4610`, `1:4362` 기준으로 식물 등록 화면 흐름을 구현했습니다.
- 1단계 검색 화면은 검색 전 empty 상태와 `몬스테라` 검색 결과 리스트를 표시합니다.
- 검색 결과 선택 시 선택 식물명을 query로 전달하고, 2단계 정보 입력 화면으로 이동합니다.
- 2단계 정보 입력 화면은 장소 선택 카드 리스트, 마지막 물 준 날짜, 하단 취소/등록 액션을 Figma 기준으로 구성했습니다.
- `CommonSearchTextField` 간격 옵션과 식물 검색 결과 행 높이 토큰을 추가했습니다.
- `docs/figma-frame-map.md`에 식물 등록 관련 node-id와 PR 매핑을 반영했습니다.

## 검증
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

Refs #17