### PR TITLE
Feat: 화면 API 연계 #45

### DIFF
--- a/docs/feature-development-guide.md
+++ b/docs/feature-development-guide.md
@@ -175,6 +175,16 @@ lib/core/network/
 
 feature의 datasource는 공통 Dio client를 주입받아 사용하고, 화면이나 Controller에서 직접 Dio를 생성하지 않습니다.
 
+실제 API 호출은 기본 개발/테스트 흐름을 깨지 않도록 `COMMONPLANT_USE_API` dart-define으로 켭니다.
+base URL은 `COMMONPLANT_API_BASE_URL`로 바꿀 수 있으며 기본값은 서버 Swagger 기준 `https://commonplant.site/api/v1`입니다.
+
+```bash
+fvm flutter run --dart-define=COMMONPLANT_USE_API=true
+fvm flutter run --dart-define=COMMONPLANT_USE_API=true --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant.site/api/v1
+```
+
+Swagger에 성공 response body schema가 없는 API는 mapper에서 확인 가능한 필드만 사용하고, 필수 필드가 없으면 공통 API 오류로 처리합니다. 응답 구조가 확정되기 전까지 화면에서 임의 필드를 직접 읽지 않습니다.
+
 ## 작업 순서
 
 1. 요구사항과 Figma 범위를 확인합니다.

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/app/router/app_routes.dart
+++ b/lib/app/router/app_routes.dart
@@ -175,6 +175,7 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
     ),
     AppRouteNames.plantEdit => PlantFormPage(
       plantId: state.pathParameters['plantId'],
+      placeId: state.uri.queryParameters['placeId'],
     ),
     AppRouteNames.memoWrite => MemoWritePage(
       plantId: state.pathParameters['plantId'] ?? '',
@@ -184,6 +185,7 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
     ),
     AppRouteNames.plantDetail => PlantDetailPage(
       plantId: state.pathParameters['plantId'] ?? '',
+      placeId: state.uri.queryParameters['placeId'],
     ),
     _ => RoutePlaceholderPage(
       route: route,

--- a/lib/app/router/route_paths.dart
+++ b/lib/app/router/route_paths.dart
@@ -63,12 +63,24 @@ abstract final class AppRoutePaths {
     return '/places/${Uri.encodeComponent(placeId)}/friends';
   }
 
-  static String plantEditLocation(String plantId) {
-    return '/plants/${Uri.encodeComponent(plantId)}/edit';
+  static String plantEditLocation(String plantId, {String? placeId}) {
+    final path = '/plants/${Uri.encodeComponent(plantId)}/edit';
+
+    if (placeId == null) {
+      return path;
+    }
+
+    return Uri(path: path, queryParameters: {'placeId': placeId}).toString();
   }
 
-  static String plantDetailLocation(String plantId) {
-    return '/plants/${Uri.encodeComponent(plantId)}';
+  static String plantDetailLocation(String plantId, {String? placeId}) {
+    final path = '/plants/${Uri.encodeComponent(plantId)}';
+
+    if (placeId == null) {
+      return path;
+    }
+
+    return Uri(path: path, queryParameters: {'placeId': placeId}).toString();
   }
 
   static String memoWriteLocation(String plantId) {

--- a/lib/core/config/app_environment.dart
+++ b/lib/core/config/app_environment.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+abstract final class AppEnvironment {
+  const AppEnvironment._();
+
+  static const bool useRemoteApi = bool.fromEnvironment('COMMONPLANT_USE_API');
+
+  static const String apiBaseUrl = String.fromEnvironment(
+    'COMMONPLANT_API_BASE_URL',
+    defaultValue: 'https://commonplant.site/api/v1',
+  );
+}
+
+final useRemoteApiProvider = Provider<bool>((ref) {
+  return AppEnvironment.useRemoteApi;
+});
+
+final apiBaseUrlProvider = Provider<String>((ref) {
+  return AppEnvironment.apiBaseUrl;
+});

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -1,0 +1,21 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_interceptor.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: ref.watch(apiBaseUrlProvider),
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      sendTimeout: const Duration(seconds: 10),
+      headers: const {'Accept': 'application/json'},
+    ),
+  );
+
+  dio.interceptors.add(AuthInterceptor(ref.watch(authTokenStoreProvider)));
+
+  return dio;
+});

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -1,0 +1,76 @@
+import 'package:dio/dio.dart';
+
+class ApiException implements Exception {
+  const ApiException({
+    required this.message,
+    this.statusCode,
+    this.code,
+    this.cause,
+  });
+
+  final String message;
+  final int? statusCode;
+  final String? code;
+  final Object? cause;
+
+  factory ApiException.fromDio(DioException exception) {
+    final response = exception.response;
+    final statusCode = response?.statusCode;
+    final data = response?.data;
+    final parsedMessage = _messageFromData(data);
+
+    return ApiException(
+      statusCode: statusCode,
+      code: _codeFromData(data),
+      message: parsedMessage ?? _messageFromType(exception.type),
+      cause: exception,
+    );
+  }
+
+  @override
+  String toString() {
+    final codeLabel = code == null ? '' : '[$code] ';
+    final statusLabel = statusCode == null ? '' : 'HTTP $statusCode ';
+
+    return 'ApiException: $statusLabel$codeLabel$message';
+  }
+}
+
+String? _messageFromData(Object? data) {
+  if (data is Map<String, Object?>) {
+    final message = data['message'] ?? data['error'] ?? data['detail'];
+
+    if (message is String && message.isNotEmpty) {
+      return message;
+    }
+  }
+
+  if (data is String && data.isNotEmpty) {
+    return data;
+  }
+
+  return null;
+}
+
+String? _codeFromData(Object? data) {
+  if (data is! Map<String, Object?>) {
+    return null;
+  }
+
+  final code = data['code'] ?? data['errorCode'];
+
+  return code is String && code.isNotEmpty ? code : null;
+}
+
+String _messageFromType(DioExceptionType type) {
+  return switch (type) {
+    DioExceptionType.connectionTimeout ||
+    DioExceptionType.sendTimeout ||
+    DioExceptionType.receiveTimeout => '요청 시간이 초과되었습니다.',
+    DioExceptionType.badCertificate => '서버 인증서가 유효하지 않습니다.',
+    DioExceptionType.badResponse => '서버 요청에 실패했습니다.',
+    DioExceptionType.cancel => '요청이 취소되었습니다.',
+    DioExceptionType.connectionError => '네트워크 연결을 확인해 주세요.',
+    DioExceptionType.unknown => '알 수 없는 네트워크 오류가 발생했습니다.',
+  };
+}

