### PR TITLE
Docs: Project 동기화 규칙 문서화 #41

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - 코드, 문서, 설정 등 저장소 변경이 필요한 요구사항을 받으면 먼저 요구사항을 분석하고 GitHub 이슈를 생성한 뒤 작업을 진행한다.
 - 작업 완료 후에는 검증 결과와 관련 커밋을 이슈에 남기고 완료 처리한다.
 - PR 생성 후에는 CommonPlant GitHub Project 10에 PR을 연결한다.
+- 이슈와 PR을 Project 10에 올린 뒤 제목 타입, Issue Type, assignees, milestone, category, status, parent issue를 최신화한다.
 - 화면 구현 전 공통 위젯과 디자인 토큰 재사용 가능 여부를 먼저 확인한다.
 - API 응답 파싱, 비즈니스 로직, 비동기 상태 처리를 화면 위젯에 직접 넣지 않는다.
 - 결정되지 않은 정책은 임의로 확정하지 않고 사용자에게 질문한다.
@@ -60,6 +61,15 @@
 - API client, 인증 토큰, 에러 처리 정책이 확정되는 경우
 - 테스트 방식이나 품질 게이트가 바뀌는 경우
 - 브랜치, 커밋, PR 규칙이 바뀌는 경우
+
+## GitHub Project 정리 기준
+
+- 이슈 제목은 `[Epic]`, `[Feature]`, `[Task]`, `[Bug]` 중 하나로 시작하고, GitHub Issue Type도 같은 의미로 입력한다.
+- 신규 일반 이슈와 PR은 `ywkim95`, `allmanLee`를 assignees로 지정한다.
+- 신규 일반 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정한다.
+- Project 10의 category는 도메인 기준으로 `User`, `Place`, `Plant`, `Memo`, `Info`, `Story`, `Calendar` 중 알맞게 지정한다.
+- 작업 중인 이슈는 Project 10 status를 `In Progress`, PR 생성 후 이슈와 PR은 `In Review`, 병합 또는 완료 후에는 `Done`으로 맞춘다.
+- 상위 범위가 있으면 parent issue를 연결하고, 하위 이슈 연결로 Sub-issues progress가 자동 갱신되었는지 확인한다.
 
 ## 커밋 규칙
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -50,10 +50,13 @@ git switch -c feature/place-list
 
 작업 전 이슈 생성 기준:
 
-- 요구사항 분석 후 작업 범위가 드러나는 제목을 작성합니다.
+- 요구사항 분석 후 `[Epic]`, `[Feature]`, `[Task]`, `[Bug]` 중 하나로 시작하는 제목을 작성합니다.
+- 제목 타입과 같은 의미의 GitHub Issue Type을 입력합니다.
 - 본문에는 작업 개요, 목표, 완료 조건, 검증 기준을 포함합니다.
 - 관련 도메인이나 작업 유형에 맞는 라벨을 지정합니다.
-- 담당자가 명확하면 assignee를 지정합니다.
+- 신규 일반 이슈는 `ywkim95`, `allmanLee`를 assignees로 지정합니다.
+- 신규 일반 이슈는 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정합니다.
+- 상위 범위가 있으면 parent issue를 연결합니다.
 - 기존 이슈가 같은 범위를 이미 다루고 있으면 새 이슈를 만들지 않고 기존 이슈를 사용합니다.
 
 작업 중 연결 기준:
@@ -180,6 +183,8 @@ Docs: 프로젝트 작업 가이드 추가
 
 - Project URL: https://github.com/orgs/UMC-CommonPlant/projects/10/views/1
 - 이슈가 이미 Project에 있어도 PR은 별도 항목으로 추가합니다.
