### PR TITLE
Docs: API Swagger 문서 정리 #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ lib/
 | [상태관리 Provider 작성 기준](docs/state-management-guide.md) | Riverpod Provider 선택, 파일 배치, async 상태 처리 기준 |
 | [폼 검증 및 에러 메시지 작성 기준](docs/form-validation-error-guide.md) | 입력 검증 위치, helper/error 메시지, 서버 에러 처리 기준 |
 | [테스트 작성 기준](docs/testing-guide.md) | unit/widget test 작성 기준, 실행 명령, CI/pre-commit 연계 |
+| [API Swagger 연계 참고 문서](docs/api-swagger-reference.md) | 서버 Swagger 기반 API 목록, 요청 모델, 확인 필요 명세 정리 |
 | [Git 브랜치 및 커밋 전략](docs/git-workflow.md) | 브랜치 전략, 커밋 메시지, PR 체크리스트 |
 | [배포 및 릴리즈 자동화 전략](docs/release-workflow.md) | `main` publish 전략, release 브랜치, Android/iOS 자동화 단계 |
 

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -1,0 +1,314 @@
+# API Swagger 연계 참고 문서
+
+이 문서는 Flutter API 연계 작업 중 Swagger UI를 반복해서 확인하는 비용을 줄이기 위한 요약 문서입니다.
+서버 명세가 부족하거나 충돌하는 부분은 임의로 보정하지 않고 `확인 필요` 항목에 남깁니다.
+
+## 확인 기준
+
+- Swagger UI: https://commonplant.site/api/v1/swagger-ui/index.html
+- OpenAPI JSON: https://commonplant.site/api/v1/api-docs/json
+- Swagger config: https://commonplant.site/api/v1/api-docs/json/swagger-config
+- 확인일: 2026-05-20
+- OpenAPI 버전: `3.1.0`
+- API title: `Common Plant API Document`
+- 서버 base path: `/api/v1`
+
+## 프론트엔드 연계 원칙
+
+- 공통 HTTP client는 `lib/core/network`에 `dio` 기반으로 둔다.
+- 화면에서 직접 JSON 파싱, Dio 생성, API 에러 문자열 분기를 하지 않는다.
+- feature별 API는 `data/datasources`, `data/repositories`, 필요 시 `domain` 계층으로 분리한다.
+- 화면 상태는 Riverpod의 `AsyncValue` 또는 Controller 상태로 `loading`, `success`, `empty`, `error`를 구분한다.
+- Swagger에 응답 body schema가 없으므로, DTO는 서버 응답 예시나 백엔드 확인 후 확정한다.
+
+## 공통 인증
+
+- Swagger 전역 security는 `bearerAuth`이다.
+- Header 형식은 `Authorization: Bearer <JWT>`로 해석한다.
+- `/auth/login`, `/auth/register`는 `security: []`로 인증 제외되어 있다.
+- 나머지 operation은 별도 security가 없어 전역 bearer 인증이 상속되는 것으로 본다.
+
+## API 목록
+
+| Domain | Method | Path | Summary | 인증 |
+| --- | --- | --- | --- | --- |
+| Auth | POST | `/auth/login` | 소셜 로그인 | 불필요 |
+| Auth | POST | `/auth/register` | 회원가입 완료 | 불필요 |
+| User | GET | `/users` | 내 정보 조회 | 필요 |
+| User | PUT | `/users` | 내 정보 수정 | 필요 |
+| User | DELETE | `/users` | 회원 탈퇴 | 필요 |
+| Place | GET | `/place/myGarden` | 내 정원 조회 | 필요 |
+| Place | GET | `/place/user` | 소속 장소 조회 | 필요 |
+| Place | GET | `/place/{code}` | 장소 조회 | 필요 |
+| Place | POST | `/place/create` | 장소 생성 | 필요 |
+| Place | PUT | `/place/update/{code}` | 장소 수정 | 필요 |
+| Place | DELETE | `/place/delete/{code}` | 장소 삭제 | 필요 |
+| Plant | GET | `/plants` | 내 식물 목록 조회 | 필요 |
+| Plant | POST | `/plants` | 식물 생성 | 필요 |
+| Plant | GET | `/plants/{plantId}` | 식물 상세 조회 | 필요 |
+| Plant | PUT | `/plants/{plantId}` | 식물 수정 | 필요 |
+| Plant | DELETE | `/plants/{plantId}` | 식물 삭제 | 필요 |
+| Plant | GET | `/plants/{plantId}/edit` | 식물 수정 정보 조회 | 필요 |
+| Image | GET | `/s3/images` | 이미지 다운로드 URL 조회 | 필요 |
+| Image | POST | `/s3/images` | 이미지 다중 업로드 | 필요 |
+| Image | PUT | `/s3/images` | 이미지 수정 | 필요 |
+| Image | DELETE | `/s3/images` | 이미지 삭제 | 필요 |
+
+## Auth
+
+### POST `/auth/login`
+
+- Content-Type: `application/json;charset=UTF-8`
+- Request schema: `Login`
+- Required: `provider`, `token`
+- `provider`: `GOOGLE`, `APPLE`, `KAKAO`
+- 성공 시 기존 유저는 `accessToken`, `refreshToken` 반환, 신규 유저는 `signupToken`, `suggestedName`, `suggestedImgUrl` 반환이라고 설명되어 있다.
+- Error:
+  - `400`: `A005`, `A008`
+  - `401`: `A001`, `A002`
+  - `409`: `A007`
+
+### POST `/auth/register`
+
+- Content-Type: `application/json;charset=UTF-8`
+- Request schema: `Register`
+- Required: `signupToken`, `name`
+- Optional: `introduction`, `imgUrl`
+- 성공 시 `accessToken`, `refreshToken` 반환이라고 설명되어 있다.
+- `signupToken` 유효 시간은 10분이다.
+- Error:
+  - `400`: `A005`
+  - `401`: `A003`, `A004`
+  - `409`: `A007`, `A011`
+
+## User
+
+### GET `/users`
+
+- 내 정보 조회 API이다.
+- Error:
+  - `401`: `A003`, `A004`
+  - `404`: `U101`
+
+### PUT `/users`
+
+- 전달한 필드만 수정한다고 설명되어 있다.
+- Content-Type: `application/json;charset=UTF-8`
+- 현재 Swagger상 request schema가 `UpdateRequest`로 연결되어 있으나, 해당 schema 설명과 필드는 식물 수정 정보이다.
+- Error:
+  - `401`: `A003`, `A004`
+  - `404`: `U101`
+
+### DELETE `/users`
+
+- 회원 탈퇴 API이며 soft delete 처리된다.
+- Error:
+  - `401`: `A003`, `A004`
+  - `404`: `U101`
+
+## Place
+
+### GET `/place/myGarden`
+
+- 사용자가 속한 장소 목록과 메인 정보를 조회한다.
+
+### GET `/place/user`
+
+- 사용자가 속한 장소 리스트를 조회한다.
+
+### GET `/place/{code}`
+
+- Path parameter:
+  - `code`: 장소 코드
+- Error:
+  - `404`: 장소 없음
+
+### POST `/place/create`
+
+- Content-Type: `multipart/form-data`
+- Form parts:
+  - `place`: `createPlaceReq`, required
+  - `image`: binary, optional
+- `createPlaceReq` properties:
+  - `name`
+  - `address`
+- Error:
+  - `400`: 요청 형식 오류
+
+### PUT `/place/update/{code}`
+
+- Path parameter:
+  - `code`: 장소 코드
+- Swagger 설명은 `place` JSON과 선택 `image` 업로드라고 되어 있다.
+- Swagger content type은 `application/json;charset=UTF-8`로 등록되어 있다.
+- Request properties:
+  - `place`: `updatePlaceReq`, required
+  - `image`: binary, optional
+- `updatePlaceReq` properties:
+  - `name`
+  - `address`
+- Error:
+  - `404`: 장소 없음
+
+### DELETE `/place/delete/{code}`
+
+- Path parameter:
+  - `code`: 장소 코드
+- Error:
+  - `404`: 장소 없음
+
+## Plant
+
+### GET `/plants`
+
+- 사용자가 속한 모든 장소의 식물을 페이지 단위로 조회한다.
+- Query parameters:
+  - `page`: optional, default `0`
+  - `size`: optional, default `20`, 최대 `50`
+
+### POST `/plants`
+
+- Content-Type: `multipart/form-data`
+- Form parts:
+  - `plant`: `CreateRequest`, required
+  - `image`: binary, optional
+- `CreateRequest` required:
+  - `placeId`
+  - `nickname`
+- `CreateRequest` optional:
+  - `scientificNameKo`
+  - `scientificNameEn`
+  - `lastWateredDate`
+  - `description`
+- Error:
+  - `400`: 요청 값 검증 실패
+  - `403`: 장소 접근 권한 없음
+
+### GET `/plants/{plantId}`
+
+- 식물 상세 정보와 장소명, 대표 메모 정보를 조회한다.
+- Path parameter:
+  - `plantId`: 식물 ID
+- Query parameter:
+  - `placeId`: 식물이 속한 장소 ID
+- Error:
+  - `403`: 장소 접근 권한 없음
+  - `404`: 식물 없음
+
+### PUT `/plants/{plantId}`
+
+- 식물 이미지 파일, 애칭, 마지막 물 준 날짜 중 전달된 값만 수정한다.
+- Content-Type: `multipart/form-data`
+- Path parameter:
+  - `plantId`: 식물 ID
+- Query parameter:
+  - `placeId`: 식물이 속한 장소 ID
+- Form parts:
+  - `plant`: `UpdateRequest`
+  - `image`: binary, optional
+- `UpdateRequest` properties:
+  - `imageKey`
+  - `nickname`
+  - `lastWateredDate`
+- Error:
+  - `400`: 수정 요청 값 오류
+  - `403`: 장소 접근 권한 없음
+  - `404`: 식물 없음
+
+### DELETE `/plants/{plantId}`
+
+- Path parameter:
+  - `plantId`: 식물 ID
+- Query parameter:
+  - `placeId`: 식물이 속한 장소 ID
+- Error:
+  - `403`: 장소 접근 권한 없음
+  - `404`: 식물 없음
+
+### GET `/plants/{plantId}/edit`
+
+- 식물 수정 화면에 필요한 현재 이미지, 애칭, 마지막 물 준 날짜를 조회한다.
+- Path parameter:
+  - `plantId`: 식물 ID
+- Query parameter:
+  - `placeId`: 식물이 속한 장소 ID
+- Error:
+  - `403`: 장소 접근 권한 없음
+  - `404`: 식물 없음
+
+## Image
+
+### GET `/s3/images`
+
+- 이미지 key로 presigned download URL을 조회한다.
+- Query parameter:
+  - `key`: 이미지 key, required
+- Error:
+  - `401`: 인증 실패
+  - `404`: 이미지 없음
+
+### POST `/s3/images`
+
+- Content-Type: `multipart/form-data`
+- Form part:
+  - `images`: binary array, required
+- 업로드 개수는 1개 이상 5개 이하이다.
+- 허용 타입은 `jpeg`, `png`, `webp`이다.
+- 파일당 최대 크기는 10MB이다.
+- Error:
+  - `400`: 이미지 개수/파일 형식/크기 오류
+
+### PUT `/s3/images`
+
+- 기존 이미지 key에 해당하는 이미지를 새 이미지 파일로 교체한다.
+- Content-Type: `multipart/form-data`
+- Query parameter:
+  - `key`: 교체 대상 이미지 key, required
+- Form part:
+  - `image`: binary, required
+- 허용 타입은 `jpeg`, `png`, `webp`이다.
+- 파일당 최대 크기는 10MB이다.
+- Error:
+  - `400`: 이미지 파일 형식/크기 오류
+  - `401`: 인증 실패
+  - `404`: 이미지 없음
+
+### DELETE `/s3/images`
+
+- 이미지 key에 해당하는 S3 객체와 이미지 메타데이터를 삭제한다.
+- Query parameter:
+  - `key`: 이미지 key, required
+- Error:
+  - `401`: 인증 실패
+  - `404`: 이미지 없음
+
+## 확인 필요
+
+- 모든 API의 response body schema가 Swagger에 없다. DTO를 확정하려면 성공 응답 예시 또는 schema가 필요하다.
+- API 공통 응답 wrapper 사용 여부가 명세에 없다.
+- `/auth/login`의 기존 유저/신규 유저 성공 응답 body 구조가 schema로 정의되어 있지 않다.
+- `/auth/register` 성공 응답 body 구조가 schema로 정의되어 있지 않다.
+- `/users` 조회 성공 응답 body 구조가 없다.
+- `PUT /users` request schema가 식물 수정용 `UpdateRequest`로 연결되어 있다. 사용자 수정 DTO 명세 확인이 필요하다.
+- Place 조회/생성/수정/삭제 성공 응답 body 구조가 없다.
+- Plant 목록/상세/수정 화면 조회 성공 응답 body 구조가 없다.
+- Image 업로드/조회/수정/삭제 성공 응답 body 구조가 없다.
+- `PUT /place/update/{code}`는 설명상 이미지 업로드가 있으나 content type이 `application/json;charset=UTF-8`이다. `multipart/form-data` 여부 확인이 필요하다.
+- multipart 요청에서 JSON part를 어떤 content type으로 보내야 하는지 명시되어 있지 않다.
+- Place create/update의 `name`, `address` required 여부와 validation rule이 없다.
+- Plant create/update의 문자열 길이, 날짜 범위, nullable 정책이 없다.
+- 에러 응답 body 구조와 code/message 필드명이 없다.
+- 401/403/404 등 공통 에러 코드 체계가 일부 API에만 구체적으로 적혀 있다.
+- refresh token 재발급 API가 Swagger에 없다.
+- 로그아웃 API가 Swagger에 없다.
+- pagination 응답 구조와 total count 제공 여부가 없다.
+- 이미지 key 저장 주체와 이미지 업로드 후 반환되는 값의 구조가 없다.
+- 서버 base URL은 Swagger server 기준 `/api/v1`만 있으므로 앱 flavor별 full base URL 정책은 별도 결정이 필요하다.
+
+## 첫 API 연계 시 우선순위 제안
+
+1. `core/network`에 Dio client, auth interceptor, 공통 exception 타입을 먼저 추가한다.
+2. Auth 성공 응답 schema를 확인한 뒤 token 저장소와 `authStateProvider`를 연결한다.
+3. Place 또는 Plant 중 화면 전환 흐름에 필요한 목록 조회 API부터 read-only로 연결한다.
+4. multipart가 필요한 생성/수정 API는 JSON part content type과 응답 구조 확인 후 진행한다.
+5. Swagger schema가 보강되기 전에는 임시 DTO를 넓게 만들지 않고, 확인된 필드만 최소 범위로 둔다.

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -282,6 +282,55 @@
   - `401`: 인증 실패
   - `404`: 이미지 없음
 
