### PR TITLE
[Phase 0] 메모 작성 화면 구현

### DIFF
--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -54,7 +54,8 @@
 | Plant | 식물 수정 | `/plants/:plantId/edit` | `#2-2-3-3 식물 수정` | `1:4254` | 기본 | #35 |  |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | `1:5186` | 기본 | #36 | 기본 상세 화면 |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | `1:5539` | 메뉴 | #36 | route가 아닌 더보기 수정/삭제 상태 |
-| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | 확인 필요 | 기본 | 대기 |  |
+| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:4984` | 기본 | 대기 | 사진/본문 입력 전 기본 상태 |
+| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:5035` | 입력 | 대기 | 사진 1장 및 본문 입력 상태 |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모` | 확인 필요 | 기본 | 대기 |  |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모 수정/삭제` | 확인 필요 | 메뉴 | 대기 | route가 아닌 상태 |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모 삭제 alert` | 확인 필요 | alert | 대기 | route가 아닌 상태 |

--- a/docs/figma-frame-map.md
+++ b/docs/figma-frame-map.md
@@ -54,8 +54,8 @@
 | Plant | 식물 수정 | `/plants/:plantId/edit` | `#2-2-3-3 식물 수정` | `1:4254` | 기본 | #35 |  |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | `1:5186` | 기본 | #36 | 기본 상세 화면 |
 | Plant | 식물 상세 | `/plants/:plantId` | `#2-4 My plants` | `1:5539` | 메뉴 | #36 | route가 아닌 더보기 수정/삭제 상태 |
-| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:4984` | 기본 | 대기 | 사진/본문 입력 전 기본 상태 |
-| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:5035` | 입력 | 대기 | 사진 1장 및 본문 입력 상태 |
+| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:4984` | 기본 | #37 | 사진/본문 입력 전 기본 상태 |
+| Memo | 메모 작성 | `/plants/:plantId/memos/new` | `#2-4-2 메모 작성` | `1:5035` | 입력 | #37 | 사진 1장 및 본문 입력 상태 |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모` | 확인 필요 | 기본 | 대기 |  |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모 수정/삭제` | 확인 필요 | 메뉴 | 대기 | route가 아닌 상태 |
 | Memo | 메모 목록 | `/plants/:plantId/memos` | `#2-4-3 메모 삭제 alert` | 확인 필요 | alert | 대기 | route가 아닌 상태 |

--- a/lib/features/memo/presentation/pages/memo_write_page.dart
+++ b/lib/features/memo/presentation/pages/memo_write_page.dart
@@ -1,9 +1,10 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/core/theme/app_theme_tokens.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_photo_add_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
@@ -20,81 +21,255 @@ class MemoWritePage extends StatefulWidget {
 }
 
 class _MemoWritePageState extends State<MemoWritePage> {
+  static const int _maxMemoLength = 200;
+  static const int _maxPhotoCount = 1;
+
   final TextEditingController _memoController = TextEditingController();
+  bool _hasPhoto = false;
+
+  bool get _canSubmit => _memoController.text.trim().isNotEmpty;
+
+  @override
+  void initState() {
+    super.initState();
+    _memoController.addListener(_handleInputChanged);
+  }
 
   @override
   void dispose() {
+    _memoController.removeListener(_handleInputChanged);
     _memoController.dispose();
     super.dispose();
   }
 
+  void _handleInputChanged() {
+    setState(() {});
+  }
+
+  void _selectPhoto() {
+    setState(() => _hasPhoto = true);
+  }
+
+  void _removePhoto() {
+    setState(() => _hasPhoto = false);
+  }
+
+  void _submit() {
+    context.go(AppRoutePaths.memoListLocation(widget.plantId));
+  }
+
   @override
   Widget build(BuildContext context) {
-    final tokens =
-        Theme.of(context).extension<AppThemeTokens>() ?? AppThemeTokens.light;
-    final canSubmit = _memoController.text.trim().isNotEmpty;
-
-    return CommonScaffold(
-      title: '메모 작성',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            '오늘 식물 상태는 어땠나요?',
-            style: AppTextStyles.size24Medium.copyWith(
-              color: AppColors.textHeadline,
-            ),
-          ),
-          const SizedBox(height: AppSpacing.x24),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: tokens.surfaceBase,
-              borderRadius: BorderRadius.circular(AppRadius.medium),
-              border: Border.all(color: tokens.borderDefault),
-            ),
-            child: TextField(
-              controller: _memoController,
-              minLines: 8,
-              maxLines: 10,
-              onChanged: (_) => setState(() {}),
-              style: AppTextStyles.size16Medium.copyWith(
-                color: AppColors.textStrong,
-              ),
-              decoration: InputDecoration(
-                hintText: '물주기, 잎 상태, 위치 변경 등을 기록해 주세요.',
-                hintStyle: AppTextStyles.size16Medium.copyWith(
-                  color: AppColors.textDisabled,
-                ),
-                border: InputBorder.none,
-                contentPadding: const EdgeInsets.all(AppSpacing.x16),
-              ),
-            ),
-          ),
-          const SizedBox(height: AppSpacing.x24),
-          Text(
-            '사진',
-            style: AppTextStyles.size16Bold.copyWith(
-              color: AppColors.textStrong,
-            ),
-          ),
-          const SizedBox(height: AppSpacing.x12),
-          const Row(
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
             children: [
-              CommonPhotoAddButton(currentCount: 0, maxCount: 3),
-              SizedBox(width: AppSpacing.x16),
-              Expanded(child: Text('사진을 함께 남기면 변화 과정을 더 쉽게 확인할 수 있어요.')),
+              CommonNavigationBar(
+                title: '메모 작성',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _MemoPhotoSection(
+                        hasPhoto: _hasPhoto,
+                        onAddPhoto: _selectPhoto,
+                        onRemovePhoto: _removePhoto,
+                      ),
+                      const SizedBox(height: AppSpacing.x32),
+                      _MemoContentField(
+                        controller: _memoController,
+                        maxLength: _maxMemoLength,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.x20,
+                  0,
+                  AppSpacing.x20,
+                  AppSpacing.x16,
+                ),
+                child: CommonButton(
+                  label: '완료',
+                  onPressed: _canSubmit ? _submit : null,
+                ),
+              ),
             ],
           ),