+- 이슈와 PR 모두 assignees, milestone, category, status를 최신 상태로 맞춥니다.
+- parent issue가 있으면 연결하고, parent의 Sub-issues progress가 자동 갱신되었는지 확인합니다.
 - `gh` CLI를 사용할 수 있으면 아래 명령으로 추가합니다.
 
 ```bash
@@ -194,12 +199,33 @@ gh project item-add 10 --owner UMC-CommonPlant --url https://github.com/UMC-Comm
 
 CLI 권한이 부족하면 GitHub UI의 PR 우측 `Projects` 영역에서 위 Project를 직접 연결합니다.
 
+## Project 필드 최신화 기준
+
+| 항목 | 기준 |
+| --- | --- |
+| Title | 이슈는 `[Epic]`, `[Feature]`, `[Task]`, `[Bug]` prefix를 사용합니다. |
+| Issue Type | 제목 prefix와 같은 의미로 `Epic`, `Feature`, `Task`, `Bug` 중 선택합니다. |
+| Assignees | 신규 일반 이슈와 PR은 `ywkim95`, `allmanLee`를 지정합니다. |
+| Milestone | 신규 일반 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)`을 지정합니다. |
+| Status | 작업 시작은 `In Progress`, PR 생성 후는 `In Review`, 완료 후는 `Done`입니다. |
+| Category | 도메인 기준으로 `User`, `Place`, `Plant`, `Memo`, `Info`, `Story`, `Calendar` 중 선택합니다. |
+| Parent issue | Epic/Feature/Task 계층이 있으면 parent issue를 연결합니다. |
+| Sub-issues progress | parent issue의 하위 이슈 연결 상태로 자동 갱신되므로 연결 후 표시를 확인합니다. |
+
+문서, 설정, 라우팅, 공통 인프라처럼 특정 도메인 하나에 묶기 어려운 작업은 category를 `Story`로 지정합니다.
+화면 구현처럼 도메인이 분명한 작업은 해당 도메인 category를 우선합니다.
+
 ## PR 체크리스트
 
 - [ ] 기준 브랜치가 올바른가?
 - [ ] 일반 작업 PR의 base가 `develop`인가?
 - [ ] 배포 PR의 base가 `main`이고 head가 `release/*`인가?
 - [ ] PR이 CommonPlant GitHub Project 10에 연결되었는가?
+- [ ] 이슈와 PR의 assignees가 `ywkim95`, `allmanLee`로 지정되었는가?
+- [ ] 이슈와 PR의 milestone이 지정되었는가?
+- [ ] Project 10의 category와 status가 최신 상태인가?
+- [ ] 이슈 제목 prefix와 GitHub Issue Type이 일치하는가?
+- [ ] parent issue와 Sub-issues progress가 필요한 경우 연결되었는가?
 - [ ] 커밋이 논리적 단위로 정리되었는가?
 - [ ] `fvm dart format --output=none --set-exit-if-changed .`를 통과했는가?
 - [ ] `fvm flutter analyze`를 통과했는가?

--- a/docs/screen-publishing-rules.md
+++ b/docs/screen-publishing-rules.md
@@ -22,6 +22,7 @@
 7. 긴 텍스트, 빈 이미지, 네트워크 실패, 키보드 노출 상태를 확인합니다.
 8. 테스트와 analyzer를 실행합니다.
 9. PR 생성 후 CommonPlant GitHub Project 10에 PR을 연결합니다.
+10. 이슈와 PR의 타입, assignees, milestone, category, status, parent issue를 최신화합니다.
 
 ## 레이아웃 기준
 
@@ -102,6 +103,9 @@
 - [ ] `fvm flutter analyze`를 통과하는가?
 - [ ] 필요한 widget test를 추가 또는 갱신했는가?
 - [ ] PR이 CommonPlant GitHub Project 10에 연결되었는가?
+- [ ] 이슈와 PR의 Project 10 category/status, assignees, milestone이 최신화되었는가?
+- [ ] 이슈 제목 타입과 GitHub Issue Type이 일치하는가?
+- [ ] parent issue가 필요한 경우 연결되어 Sub-issues progress가 갱신되었는가?
 
 ## 결정 필요
 


### PR DESCRIPTION
## 작업 내용
- AGENTS.md에 Project 10 메타데이터 최신화 필수 규칙을 추가했습니다.
- docs/git-workflow.md에 이슈 제목 타입, Issue Type, assignees, milestone, category/status, parent issue, Sub-issues progress 기준을 정리했습니다.
- 화면 퍼블리싱 체크리스트에 Project 필드 최신화 확인 항목을 추가했습니다.

## 검증
- `git diff --check`

Closes #41