--- a/lib/core/network/api_response_parser.dart
+++ b/lib/core/network/api_response_parser.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+
+import 'package:commonplant_frontend/core/network/api_exception.dart';
+
+typedef JsonMap = Map<String, Object?>;
+
+JsonMap jsonObjectFromResponse(Object? data, {required String context}) {
+  final normalized = _normalizeResponseData(data);
+
+  if (normalized is JsonMap) {
+    return normalized;
+  }
+
+  throw ApiException(message: '$context 응답이 JSON object 형식이 아닙니다.');
+}
+
+List<JsonMap> jsonListFromResponse(Object? data, {required String context}) {
+  final normalized = _normalizeResponseData(data);
+  final unwrapped = _unwrapData(normalized);
+
+  if (unwrapped is List) {
+    return [
+      for (final item in unwrapped)
+        if (item is JsonMap) item,
+    ];
+  }
+
+  if (unwrapped is JsonMap) {
+    for (final key in const ['items', 'content', 'list', 'places', 'plants']) {
+      final value = unwrapped[key];
+      if (value is List) {
+        return [
+          for (final item in value)
+            if (item is JsonMap) item,
+        ];
+      }
+    }
+  }
+
+  throw ApiException(message: '$context 응답에서 목록 데이터를 찾을 수 없습니다.');
+}
+
+JsonMap unwrapJsonObject(Object? data, {required String context}) {
+  final object = jsonObjectFromResponse(data, context: context);
+  final unwrapped = _unwrapData(object);
+
+  if (unwrapped is JsonMap) {
+    return unwrapped;
+  }
+
+  return object;
+}
+
+String readRequiredString(JsonMap json, List<String> keys, String context) {
+  final value = readOptionalString(json, keys);
+
+  if (value != null && value.isNotEmpty) {
+    return value;
+  }
+
+  throw ApiException(message: '$context 필드가 응답에 없습니다: ${keys.join(', ')}');
+}
+
+String? readOptionalString(JsonMap json, List<String> keys) {
+  for (final key in keys) {
+    final value = json[key];
+
+    if (value == null) {
+      continue;
+    }
+
+    if (value is String) {
+      return value;
+    }
+
+    if (value is num || value is bool) {
+      return value.toString();
+    }
+  }
+
+  return null;
+}
+
+int? readOptionalInt(JsonMap json, List<String> keys) {
+  for (final key in keys) {
+    final value = json[key];
+
+    if (value is int) {
+      return value;
+    }
+
+    if (value is num) {
+      return value.toInt();
+    }
+
+    if (value is String) {
+      return int.tryParse(value);
+    }
+  }
+
+  return null;
+}
+
+Object? _normalizeResponseData(Object? data) {
+  if (data is String && data.isNotEmpty) {
+    return jsonDecode(data);
+  }
+
+  return data;
+}
+
+Object? _unwrapData(Object? data) {
+  if (data is! JsonMap) {
+    return data;
+  }
+
+  for (final key in const ['data', 'result', 'payload', 'body']) {
+    final value = data[key];
+    if (value != null) {
+      return value;
+    }
+  }
+
+  return data;
+}

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -1,0 +1,22 @@
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:dio/dio.dart';
+
+class AuthInterceptor extends Interceptor {
+  const AuthInterceptor(this._tokenStore);
+
+  final AuthTokenStore _tokenStore;
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final accessToken = await _tokenStore.readAccessToken();
+
+    if (accessToken != null && accessToken.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $accessToken';
+    }
+
+    handler.next(options);
+  }
+}