+## 화면별 API 매핑
+
+아래 표는 현재 Swagger에서 method, path, 목적, 필수 parameter가 충돌 없이 확인되는 API만 화면에 연결한 목록이다.
+Swagger에 없거나 content type/schema 충돌이 있는 API는 넣지 않고 `확인 필요`에 남긴다.
+단, 모든 API의 성공 response body schema는 공통으로 비어 있으므로 실제 DTO 작성 전에는 응답 예시 확인이 필요하다.
+
+| 화면 | Route | 필요한 API | 사용 목적 |
+| --- | --- | --- | --- |
+| 홈 | `/` | `GET /users` | 홈 상단 사용자 정보 표시 |
+| 홈 | `/` | `GET /place/myGarden` | 사용자의 장소 목록과 메인 정원 정보 표시 |
+| 홈 | `/` | `GET /plants?page=0&size=...` | 사용자의 식물 요약 목록 표시 |
+| 온보딩 | `/onboarding` | 연결 가능 API 없음 | 화면 이동만 처리 |
+| 로그인 | `/login` | `POST /auth/login` | 소셜 SDK token으로 로그인 또는 가입 필요 상태 판단 |
+| 프로필 설정 | `/profile/setup` | `POST /auth/register` | signupToken과 프로필 입력값으로 회원가입 완료 |
+| 개인정보 이용약관 | `/terms/privacy` | 연결 가능 API 없음 | 약관 동의 UI 및 다음 화면 이동 처리 |
+| 장소 친구 요청 | `/places/invitations` | 연결 가능 API 없음 | 초대 요청 목록/수락/거절 API가 Swagger에 없음 |
+| 장소 등록 | `/places/new` | `POST /place/create` | 장소 이름, 주소, 선택 이미지로 장소 생성 |
+| 주소 검색 | `/places/new/address-search` | 연결 가능 API 없음 | 주소 검색 API가 Swagger에 없음 |
+| 친구 추가 | `/places/new/friends` | 연결 가능 API 없음 | 사용자 검색/친구 초대 API가 Swagger에 없음 |
+| 장소 수정 | `/places/:placeId/edit` | 연결 가능 API 없음 | `PUT /place/update/{code}`는 content type 확인 필요로 제외 |
+| 친구 관리 | `/places/:placeId/friends` | 연결 가능 API 없음 | 장소 멤버 조회/삭제/권한 API가 Swagger에 없음 |
+| 장소 상세 | `/places/:placeId` | `GET /place/{code}` | 장소 상세 정보 조회 |
+| 장소 상세 | `/places/:placeId` | `DELETE /place/delete/{code}` | 장소 나가기 또는 삭제 액션 후보 |
+| 식물 등록 검색 | `/plants/new/search` | 연결 가능 API 없음 | 식물 검색 API가 Swagger에 없음 |
+| 식물 등록 정보 입력 | `/plants/new/details` | `GET /place/user` | 식물을 등록할 장소 선택 목록 조회 |
+| 식물 등록 정보 입력 | `/plants/new/details` | `POST /plants` | 선택한 장소에 식물 생성 |
+| 식물 수정 | `/plants/:plantId/edit` | `GET /plants/{plantId}/edit?placeId=...` | 식물 수정 화면 초기값 조회 |
+| 식물 수정 | `/plants/:plantId/edit` | `PUT /plants/{plantId}?placeId=...` | 식물 이미지, 애칭, 마지막 물 준 날짜 수정 |
+| 식물 상세 | `/plants/:plantId` | `GET /plants/{plantId}?placeId=...` | 식물 상세, 장소명, 대표 메모 정보 조회 |
+| 식물 상세 | `/plants/:plantId` | `DELETE /plants/{plantId}?placeId=...` | 식물 삭제 |
+| 메모 작성 | `/plants/:plantId/memos/new` | 연결 가능 API 없음 | 메모 생성 API가 Swagger에 없음 |
+| 메모 목록 | `/plants/:plantId/memos` | 연결 가능 API 없음 | 메모 목록/수정/삭제 API가 Swagger에 없음 |
+
+## 화면별 제외 API
+
+아래 API는 현재 화면에서 필요해 보이지만 충돌 또는 명세 공백 때문에 위 매핑에서 제외한다.
+
+| 화면 | 제외 API | 제외 사유 |
+| --- | --- | --- |
+| 프로필 설정 | `PUT /users` | request schema가 식물 수정용 `UpdateRequest`로 연결되어 있어 사용자 수정 DTO 확인 필요 |
+| 장소 수정 | `PUT /place/update/{code}` | 설명은 이미지 업로드 포함이나 content type이 `application/json;charset=UTF-8`로 등록되어 있어 multipart 여부 확인 필요 |
+| 장소 친구 요청 | 미정 | 초대 요청 목록, 수락, 거절 API가 Swagger에 없음 |
+| 친구 추가 | 미정 | 사용자 검색, 친구 선택, 장소 초대 API가 Swagger에 없음 |
+| 친구 관리 | 미정 | 장소 멤버 목록, 멤버 삭제, 권한 변경 API가 Swagger에 없음 |
+| 주소 검색 | 미정 | 서버 주소 검색 API 사용 여부가 Swagger에 없음 |
+| 식물 등록 검색 | 미정 | 식물 학명/추천 검색 API가 Swagger에 없음 |
+| 메모 작성 | 미정 | 메모 생성 API가 Swagger에 없음 |
+| 메모 목록 | 미정 | 메모 목록, 수정, 삭제 API가 Swagger에 없음 |
+
 ## 확인 필요
 
 - 모든 API의 response body schema가 Swagger에 없다. DTO를 확정하려면 성공 응답 예시 또는 schema가 필요하다.


### PR DESCRIPTION
## 관련 이슈
Closes #43

## 구현 범위
- 서버 Swagger 기반 API 연계 참고 문서 추가
- README 프로젝트 문서 섹션에 API 문서 링크 추가

## 주요 변경사항
- Swagger UI, OpenAPI JSON, Swagger config 경로 정리
- Auth/User/Place/Plant/Image API 목록과 요청 모델 요약
- 응답 schema 부재, User 수정 schema 충돌, multipart content type 등 확인 필요 항목 문서화

## 테스트 여부
- `git diff --check` 통과

## 리뷰 포인트
- 확인 필요 항목이 백엔드와 논의할 내용으로 충분한지
- 첫 API 연계 우선순위가 실제 작업 순서와 맞는지

## 문서 반영 여부
- `docs/api-swagger-reference.md` 추가
- `README.md` 문서 링크 추가

## Breaking change 여부
- 없음