-          const SizedBox(height: AppSpacing.x32),
-          CommonButton(
-            label: '저장',
-            onPressed: canSubmit
-                ? () =>
-                      context.go(AppRoutePaths.memoListLocation(widget.plantId))
-                : null,
+        ),
+      ),
+    );
+  }
+}
+
+class _MemoPhotoSection extends StatelessWidget {
+  const _MemoPhotoSection({
+    required this.hasPhoto,
+    required this.onAddPhoto,
+    required this.onRemovePhoto,
+  });
+
+  final bool hasPhoto;
+  final VoidCallback onAddPhoto;
+  final VoidCallback onRemovePhoto;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: AppSizes.photoAddButtonSize + AppSpacing.x4,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.x4),
+            child: CommonPhotoAddButton(
+              currentCount: hasPhoto ? 1 : 0,
+              maxCount: _MemoWritePageState._maxPhotoCount,
+              backgroundColor: hasPhoto ? AppColors.surfaceDisabled : null,
+              onTap: hasPhoto ? null : onAddPhoto,
+            ),
+          ),
+          if (hasPhoto) ...[
+            const SizedBox(width: AppSpacing.x16),
+            _MemoSelectedPhoto(onRemove: onRemovePhoto),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MemoSelectedPhoto extends StatelessWidget {
+  const _MemoSelectedPhoto({required this.onRemove});
+
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppSizes.photoAddButtonSize + AppSpacing.x10,
+      height: AppSizes.photoAddButtonSize + AppSpacing.x4,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            left: 0,
+            top: AppSpacing.x4,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AppRadius.small),
+              child: Image.asset(
+                AppImageAssets.placeDetailMonstera,
+                width: AppSizes.photoAddButtonSize,
+                height: AppSizes.photoAddButtonSize,
+                fit: BoxFit.cover,
+                semanticLabel: '첨부된 메모 사진',
+              ),
+            ),
+          ),
+          Positioned(
+            right: 0,
+            top: 0,
+            child: SizedBox.square(
+              dimension: AppSizes.iconMedium,
+              child: IconButton(
+                tooltip: '첨부 사진 삭제',
+                onPressed: onRemove,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints.tightFor(
+                  width: AppSizes.iconMedium,
+                  height: AppSizes.iconMedium,
+                ),
+                style: IconButton.styleFrom(
+                  backgroundColor: AppColors.textBody,
+                  foregroundColor: AppColors.white,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                icon: const Icon(Icons.close, size: AppSizes.iconSmall),
+              ),
+            ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _MemoContentField extends StatelessWidget {
+  const _MemoContentField({required this.controller, required this.maxLength});
+
+  final TextEditingController controller;
+  final int maxLength;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentLength = controller.text.characters.length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        DecoratedBox(
+          decoration: const BoxDecoration(
+            border: Border(bottom: BorderSide(color: AppColors.borderDefault)),
+          ),
+          child: TextField(
+            controller: controller,
+            maxLength: maxLength,
+            minLines: 1,
+            maxLines: 6,
+            keyboardType: TextInputType.multiline,
+            style: AppTextStyles.size16Medium.copyWith(
+              color: AppColors.textStrong,
+            ),
+            decoration: InputDecoration(
+              hintText: '메모 내용을 입력해 주세요',
+              hintStyle: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textDisabled,
+              ),
+              counterText: '',
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: AppSpacing.x16,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x8),
+        RichText(
+          text: TextSpan(
+            style: AppTextStyles.size14Medium.copyWith(
+              color: AppColors.textBody,
+            ),
+            children: [
+              TextSpan(
+                text: '$currentLength',
+                style: AppTextStyles.size14Bold.copyWith(
+                  color: AppColors.textBody,
+                ),
+              ),
+              TextSpan(text: '/$maxLength'),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/shared/widgets/common_photo_add_button.dart
+++ b/lib/shared/widgets/common_photo_add_button.dart
@@ -14,12 +14,14 @@ class CommonPhotoAddButton extends StatelessWidget {
     this.currentCount = 0,
     this.maxCount = 1,
     this.size = AppSizes.photoAddButtonSize,
+    this.backgroundColor,
   });
 
   final VoidCallback? onTap;
   final int currentCount;
   final int maxCount;
   final double size;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +29,7 @@ class CommonPhotoAddButton extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        color: Colors.transparent,
+        color: backgroundColor ?? Colors.transparent,
         borderRadius: BorderRadius.circular(AppRadius.small),
         border: Border.all(color: AppColors.borderDefault, width: 1),
       ),

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -90,7 +90,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('메모 작성'), findsOneWidget);
-    expect(find.text('오늘 식물 상태는 어땠나요?'), findsOneWidget);
+    expect(find.text('메모 내용을 입력해 주세요'), findsOneWidget);
     expect(find.text('라우트 준비 중'), findsNothing);
   });
 
@@ -409,7 +409,7 @@ void main() {
     await tester.tap(find.text('작성하기'));
     await tester.pumpAndSettle();
 
-    expect(find.text('오늘 식물 상태는 어땠나요?'), findsOneWidget);
+    expect(find.text('메모 내용을 입력해 주세요'), findsOneWidget);
   });
 
   testWidgets('memo list에서 메모 작성과 삭제 dialog를 표시한다', (

--- a/test/features/memo/presentation/pages/memo_write_page_test.dart
+++ b/test/features/memo/presentation/pages/memo_write_page_test.dart
@@ -1,0 +1,59 @@
+import 'package:commonplant_frontend/features/memo/presentation/pages/memo_write_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('메모 작성 기본 화면은 빈 사진과 비활성 완료 버튼을 표시한다', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('메모 작성'), findsOneWidget);
+    expect(find.text('메모 내용을 입력해 주세요'), findsOneWidget);
+    expect(find.text('0/1', findRichText: true), findsOneWidget);
+    expect(find.text('0/200', findRichText: true), findsOneWidget);
+
+    final submitButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '완료'),
+    );
+    expect(submitButton.onPressed, isNull);
+  });
+
+  testWidgets('메모를 입력하면 글자 수와 완료 버튼 상태를 갱신한다', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '오늘도 맑음');
+    await tester.pumpAndSettle();
+
+    expect(find.text('6/200', findRichText: true), findsOneWidget);
+
+    final submitButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '완료'),
+    );
+    expect(submitButton.onPressed, isNotNull);
+  });
+
+  testWidgets('사진 추가 버튼은 첨부 사진과 삭제 버튼을 표시한다', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('사진 추가'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1/1', findRichText: true), findsOneWidget);
+    expect(find.bySemanticsLabel('첨부된 메모 사진'), findsOneWidget);
+    expect(find.byTooltip('첨부 사진 삭제'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('첨부 사진 삭제'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('0/1', findRichText: true), findsOneWidget);
+    expect(find.bySemanticsLabel('첨부된 메모 사진'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 작업 내용
- Figma `#2-4-2 메모 작성` 기본 프레임(`1:4984`) 기준으로 메모 작성 기본 화면을 구현했습니다.
- 입력 상태 프레임(`1:5035`)을 반영해 사진 1장 첨부/삭제, 본문 입력, 글자 수 카운터를 연결했습니다.
- 메모 본문 입력 여부에 따라 `완료` 버튼 활성화를 처리하고 저장 후 메모 목록으로 이동하도록 했습니다.
- `docs/figma-frame-map.md`에 메모 작성 기본/입력 상태 node-id를 기록했습니다.

## 검증
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

Refs #17