--- a/lib/core/network/auth_token_store.dart
+++ b/lib/core/network/auth_token_store.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+abstract interface class AuthTokenStore {
+  Future<String?> readAccessToken();
+
+  Future<String?> readRefreshToken();
+
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  });
+
+  Future<void> clear();
+}
+
+final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {
+  return const FlutterSecureStorage();
+});
+
+final authTokenStoreProvider = Provider<AuthTokenStore>((ref) {
+  return SecureAuthTokenStore(ref.watch(secureStorageProvider));
+});
+
+class SecureAuthTokenStore implements AuthTokenStore {
+  const SecureAuthTokenStore(this._storage);
+
+  static const String _accessTokenKey = 'commonplant.accessToken';
+  static const String _refreshTokenKey = 'commonplant.refreshToken';
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> readAccessToken() {
+    return _storage.read(key: _accessTokenKey);
+  }
+
+  @override
+  Future<String?> readRefreshToken() {
+    return _storage.read(key: _refreshTokenKey);
+  }
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    await _storage.write(key: _accessTokenKey, value: accessToken);
+    await _storage.write(key: _refreshTokenKey, value: refreshToken);
+  }
+
+  @override
+  Future<void> clear() async {
+    await _storage.delete(key: _accessTokenKey);
+    await _storage.delete(key: _refreshTokenKey);
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -194,9 +194,27 @@ class _HomeBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final places = ref.watch(placeListProvider);
+    final placesAsync = ref.watch(placeSummariesProvider);
+    final plantsAsync = ref.watch(plantSummariesProvider);
+
+    if (placesAsync.isLoading || plantsAsync.isLoading) {
+      return const _HomeStatusBody(
+        child: CircularProgressIndicator(color: AppColors.brandPrimary),
+      );
+    }
+
+    if (placesAsync.hasError || plantsAsync.hasError) {
+      return _HomeStatusBody(
+        child: Text(
+          '데이터를 불러오지 못했어요',
+          style: AppTextStyles.size16Medium.copyWith(color: AppColors.textBody),
+        ),
+      );
+    }
+
+    final places = placesAsync.value ?? const [];
     final hasPlaces = places.isNotEmpty;
-    final plants = ref.watch(plantListProvider);
+    final plants = plantsAsync.value ?? const [];
     final hasPlants = plants.isNotEmpty;
 
     return SingleChildScrollView(
@@ -266,7 +284,10 @@ class _HomeBody extends ConsumerWidget {
                         button: true,
                         child: CommonPlantCard(
                           onTap: () => context.push(
-                            AppRoutePaths.plantDetailLocation(plant.id),
+                            AppRoutePaths.plantDetailLocation(
+                              plant.id,
+                              placeId: plant.placeId,
+                            ),
                           ),
                         ),
                       ),
@@ -298,6 +319,22 @@ class _HomeBody extends ConsumerWidget {
               ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _HomeStatusBody extends StatelessWidget {
+  const _HomeStatusBody({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.x20),
+        child: child,
       ),
     );
   }

--- a/lib/features/login/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/login/data/datasources/auth_remote_data_source.dart
@@ -1,0 +1,35 @@
+import 'package:commonplant_frontend/core/network/api_exception.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:dio/dio.dart';
+
+class AuthRemoteDataSource {
+  const AuthRemoteDataSource(this._dio);
+
+  final Dio _dio;
+
+  Future<Object?> login(LoginRequest request) async {
+    try {
+      final response = await _dio.post<Object?>(
+        '/auth/login',
+        data: request.toJson(),
+      );
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Object?> register(RegisterRequest request) async {
+    try {
+      final response = await _dio.post<Object?>(
+        '/auth/register',
+        data: request.toJson(),
+      );
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+}

--- a/lib/features/login/data/dtos/auth_requests.dart
+++ b/lib/features/login/data/dtos/auth_requests.dart
@@ -1,0 +1,33 @@
+class LoginRequest {
+  const LoginRequest({required this.provider, required this.token});
+
+  final String provider;
+  final String token;
+
+  Map<String, Object?> toJson() {
+    return {'provider': provider, 'token': token};
+  }
+}
+
+class RegisterRequest {
+  const RegisterRequest({
+    required this.signupToken,
+    required this.name,
+    this.introduction,
+    this.imgUrl,
+  });
+
+  final String signupToken;
+  final String name;
+  final String? introduction;
+  final String? imgUrl;
+
+  Map<String, Object?> toJson() {
+    return {
+      'signupToken': signupToken,
+      'name': name,
+      if (introduction != null) 'introduction': introduction,
+      if (imgUrl != null) 'imgUrl': imgUrl,
+    };
+  }
+}

--- a/lib/features/login/data/dtos/auth_result.dart
+++ b/lib/features/login/data/dtos/auth_result.dart
@@ -1,0 +1,60 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+
+sealed class AuthResult {
+  const AuthResult();
+}
+
+class AuthenticatedResult extends AuthResult {
+  const AuthenticatedResult({
+    required this.accessToken,
+    required this.refreshToken,
+  });
+
+  final String accessToken;
+  final String refreshToken;
+}
+
+class SignupRequiredResult extends AuthResult {
+  const SignupRequiredResult({
+    required this.signupToken,
+    this.suggestedName,
+    this.suggestedImgUrl,
+  });
+
+  final String signupToken;
+  final String? suggestedName;
+  final String? suggestedImgUrl;
+}
+
+AuthResult authResultFromJson(JsonMap json) {
+  final object = json['isNewUser'] == null
+      ? unwrapJsonObject(json, context: 'Auth')
+      : json;
+  final isNewUser = object['isNewUser'];
+
+  if (isNewUser == true || object['signupToken'] != null) {
+    return SignupRequiredResult(
+      signupToken: readRequiredString(object, const [
+        'signupToken',
+      ], 'signupToken'),
+      suggestedName: readOptionalString(object, const [
+        'suggestedName',
+        'name',
+      ]),
+      suggestedImgUrl: readOptionalString(object, const [
+        'suggestedImgUrl',
+        'imgUrl',
+        'imageUrl',
+      ]),
+    );
+  }
+
+  return AuthenticatedResult(
+    accessToken: readRequiredString(object, const [
+      'accessToken',
+    ], 'accessToken'),
+    refreshToken: readRequiredString(object, const [
+      'refreshToken',
+    ], 'refreshToken'),
+  );
+}

--- a/lib/features/login/data/repositories/auth_repository.dart
+++ b/lib/features/login/data/repositories/auth_repository.dart
@@ -1,0 +1,59 @@
+import 'package:commonplant_frontend/core/network/api_client.dart';
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/datasources/auth_remote_data_source.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final authRemoteDataSourceProvider = Provider<AuthRemoteDataSource>((ref) {
+  return AuthRemoteDataSource(ref.watch(dioProvider));
+});
+
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  return AuthRepository(
+    ref.watch(authRemoteDataSourceProvider),
+    ref.watch(authTokenStoreProvider),
+  );
+});
+
+class AuthRepository {
+  const AuthRepository(this._remoteDataSource, this._tokenStore);
+
+  final AuthRemoteDataSource _remoteDataSource;
+  final AuthTokenStore _tokenStore;
+
+  Future<AuthResult> login(LoginRequest request) async {
+    final data = await _remoteDataSource.login(request);
+    final result = authResultFromJson(
+      jsonObjectFromResponse(data, context: '로그인'),
+    );
+
+    await _saveIfAuthenticated(result);
+
+    return result;
+  }
+
+  Future<AuthResult> register(RegisterRequest request) async {
+    final data = await _remoteDataSource.register(request);
+    final result = authResultFromJson(
+      jsonObjectFromResponse(data, context: '회원가입'),
+    );
+
+    await _saveIfAuthenticated(result);
+
+    return result;
+  }
+
+  Future<void> _saveIfAuthenticated(AuthResult result) async {
+    if (result case AuthenticatedResult(
+      :final accessToken,
+      :final refreshToken,
+    )) {
+      await _tokenStore.saveTokens(
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      );
+    }
+  }
+}

--- a/lib/features/place/data/datasources/place_remote_data_source.dart
+++ b/lib/features/place/data/datasources/place_remote_data_source.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:commonplant_frontend/core/network/api_exception.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:dio/dio.dart';
+
+class PlaceRemoteDataSource {
+  const PlaceRemoteDataSource(this._dio);
+
+  final Dio _dio;
+
+  Future<Object?> getMyGarden() async {
+    try {
+      final response = await _dio.get<Object?>('/place/myGarden');
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Object?> getUserPlaces() async {
+    try {
+      final response = await _dio.get<Object?>('/place/user');
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Object?> getPlace(String code) async {
+    try {
+      final response = await _dio.get<Object?>('/place/$code');
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<void> createPlace(CreatePlaceRequest request) async {
+    try {
+      await _dio.post<Object?>(
+        '/place/create',
+        data: FormData.fromMap({
+          'place': MultipartFile.fromString(
+            jsonEncode(request.toJson()),
+            contentType: DioMediaType('application', 'json'),
+          ),
+        }),
+      );
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<void> deletePlace(String code) async {
+    try {
+      await _dio.delete<Object?>('/place/delete/$code');
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+}

--- a/lib/features/place/data/dtos/place_requests.dart
+++ b/lib/features/place/data/dtos/place_requests.dart
@@ -1,0 +1,13 @@
+class CreatePlaceRequest {
+  const CreatePlaceRequest({required this.name, this.address});
+
+  final String name;
+  final String? address;
+
+  Map<String, Object?> toJson() {
+    return {
+      'name': name,
+      if (address != null && address!.isNotEmpty) 'address': address,
+    };
+  }
+}

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -1,0 +1,65 @@
+import 'package:commonplant_frontend/core/network/api_client.dart';
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeRemoteDataSourceProvider = Provider<PlaceRemoteDataSource>((ref) {
+  return PlaceRemoteDataSource(ref.watch(dioProvider));
+});
+
+final placeRepositoryProvider = Provider<PlaceRepository>((ref) {
+  return PlaceRepository(ref.watch(placeRemoteDataSourceProvider));
+});
+
+class PlaceRepository {
+  const PlaceRepository(this._remoteDataSource);
+
+  final PlaceRemoteDataSource _remoteDataSource;
+
+  Future<List<PlaceSummary>> fetchMyGardenPlaces() async {
+    final data = await _remoteDataSource.getMyGarden();
+    final items = jsonListFromResponse(data, context: '내 정원 조회');
+
+    return [for (final item in items) placeSummaryFromJson(item)];
+  }
+
+  Future<List<PlaceSummary>> fetchUserPlaces() async {
+    final data = await _remoteDataSource.getUserPlaces();
+    final items = jsonListFromResponse(data, context: '소속 장소 조회');
+
+    return [for (final item in items) placeSummaryFromJson(item)];
+  }
+
+  Future<PlaceSummary> fetchPlace(String code) async {
+    final data = await _remoteDataSource.getPlace(code);
+    final object = unwrapJsonObject(data, context: '장소 조회');
+
+    return placeSummaryFromJson(object, fallbackId: code);
+  }
+
+  Future<void> createPlace(CreatePlaceRequest request) {
+    return _remoteDataSource.createPlace(request);
+  }
+
+  Future<void> deletePlace(String code) {
+    return _remoteDataSource.deletePlace(code);
+  }
+}
+
+PlaceSummary placeSummaryFromJson(JsonMap json, {String? fallbackId}) {
+  return PlaceSummary(
+    id:
+        readOptionalString(json, const [
+          'id',
+          'placeId',
+          'code',
+          'placeCode',
+        ]) ??
+        fallbackId ??
+        readRequiredString(json, const ['nanoId'], '장소 ID'),
+    name: readRequiredString(json, const ['name', 'placeName'], '장소 이름'),
+    address: readOptionalString(json, const ['address', 'placeAddress']),
+  );
+}

--- a/lib/features/place/domain/entities/place_summary.dart
+++ b/lib/features/place/domain/entities/place_summary.dart
@@ -1,0 +1,15 @@
+class PlaceSummary {
+  const PlaceSummary({required this.id, required this.name, this.address});
+
+  final String id;
+  final String name;
+  final String? address;
+
+  PlaceSummary copyWith({String? id, String? name, String? address}) {
+    return PlaceSummary(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      address: address ?? this.address,
+    );
+  }
+}

--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -1,11 +1,13 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
@@ -14,6 +16,7 @@ import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:commonplant_frontend/shared/widgets/common_watering_button.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 enum PlaceDetailRole { leader, member }
@@ -56,8 +59,26 @@ class PlaceDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final detail = _PlaceDetailData.mock(placeId, role: role);
+    final mockDetail = _PlaceDetailData.mock(placeId, role: role);
 
+    if (AppEnvironment.useRemoteApi) {
+      return Consumer(
+        builder: (context, ref, _) {
+          final remoteDetail = ref.watch(placeDetailProvider(placeId));
+          final detail = switch (remoteDetail) {
+            AsyncData(:final value) => mockDetail.applySummary(value),
+            _ => mockDetail,
+          };
+
+          return _buildScaffold(context, detail);
+        },
+      );
+    }
+
+    return _buildScaffold(context, mockDetail);
+  }
+
+  Widget _buildScaffold(BuildContext context, _PlaceDetailData detail) {
     return CommonScaffold(
       title: 'My place',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -78,7 +99,7 @@ class PlaceDetailPage extends StatelessWidget {
             child: Column(
               children: [
                 _PlaceDetailHeader(detail: detail, placeId: placeId),
-                _PlacePlantList(plants: detail.plants),
+                _PlacePlantList(placeId: placeId, plants: detail.plants),
               ],
             ),
           ),
@@ -106,6 +127,18 @@ class _PlaceDetailData {
   final String humidityLabel;
   final List<_PlaceFriend> friends;
   final List<_PlacePlant> plants;
+
+  _PlaceDetailData applySummary(PlaceSummary summary) {
+    return _PlaceDetailData(
+      role: role,
+      name: summary.name,
+      address: summary.address ?? address,
+      sunlightLabel: sunlightLabel,
+      humidityLabel: humidityLabel,
+      friends: friends,
+      plants: plants,
+    );
+  }
 
   static _PlaceDetailData mock(String placeId, {PlaceDetailRole? role}) {
     final effectiveRole = role ?? _roleFromPlaceId(placeId);
@@ -485,8 +518,9 @@ class _FriendManagementShortcut extends StatelessWidget {
 }
 
 class _PlacePlantList extends StatelessWidget {
-  const _PlacePlantList({required this.plants});
+  const _PlacePlantList({required this.placeId, required this.plants});
 
+  final String placeId;
   final List<_PlacePlant> plants;
 
   @override
@@ -517,8 +551,9 @@ class _PlacePlantList extends StatelessWidget {
                 dateLabel: plant.dateLabel,
                 isPrimary: plant.canWater,
               ),
-              onTap: () =>
-                  context.push(AppRoutePaths.plantDetailLocation(plant.id)),
+              onTap: () => context.push(
+                AppRoutePaths.plantDetailLocation(plant.id, placeId: placeId),
+              ),
             ),
             if (plant != plants.last) const SizedBox(height: AppSpacing.x16),
           ],

--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -1,9 +1,12 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
@@ -66,7 +69,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
         onImageTap: () {},
         onAddressTap: () => context.push(AppRoutePaths.addressSearch),
         onAddressClear: () => setState(() => _address = null),
-        onNext: _submit,
+        onNext: () => _submit(),
       );
     }
 
@@ -78,11 +81,11 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       onImageTap: () {},
       onAddressTap: () => context.push(AppRoutePaths.addressSearch),
       onAddressClear: () => setState(() => _address = null),
-      onComplete: _submit,
+      onComplete: () => _submit(),
     );
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     final name = _nameController.text.trim();
     final notifier = ref.read(placeListProvider.notifier);
 
@@ -90,6 +93,28 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       notifier.updatePlace(id: placeId, name: name, address: _address);
       context.go(AppRoutePaths.home);
     } else {
+      if (ref.read(useRemoteApiProvider)) {
+        try {
+          await ref
+              .read(placeRepositoryProvider)
+              .createPlace(CreatePlaceRequest(name: name, address: _address));
+          ref.invalidate(remotePlaceListProvider);
+        } catch (error) {
+          if (!mounted) {
+            return;
+          }
+
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('장소 생성에 실패했어요: $error')));
+          return;
+        }
+      }
+
+      if (!mounted) {
+        return;
+      }
+
       notifier.addPlace(name: name, address: _address);
       context.push(AppRoutePaths.placeFriendAdd);
     }

--- a/lib/features/place/presentation/providers/place_list_provider.dart
+++ b/lib/features/place/presentation/providers/place_list_provider.dart
@@ -1,25 +1,43 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+export 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 
 final placeListProvider =
     NotifierProvider<PlaceListNotifier, List<PlaceSummary>>(
       PlaceListNotifier.new,
     );
 
-class PlaceSummary {
-  const PlaceSummary({required this.id, required this.name, this.address});
+final remotePlaceListProvider = FutureProvider<List<PlaceSummary>>((ref) {
+  return ref.watch(placeRepositoryProvider).fetchMyGardenPlaces();
+});
 
-  final String id;
-  final String name;
-  final String? address;
-
-  PlaceSummary copyWith({String? id, String? name, String? address}) {
-    return PlaceSummary(
-      id: id ?? this.id,
-      name: name ?? this.name,
-      address: address ?? this.address,
-    );
+final placeSummariesProvider = Provider<AsyncValue<List<PlaceSummary>>>((ref) {
+  if (ref.watch(useRemoteApiProvider)) {
+    return ref.watch(remotePlaceListProvider);
   }
-}
+
+  return AsyncData(ref.watch(placeListProvider));
+});
+
+final plantRegistrationPlaceProvider = FutureProvider<List<PlaceSummary>>((
+  ref,
+) {
+  if (ref.watch(useRemoteApiProvider)) {
+    return ref.watch(placeRepositoryProvider).fetchUserPlaces();
+  }
+
+  return ref.watch(placeListProvider);
+});
+
+final placeDetailProvider = FutureProvider.family<PlaceSummary, String>((
+  ref,
+  code,
+) {
+  return ref.watch(placeRepositoryProvider).fetchPlace(code);
+});
 
 class PlaceListNotifier extends Notifier<List<PlaceSummary>> {
   int _nextId = 1;

--- a/lib/features/plant/data/datasources/plant_remote_data_source.dart
+++ b/lib/features/plant/data/datasources/plant_remote_data_source.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:commonplant_frontend/core/network/api_exception.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:dio/dio.dart';
+
+class PlantRemoteDataSource {
+  const PlantRemoteDataSource(this._dio);
+
+  final Dio _dio;
+
+  Future<Object?> getPlants({int page = 0, int size = 20}) async {
+    try {
+      final response = await _dio.get<Object?>(
+        '/plants',
+        queryParameters: {'page': page, 'size': size},
+      );
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<void> createPlant(CreatePlantRequest request) async {
+    try {
+      await _dio.post<Object?>(
+        '/plants',
+        data: FormData.fromMap({
+          'plant': MultipartFile.fromString(
+            jsonEncode(request.toJson()),
+            contentType: DioMediaType('application', 'json'),
+          ),
+        }),
+      );
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Object?> getPlant({
+    required String plantId,
+    required String placeId,
+  }) async {
+    try {
+      final response = await _dio.get<Object?>(
+        '/plants/$plantId',
+        queryParameters: {'placeId': placeId},
+      );
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Object?> getPlantEditInfo({
+    required String plantId,
+    required String placeId,
+  }) async {
+    try {
+      final response = await _dio.get<Object?>(
+        '/plants/$plantId/edit',
+        queryParameters: {'placeId': placeId},
+      );
+
+      return response.data;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeId,
+    required UpdatePlantRequest request,
+  }) async {
+    try {
+      await _dio.put<Object?>(
+        '/plants/$plantId',
+        queryParameters: {'placeId': placeId},
+        data: FormData.fromMap({
+          'plant': MultipartFile.fromString(
+            jsonEncode(request.toJson()),
+            contentType: DioMediaType('application', 'json'),
+          ),
+        }),
+      );
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<void> deletePlant({
+    required String plantId,
+    required String placeId,
+  }) async {
+    try {
+      await _dio.delete<Object?>(
+        '/plants/$plantId',
+        queryParameters: {'placeId': placeId},
+      );
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+}

--- a/lib/features/plant/data/dtos/plant_requests.dart
+++ b/lib/features/plant/data/dtos/plant_requests.dart
@@ -1,0 +1,48 @@
+class CreatePlantRequest {
+  const CreatePlantRequest({
+    required this.placeId,
+    required this.nickname,
+    this.scientificNameKo,
+    this.scientificNameEn,
+    this.lastWateredDate,
+    this.description,
+  });
+
+  final int placeId;
+  final String nickname;
+  final String? scientificNameKo;
+  final String? scientificNameEn;
+  final String? lastWateredDate;
+  final String? description;
+
+  Map<String, Object?> toJson() {
+    return {
+      'placeId': placeId,
+      'nickname': nickname,
+      if (scientificNameKo != null) 'scientificNameKo': scientificNameKo,
+      if (scientificNameEn != null) 'scientificNameEn': scientificNameEn,
+      if (lastWateredDate != null) 'lastWateredDate': lastWateredDate,
+      if (description != null) 'description': description,
+    };
+  }
+}
+
+class UpdatePlantRequest {
+  const UpdatePlantRequest({
+    this.imageKey,
+    this.nickname,
+    this.lastWateredDate,
+  });
+
+  final String? imageKey;
+  final String? nickname;
+  final String? lastWateredDate;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (imageKey != null) 'imageKey': imageKey,
+      if (nickname != null) 'nickname': nickname,
+      if (lastWateredDate != null) 'lastWateredDate': lastWateredDate,
+    };
+  }
+}

--- a/lib/features/plant/data/repositories/plant_repository.dart
+++ b/lib/features/plant/data/repositories/plant_repository.dart
@@ -1,0 +1,113 @@
+import 'package:commonplant_frontend/core/network/api_client.dart';
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantRemoteDataSourceProvider = Provider<PlantRemoteDataSource>((ref) {
+  return PlantRemoteDataSource(ref.watch(dioProvider));
+});
+
+final plantRepositoryProvider = Provider<PlantRepository>((ref) {
+  return PlantRepository(ref.watch(plantRemoteDataSourceProvider));
+});
+
+class PlantRepository {
+  const PlantRepository(this._remoteDataSource);
+
+  final PlantRemoteDataSource _remoteDataSource;
+
+  Future<List<PlantSummary>> fetchPlants({int page = 0, int size = 20}) async {
+    final data = await _remoteDataSource.getPlants(page: page, size: size);
+    final items = jsonListFromResponse(data, context: '식물 목록 조회');
+
+    return [for (final item in items) plantSummaryFromJson(item)];
+  }
+
+  Future<void> createPlant(CreatePlantRequest request) {
+    return _remoteDataSource.createPlant(request);
+  }
+
+  Future<PlantDetail> fetchPlant({
+    required String plantId,
+    required String placeId,
+  }) async {
+    final data = await _remoteDataSource.getPlant(
+      plantId: plantId,
+      placeId: placeId,
+    );
+    final object = unwrapJsonObject(data, context: '식물 상세 조회');
+
+    return plantDetailFromJson(
+      object,
+      fallbackId: plantId,
+      fallbackPlaceId: placeId,
+    );
+  }
+
+  Future<PlantEditInfo> fetchPlantEditInfo({
+    required String plantId,
+    required String placeId,
+  }) async {
+    final data = await _remoteDataSource.getPlantEditInfo(
+      plantId: plantId,
+      placeId: placeId,
+    );
+    final object = unwrapJsonObject(data, context: '식물 수정 정보 조회');
+
+    return PlantEditInfo(
+      name: readRequiredString(object, const ['nickname', 'name'], '식물 애칭'),
+      lastWateredDate: readOptionalString(object, const ['lastWateredDate']),
+      imageKey: readOptionalString(object, const ['imageKey']),
+    );
+  }
+
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeId,
+    required UpdatePlantRequest request,
+  }) {
+    return _remoteDataSource.updatePlant(
+      plantId: plantId,
+      placeId: placeId,
+      request: request,
+    );
+  }
+
+  Future<void> deletePlant({required String plantId, required String placeId}) {
+    return _remoteDataSource.deletePlant(plantId: plantId, placeId: placeId);
+  }
+}
+
+PlantSummary plantSummaryFromJson(JsonMap json) {
+  return PlantSummary(
+    id: readRequiredString(json, const ['id', 'plantId'], '식물 ID'),
+    name: readRequiredString(json, const ['nickname', 'name'], '식물 이름'),
+    placeId: readOptionalString(json, const ['placeId']),
+    placeName: readOptionalString(json, const ['placeName']),
+    description: readOptionalString(json, const ['description']),
+  );
+}
+
+PlantDetail plantDetailFromJson(
+  JsonMap json, {
+  required String fallbackId,
+  String? fallbackPlaceId,
+}) {
+  return PlantDetail(
+    id: readOptionalString(json, const ['id', 'plantId']) ?? fallbackId,
+    name: readRequiredString(json, const ['nickname', 'name'], '식물 이름'),
+    placeId: readOptionalString(json, const ['placeId']) ?? fallbackPlaceId,
+    placeName: readOptionalString(json, const ['placeName']),
+    species: readOptionalString(json, const [
+      'scientificNameEn',
+      'scientificNameKo',
+      'species',
+    ]),
+    description: readOptionalString(json, const ['description']),
+    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
+    imageKey: readOptionalString(json, const ['imageKey']),
+  );
+}

--- a/lib/features/plant/domain/entities/plant_detail.dart
+++ b/lib/features/plant/domain/entities/plant_detail.dart
@@ -1,0 +1,33 @@
+class PlantDetail {
+  const PlantDetail({
+    required this.id,
+    required this.name,
+    this.placeId,
+    this.placeName,
+    this.species,
+    this.description,
+    this.lastWateredDate,
+    this.imageKey,
+  });
+
+  final String id;
+  final String name;
+  final String? placeId;
+  final String? placeName;
+  final String? species;
+  final String? description;
+  final String? lastWateredDate;
+  final String? imageKey;
+}
+
+class PlantEditInfo {
+  const PlantEditInfo({
+    required this.name,
+    this.lastWateredDate,
+    this.imageKey,
+  });
+
+  final String name;
+  final String? lastWateredDate;
+  final String? imageKey;
+}

--- a/lib/features/plant/domain/entities/plant_summary.dart
+++ b/lib/features/plant/domain/entities/plant_summary.dart
@@ -1,0 +1,31 @@
+class PlantSummary {
+  const PlantSummary({
+    required this.id,
+    required this.name,
+    this.placeId,
+    this.placeName,
+    this.description,
+  });
+
+  final String id;
+  final String name;
+  final String? placeId;
+  final String? placeName;
+  final String? description;
+
+  PlantSummary copyWith({
+    String? id,
+    String? name,
+    String? placeId,
+    String? placeName,
+    String? description,
+  }) {
+    return PlantSummary(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      placeId: placeId ?? this.placeId,
+      placeName: placeName ?? this.placeName,
+      description: description ?? this.description,
+    );
+  }
+}

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -1,11 +1,14 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
@@ -13,12 +16,14 @@ import 'package:commonplant_frontend/shared/widgets/common_memo_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 class PlantDetailPage extends StatelessWidget {
-  const PlantDetailPage({super.key, required this.plantId});
+  const PlantDetailPage({super.key, required this.plantId, this.placeId});
 
   final String plantId;
+  final String? placeId;
 
   void _showPlantMenu(BuildContext context) {
     showGeneralDialog<void>(
@@ -41,7 +46,12 @@ class PlantDetailPage extends StatelessWidget {
                 child: CommonEditDeletePopup(
                   onEdit: () {
                     Navigator.of(dialogContext).pop();
-                    context.push(AppRoutePaths.plantEditLocation(plantId));
+                    context.push(
+                      AppRoutePaths.plantEditLocation(
+                        plantId,
+                        placeId: placeId,
+                      ),
+                    );
                   },
                   onDelete: () {
                     Navigator.of(dialogContext).pop();
@@ -80,8 +90,28 @@ class PlantDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final detail = _PlantDetailData.mock();
+    final mockDetail = _PlantDetailData.mock();
 
+    if (AppEnvironment.useRemoteApi && placeId != null) {
+      return Consumer(
+        builder: (context, ref, _) {
+          final remoteDetail = ref.watch(
+            remotePlantDetailProvider((plantId: plantId, placeId: placeId!)),
+          );
+          final detail = switch (remoteDetail) {
+            AsyncData(:final value) => mockDetail.applyRemote(value),
+            _ => mockDetail,
+          };
+
+          return _buildScaffold(context, detail);
+        },
+      );
+    }
+
+    return _buildScaffold(context, mockDetail);
+  }
+
+  Widget _buildScaffold(BuildContext context, _PlantDetailData detail) {
     return CommonScaffold(
       title: 'My plant',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -131,6 +161,20 @@ class _PlantDetailData {
   final String lastWateredDate;
   final String wateringCycleLabel;
   final List<_PlantMemo> memos;
+
+  _PlantDetailData applyRemote(PlantDetail detail) {
+    return _PlantDetailData(
+      placeName: detail.placeName ?? placeName,
+      name: detail.name,
+      species: detail.species ?? species,
+      daysTogether: daysTogether,
+      dDayLabel: dDayLabel,
+      startDate: startDate,
+      lastWateredDate: detail.lastWateredDate ?? lastWateredDate,
+      wateringCycleLabel: wateringCycleLabel,
+      memos: memos,
+    );
+  }
 
   static _PlantDetailData mock() {
     return const _PlantDetailData(

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,11 +1,15 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
@@ -18,9 +22,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 class PlantFormPage extends ConsumerStatefulWidget {
-  const PlantFormPage({super.key, this.plantId, this.initialPlantName});
+  const PlantFormPage({
+    super.key,
+    this.plantId,
+    this.placeId,
+    this.initialPlantName,
+  });
 
   final String? plantId;
+  final String? placeId;
   final String? initialPlantName;
 
   bool get isEdit => plantId != null;
@@ -86,17 +96,24 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
         nameController: _nameController,
         canSubmit: canSubmit,
         onChanged: (_) => setState(() {}),
-        onSubmit: _submitEdit,
+        onSubmit: () => _submitEdit(),
       );
     }
 
+    final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
+    final registrationPlaces = _registrationPlacesFromSummaries(
+      remotePlaces.value ?? const [],
+    );
+    final places = registrationPlaces.isEmpty ? _places : registrationPlaces;
+    final selectedPlaceId = _effectiveSelectedPlaceId(places);
+
     return _PlantCreateScaffold(
-      places: _places,
-      selectedPlaceId: _selectedPlaceId,
+      places: places,
+      selectedPlaceId: selectedPlaceId,
       wateringDate: '2023. 01. 30',
       onPlaceSelected: (place) => setState(() => _selectedPlaceId = place.id),
       onCancel: _cancelCreate,
-      onSubmit: _submitCreate,
+      onSubmit: () => _submitCreate(),
     );
   }
 
@@ -111,19 +128,36 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   _PlantRegistrationPlace? get _selectedPlace {
+    final remotePlaces = ref.read(plantRegistrationPlaceProvider).value;
+    final places = _registrationPlacesFromSummaries(remotePlaces ?? const []);
+    final effectivePlaces = places.isEmpty ? _places : places;
     final selectedPlaceId = _selectedPlaceId;
 
     if (selectedPlaceId == null) {
       return null;
     }
 
-    for (final place in _places) {
+    for (final place in effectivePlaces) {
       if (place.id == selectedPlaceId) {
         return place;
       }
     }
 
-    return null;
+    return effectivePlaces.isEmpty ? null : effectivePlaces.first;
+  }
+
+  String? _effectiveSelectedPlaceId(List<_PlantRegistrationPlace> places) {
+    final selectedPlaceId = _selectedPlaceId;
+
+    if (selectedPlaceId != null) {
+      for (final place in places) {
+        if (place.id == selectedPlaceId) {
+          return selectedPlaceId;
+        }
+      }
+    }
+
+    return places.isEmpty ? null : places.first.id;
   }
 
   void _cancelCreate() {
@@ -135,26 +169,111 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     context.go(AppRoutePaths.home);
   }
 
-  void _submitCreate() {
+  Future<void> _submitCreate() async {
     final selectedPlace = _selectedPlace;
 
     if (selectedPlace == null) {
       return;
     }
 
+    if (ref.read(useRemoteApiProvider)) {
+      final placeId = int.tryParse(selectedPlace.id);
+
+      if (placeId == null) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('장소 ID 형식을 확인해 주세요.')));
+        return;
+      }
+
+      try {
+        await ref
+            .read(plantRepositoryProvider)
+            .createPlant(
+              CreatePlantRequest(
+                placeId: placeId,
+                nickname: _selectedPlantName,
+                scientificNameKo: _selectedPlantName,
+              ),
+            );
+        ref.invalidate(remotePlantListProvider);
+      } catch (error) {
+        if (!mounted) {
+          return;
+        }
+
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('식물 등록에 실패했어요: $error')));
+        return;
+      }
+    }
+
+    if (!mounted) {
+      return;
+    }
+
     ref
         .read(plantListProvider.notifier)
-        .addPlant(name: _selectedPlantName, placeName: selectedPlace.name);
+        .addPlant(
+          name: _selectedPlantName,
+          placeId: selectedPlace.id,
+          placeName: selectedPlace.name,
+        );
     context.go(AppRoutePaths.home);
   }
 
-  void _submitEdit() {
+  Future<void> _submitEdit() async {
     final name = _nameController.text.trim();
+
+    if (ref.read(useRemoteApiProvider) && widget.placeId != null) {
+      try {
+        await ref
+            .read(plantRepositoryProvider)
+            .updatePlant(
+              plantId: widget.plantId!,
+              placeId: widget.placeId!,
+              request: UpdatePlantRequest(nickname: name),
+            );
+        ref.invalidate(remotePlantListProvider);
+      } catch (error) {
+        if (!mounted) {
+          return;
+        }
+
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('식물 수정에 실패했어요: $error')));
+        return;
+      }
+    }
+
+    if (!mounted) {
+      return;
+    }
 
     ref
         .read(plantListProvider.notifier)
         .updatePlant(id: widget.plantId!, name: name);
-    context.go(AppRoutePaths.plantDetailLocation(widget.plantId!));
+    context.go(
+      AppRoutePaths.plantDetailLocation(
+        widget.plantId!,
+        placeId: widget.placeId,
+      ),
+    );
+  }
+
+  List<_PlantRegistrationPlace> _registrationPlacesFromSummaries(
+    List<PlaceSummary> summaries,
+  ) {
+    return [
+      for (final place in summaries)
+        _PlantRegistrationPlace(
+          id: place.id,
+          name: place.name,
+          imageAsset: AppImageAssets.placeEditLivingRoom,
+        ),
+    ];
   }
 }
 

--- a/lib/features/plant/presentation/providers/plant_list_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_list_provider.dart
@@ -1,37 +1,43 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+export 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
 
 final plantListProvider =
     NotifierProvider<PlantListNotifier, List<PlantSummary>>(
       PlantListNotifier.new,
     );
 
-class PlantSummary {
-  const PlantSummary({
-    required this.id,
-    required this.name,
-    this.placeName,
-    this.description,
-  });
+final remotePlantListProvider = FutureProvider<List<PlantSummary>>((ref) {
+  return ref.watch(plantRepositoryProvider).fetchPlants();
+});
 
-  final String id;
-  final String name;
-  final String? placeName;
-  final String? description;
-
-  PlantSummary copyWith({
-    String? id,
-    String? name,
-    String? placeName,
-    String? description,
-  }) {
-    return PlantSummary(
-      id: id ?? this.id,
-      name: name ?? this.name,
-      placeName: placeName ?? this.placeName,
-      description: description ?? this.description,
-    );
+final plantSummariesProvider = Provider<AsyncValue<List<PlantSummary>>>((ref) {
+  if (ref.watch(useRemoteApiProvider)) {
+    return ref.watch(remotePlantListProvider);
   }
-}
+
+  return AsyncData(ref.watch(plantListProvider));
+});
+
+typedef PlantPlaceParams = ({String plantId, String placeId});
+
+final remotePlantDetailProvider =
+    FutureProvider.family<PlantDetail, PlantPlaceParams>((ref, params) {
+      return ref
+          .watch(plantRepositoryProvider)
+          .fetchPlant(plantId: params.plantId, placeId: params.placeId);
+    });
+
+final remotePlantEditInfoProvider =
+    FutureProvider.family<PlantEditInfo, PlantPlaceParams>((ref, params) {
+      return ref
+          .watch(plantRepositoryProvider)
+          .fetchPlantEditInfo(plantId: params.plantId, placeId: params.placeId);
+    });
 
 class PlantListNotifier extends Notifier<List<PlantSummary>> {
   int _nextId = 1;
@@ -43,12 +49,14 @@ class PlantListNotifier extends Notifier<List<PlantSummary>> {
 
   PlantSummary addPlant({
     required String name,
+    String? placeId,
     String? placeName,
     String? description,
   }) {
     final plant = PlantSummary(
       id: 'plant-${_nextId++}',
       name: name,
+      placeId: placeId,
       placeName: placeName,
       description: description,
     );
@@ -59,6 +67,7 @@ class PlantListNotifier extends Notifier<List<PlantSummary>> {
   void updatePlant({
     required String id,
     required String name,
+    String? placeId,
     String? placeName,
     String? description,
   }) {
@@ -67,6 +76,7 @@ class PlantListNotifier extends Notifier<List<PlantSummary>> {
         if (plant.id == id)
           plant.copyWith(
             name: name,
+            placeId: placeId,
             placeName: placeName,
             description: description,
           )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -113,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -142,6 +166,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.2.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -216,6 +288,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   js:
     dependency: transitive
     description:
@@ -328,6 +416,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -336,6 +472,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -573,6 +725,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -591,4 +759,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.35.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   go_router: ^17.2.0
   flutter_riverpod: ^3.3.1
   flutter_svg: ^2.2.0
+  dio: ^5.9.2
+  flutter_secure_storage: ^10.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 관련 이슈
Closes #45

## 구현 범위
- Dio 기반 공통 API client, bearer auth interceptor, secure token store 추가
- Auth / Place / Plant remote datasource, request DTO, repository 추가
- Home, Place, Plant 화면 provider를 API 모드에서 remote repository와 연결
- 장소/식물 생성 및 식물 수정 액션에 remote repository 호출 경로 추가
- Plant 상세/수정 route에 placeId query 전달 지원
- API 실행 dart-define 문서화

## 주요 변경사항
- `COMMONPLANT_USE_API=true`일 때 실제 API 호출 활성화
- 기본 개발/테스트에서는 기존 local state 유지
- Swagger 응답 schema가 없는 항목은 필수 필드가 없으면 공통 API 오류로 처리
- `dio`, `flutter_secure_storage` 의존성 추가

## 테스트 여부
- `fvm dart format --output=none --set-exit-if-changed .` 통과
- `fvm flutter analyze` 통과
- `fvm flutter test` 통과
- `git diff --check` 통과

## 리뷰 포인트
- API 모드를 dart-define으로 켜는 방식이 현재 인증/응답 명세 공백 상황에 적절한지
- Swagger 응답 schema 확정 후 mapper 보강이 필요한 필드
- iOS secure storage 의존성 추가로 생성된 Podfile/xconfig 변경

## 문서 반영 여부
- `docs/feature-development-guide.md`에 API 모드 실행 방법 추가

## Breaking change 여부
- 없음