### PR TITLE
Feat: 폼 UX 보강 #48

### DIFF
--- a/lib/features/login/presentation/pages/profile_setup_page.dart
+++ b/lib/features/login/presentation/pages/profile_setup_page.dart
@@ -292,17 +292,25 @@ class _ProfileNicknameField extends StatelessWidget {
     return nickname.length >= 2 && nickname.length <= 10;
   }
 
+  bool get _hasNicknameError {
+    final nickname = controller.text.trim();
+    return nickname.isNotEmpty && !_hasValidNickname;
+  }
+
   @override
   Widget build(BuildContext context) {
     final hasText = controller.text.isNotEmpty;
     final hasValidNickname = _hasValidNickname;
-    final lineColor = hasValidNickname
+    final hasNicknameError = _hasNicknameError;
+    final lineColor = hasNicknameError
+        ? AppColors.danger
+        : hasValidNickname
         ? AppColors.brandStrong
         : AppColors.textDisabled;
 
     return SizedBox(
       key: const ValueKey('profileNicknameField'),
-      height: hasValidNickname
+      height: hasValidNickname || hasNicknameError
           ? _nicknameFieldHeightWithHelper
           : _nicknameFieldHeight,
       child: Stack(
@@ -368,6 +376,17 @@ class _ProfileNicknameField extends StatelessWidget {
                 '사용 가능한 닉네임입니다',
                 style: AppTextStyles.size12Medium.copyWith(
                   color: AppColors.brandStrong,
+                ),
+              ),
+            ),
+          if (hasNicknameError)
+            Positioned(
+              left: 0,
+              top: 64,
+              child: Text(
+                '2~10자의 닉네임으로 입력해 주세요',
+                style: AppTextStyles.size12Medium.copyWith(
+                  color: AppColors.danger,
                 ),
               ),
             ),

--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -35,6 +35,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   late final String _initialName;
   late final String? _initialAddress;
   String? _address;
+  bool _isSubmitting = false;
 
   @override
   void initState() {
@@ -58,13 +59,14 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
         !widget.isEdit ||
         currentName != _initialName ||
         _address != _initialAddress;
-    final canSubmit = currentName.isNotEmpty && hasChanges;
+    final canSubmit = currentName.isNotEmpty && hasChanges && !_isSubmitting;
 
     if (!widget.isEdit) {
       return _PlaceCreateScaffold(
         nameController: _nameController,
         address: _address,
         canSubmit: canSubmit,
+        isSubmitting: _isSubmitting,
         onNameChanged: (_) => setState(() {}),
         onImageTap: () {},
         onAddressTap: () => context.push(AppRoutePaths.addressSearch),
@@ -77,6 +79,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       nameController: _nameController,
       address: _address,
       canSubmit: canSubmit,
+      isSubmitting: _isSubmitting,
       onNameChanged: (_) => setState(() {}),
       onImageTap: () {},
       onAddressTap: () => context.push(AppRoutePaths.addressSearch),
@@ -86,37 +89,51 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   }
 
   Future<void> _submit() async {
+    if (_isSubmitting) {
+      return;
+    }
+
     final name = _nameController.text.trim();
     final notifier = ref.read(placeListProvider.notifier);
 
-    if (widget.placeId case final placeId?) {
-      notifier.updatePlace(id: placeId, name: name, address: _address);
-      context.go(AppRoutePaths.home);
-    } else {
-      if (ref.read(useRemoteApiProvider)) {
-        try {
-          await ref
-              .read(placeRepositoryProvider)
-              .createPlace(CreatePlaceRequest(name: name, address: _address));
-          ref.invalidate(remotePlaceListProvider);
-        } catch (error) {
-          if (!mounted) {
+    setState(() => _isSubmitting = true);
+
+    try {
+      if (widget.placeId case final placeId?) {
+        notifier.updatePlace(id: placeId, name: name, address: _address);
+        if (mounted) {
+          context.go(AppRoutePaths.home);
+        }
+      } else {
+        if (ref.read(useRemoteApiProvider)) {
+          try {
+            await ref
+                .read(placeRepositoryProvider)
+                .createPlace(CreatePlaceRequest(name: name, address: _address));
+            ref.invalidate(remotePlaceListProvider);
+          } catch (error) {
+            if (!mounted) {
+              return;
+            }
+
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(SnackBar(content: Text('장소 생성에 실패했어요: $error')));
             return;
           }
+        }
 
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('장소 생성에 실패했어요: $error')));
+        if (!mounted) {
           return;
         }
-      }
 
-      if (!mounted) {
-        return;
+        notifier.addPlace(name: name, address: _address);
+        context.push(AppRoutePaths.placeFriendAdd);
       }
-
-      notifier.addPlace(name: name, address: _address);
-      context.push(AppRoutePaths.placeFriendAdd);
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
     }
   }
 }
@@ -126,6 +143,7 @@ class _PlaceEditScaffold extends StatelessWidget {
     required this.nameController,
     required this.address,
     required this.canSubmit,
+    required this.isSubmitting,
     required this.onNameChanged,
     required this.onImageTap,
     required this.onAddressTap,
@@ -136,6 +154,7 @@ class _PlaceEditScaffold extends StatelessWidget {
   final TextEditingController nameController;
   final String? address;
   final bool canSubmit;
+  final bool isSubmitting;
   final ValueChanged<String> onNameChanged;
   final VoidCallback onImageTap;
   final VoidCallback onAddressTap;
@@ -203,6 +222,7 @@ class _PlaceEditScaffold extends StatelessWidget {
                       bottom: AppSpacing.x16,
                       child: CommonButton(
                         label: '완료',
+                        isLoading: isSubmitting,
                         onPressed: canSubmit ? onComplete : null,
                       ),
                     ),
@@ -222,6 +242,7 @@ class _PlaceCreateScaffold extends StatelessWidget {
     required this.nameController,
     required this.address,
     required this.canSubmit,
+    required this.isSubmitting,
     required this.onNameChanged,
     required this.onImageTap,
     required this.onAddressTap,
@@ -232,6 +253,7 @@ class _PlaceCreateScaffold extends StatelessWidget {
   final TextEditingController nameController;
   final String? address;
   final bool canSubmit;
+  final bool isSubmitting;
   final ValueChanged<String> onNameChanged;
   final VoidCallback onImageTap;
   final VoidCallback onAddressTap;
@@ -294,6 +316,7 @@ class _PlaceCreateScaffold extends StatelessWidget {
                       bottom: AppSpacing.x16,
                       child: CommonButton(
                         label: '다음',
+                        isLoading: isSubmitting,
                         onPressed: canSubmit ? onNext : null,
                       ),
                     ),

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -45,6 +45,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   late final TextEditingController _nameController;
   late final String _selectedPlantName;
   String? _selectedPlaceId;
+  bool _isSubmitting = false;
 
   static const List<_PlantRegistrationPlace> _places = [
     _PlantRegistrationPlace(
@@ -90,11 +91,14 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     if (widget.isEdit) {
       final trimmedName = _nameController.text.trim();
       final canSubmit =
-          trimmedName.isNotEmpty && trimmedName != _defaultEditPlantName;
+          trimmedName.isNotEmpty &&
+          trimmedName != _defaultEditPlantName &&
+          !_isSubmitting;
 
       return _PlantEditScaffold(
         nameController: _nameController,
         canSubmit: canSubmit,
+        isSubmitting: _isSubmitting,
         onChanged: (_) => setState(() {}),
         onSubmit: () => _submitEdit(),
       );
@@ -111,6 +115,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       places: places,
       selectedPlaceId: selectedPlaceId,
       wateringDate: '2023. 01. 30',
+      isSubmitting: _isSubmitting,
       onPlaceSelected: (place) => setState(() => _selectedPlaceId = place.id),
       onCancel: _cancelCreate,
       onSubmit: () => _submitCreate(),
@@ -170,97 +175,121 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Future<void> _submitCreate() async {
+    if (_isSubmitting) {
+      return;
+    }
+
     final selectedPlace = _selectedPlace;
 
     if (selectedPlace == null) {
       return;
     }
 
-    if (ref.read(useRemoteApiProvider)) {
-      final placeId = int.tryParse(selectedPlace.id);
+    setState(() => _isSubmitting = true);
 
-      if (placeId == null) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('장소 ID 형식을 확인해 주세요.')));
-        return;
-      }
+    try {
+      if (ref.read(useRemoteApiProvider)) {
+        final placeId = int.tryParse(selectedPlace.id);
 
-      try {
-        await ref
-            .read(plantRepositoryProvider)
-            .createPlant(
-              CreatePlantRequest(
-                placeId: placeId,
-                nickname: _selectedPlantName,
-                scientificNameKo: _selectedPlantName,
-              ),
-            );
-        ref.invalidate(remotePlantListProvider);
-      } catch (error) {
-        if (!mounted) {
+        if (placeId == null) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('장소 ID 형식을 확인해 주세요.')));
           return;
         }
 
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('식물 등록에 실패했어요: $error')));
+        try {
+          await ref
+              .read(plantRepositoryProvider)
+              .createPlant(
+                CreatePlantRequest(
+                  placeId: placeId,
+                  nickname: _selectedPlantName,
+                  scientificNameKo: _selectedPlantName,
+                ),
+              );
+          ref.invalidate(remotePlantListProvider);
+        } catch (error) {
+          if (!mounted) {
+            return;
+          }
+
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('식물 등록에 실패했어요: $error')));
+          return;
+        }
+      }
+
+      if (!mounted) {
         return;
       }
-    }
 
-    if (!mounted) {
-      return;
+      ref
+          .read(plantListProvider.notifier)
+          .addPlant(
+            name: _selectedPlantName,
+            placeId: selectedPlace.id,
+            placeName: selectedPlace.name,
+          );
+      context.go(AppRoutePaths.home);
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
     }
-
-    ref
-        .read(plantListProvider.notifier)
-        .addPlant(
-          name: _selectedPlantName,
-          placeId: selectedPlace.id,
-          placeName: selectedPlace.name,
-        );
-    context.go(AppRoutePaths.home);
   }
 
   Future<void> _submitEdit() async {
-    final name = _nameController.text.trim();
-
-    if (ref.read(useRemoteApiProvider) && widget.placeId != null) {
-      try {
-        await ref
-            .read(plantRepositoryProvider)
-            .updatePlant(
-              plantId: widget.plantId!,
-              placeId: widget.placeId!,
-              request: UpdatePlantRequest(nickname: name),
-            );
-        ref.invalidate(remotePlantListProvider);
-      } catch (error) {
-        if (!mounted) {
-          return;
-        }
-
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('식물 수정에 실패했어요: $error')));
-        return;
-      }
-    }
-
-    if (!mounted) {
+    if (_isSubmitting) {
       return;
     }
 
-    ref
-        .read(plantListProvider.notifier)
-        .updatePlant(id: widget.plantId!, name: name);
-    context.go(
-      AppRoutePaths.plantDetailLocation(
-        widget.plantId!,
-        placeId: widget.placeId,
-      ),
-    );
+    final name = _nameController.text.trim();
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      if (ref.read(useRemoteApiProvider) && widget.placeId != null) {
+        try {
+          await ref
+              .read(plantRepositoryProvider)
+              .updatePlant(
+                plantId: widget.plantId!,
+                placeId: widget.placeId!,
+                request: UpdatePlantRequest(nickname: name),
+              );
+          ref.invalidate(remotePlantListProvider);
+        } catch (error) {
+          if (!mounted) {
+            return;
+          }
+
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('식물 수정에 실패했어요: $error')));
+          return;
+        }
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      ref
+          .read(plantListProvider.notifier)
+          .updatePlant(id: widget.plantId!, name: name);
+      context.go(
+        AppRoutePaths.plantDetailLocation(
+          widget.plantId!,
+          placeId: widget.placeId,
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
   }
 
   List<_PlantRegistrationPlace> _registrationPlacesFromSummaries(
@@ -281,12 +310,14 @@ class _PlantEditScaffold extends StatelessWidget {
   const _PlantEditScaffold({
     required this.nameController,
     required this.canSubmit,
+    required this.isSubmitting,
     required this.onChanged,
     required this.onSubmit,
   });
 
   final TextEditingController nameController;
   final bool canSubmit;
+  final bool isSubmitting;
   final ValueChanged<String> onChanged;
   final VoidCallback onSubmit;
 
@@ -338,6 +369,7 @@ class _PlantEditScaffold extends StatelessWidget {
                 ),
                 child: CommonButton(
                   label: '완료',
+                  isLoading: isSubmitting,
                   onPressed: canSubmit ? onSubmit : null,
                 ),
               ),
@@ -409,6 +441,7 @@ class _PlantCreateScaffold extends StatelessWidget {
     required this.places,
     required this.selectedPlaceId,
     required this.wateringDate,
+    required this.isSubmitting,
     required this.onPlaceSelected,
     required this.onCancel,
     required this.onSubmit,
@@ -417,6 +450,7 @@ class _PlantCreateScaffold extends StatelessWidget {
   final List<_PlantRegistrationPlace> places;
   final String? selectedPlaceId;
   final String wateringDate;
+  final bool isSubmitting;
   final ValueChanged<_PlantRegistrationPlace> onPlaceSelected;
   final VoidCallback onCancel;
   final VoidCallback onSubmit;
@@ -460,7 +494,11 @@ class _PlantCreateScaffold extends StatelessWidget {
                   ),
                 ),
               ),
-              _PlantFormBottomActions(onCancel: onCancel, onSubmit: onSubmit),
+              _PlantFormBottomActions(
+                isSubmitting: isSubmitting,
+                onCancel: onCancel,
+                onSubmit: onSubmit,
+              ),
             ],
           ),
         ),
@@ -585,10 +623,12 @@ class _PlantWateringDateField extends StatelessWidget {
 
 class _PlantFormBottomActions extends StatelessWidget {
   const _PlantFormBottomActions({
+    required this.isSubmitting,
     required this.onCancel,
     required this.onSubmit,
   });
 
+  final bool isSubmitting;
   final VoidCallback onCancel;
   final VoidCallback onSubmit;
 
@@ -619,6 +659,7 @@ class _PlantFormBottomActions extends StatelessWidget {
               size: CommonButtonSize.medium,
               backgroundColor: AppColors.brandAccent,
               foregroundColor: AppColors.white,
+              isLoading: isSubmitting,
               onPressed: onSubmit,
             ),
           ),

--- a/lib/shared/widgets/common_button.dart
+++ b/lib/shared/widgets/common_button.dart
@@ -23,6 +23,7 @@ class CommonButton extends StatelessWidget {
     this.borderColor,
     this.leading,
     this.trailing,
+    this.isLoading = false,
   });
 
   const CommonButton.secondary({
@@ -37,6 +38,7 @@ class CommonButton extends StatelessWidget {
     this.borderColor,
     this.leading,
     this.trailing,
+    this.isLoading = false,
   }) : variant = CommonButtonVariant.secondary;
 
   const CommonButton.neutral({
@@ -51,6 +53,7 @@ class CommonButton extends StatelessWidget {
     this.borderColor,
     this.leading,
     this.trailing,
+    this.isLoading = false,
   }) : variant = CommonButtonVariant.neutral;
 
   const CommonButton.dark({
@@ -65,6 +68,7 @@ class CommonButton extends StatelessWidget {
     this.borderColor,
     this.leading,
     this.trailing,
+    this.isLoading = false,
   }) : variant = CommonButtonVariant.dark;
 
   const CommonButton.text({
@@ -79,6 +83,7 @@ class CommonButton extends StatelessWidget {
     this.borderColor,
     this.leading,
     this.trailing,
+    this.isLoading = false,
   }) : variant = CommonButtonVariant.text;
 
   final String label;
@@ -92,6 +97,9 @@ class CommonButton extends StatelessWidget {
   final Color? borderColor;
   final Widget? leading;
   final Widget? trailing;
+  final bool isLoading;
+
+  VoidCallback? get _effectiveOnPressed => isLoading ? null : onPressed;
 
   double get _height {
     switch (size) {
@@ -129,6 +137,18 @@ class CommonButton extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
+        if (isLoading) ...[
+          SizedBox.square(
+            dimension: AppSizes.iconSmall,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                textStyle.color ?? AppThemeTokens.light.textDisabled,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.x8),
+        ],
         if (leading != null) ...[
           leading!,
           const SizedBox(width: AppSpacing.x8),
@@ -160,18 +180,22 @@ class CommonButton extends StatelessWidget {
         foregroundColor ??
         switch (variant) {
           CommonButtonVariant.primary || CommonButtonVariant.dark =>
-            onPressed == null ? tokens.textDisabled : tokens.onBrand,
+            _effectiveOnPressed == null ? tokens.textDisabled : tokens.onBrand,
           CommonButtonVariant.secondary || CommonButtonVariant.text =>
-            onPressed == null ? tokens.textDisabled : tokens.brandAccent,
+            _effectiveOnPressed == null
+                ? tokens.textDisabled
+                : tokens.brandAccent,
           CommonButtonVariant.neutral =>
-            onPressed == null ? tokens.textDisabled : tokens.textStrong,
+            _effectiveOnPressed == null
+                ? tokens.textDisabled
+                : tokens.textStrong,
         };
 
     return baseStyle.copyWith(color: effectiveForegroundColor);
   }
 
   Color _backgroundColor(AppThemeTokens tokens) {
-    if (onPressed == null) {
+    if (_effectiveOnPressed == null) {
       return backgroundColor ?? tokens.surfaceDisabled;
     }
 
@@ -222,7 +246,7 @@ class CommonButton extends StatelessWidget {
       case CommonButtonVariant.primary:
         return _wrapWidth(
           FilledButton(
-            onPressed: onPressed,
+            onPressed: _effectiveOnPressed,
             style: FilledButton.styleFrom(
               backgroundColor: _backgroundColor(tokens),
               foregroundColor: textStyle.color,
@@ -239,7 +263,7 @@ class CommonButton extends StatelessWidget {
       case CommonButtonVariant.secondary:
         return _wrapWidth(
           OutlinedButton(
-            onPressed: onPressed,
+            onPressed: _effectiveOnPressed,
             style: OutlinedButton.styleFrom(
               backgroundColor: _backgroundColor(tokens),
               foregroundColor: textStyle.color,
@@ -257,7 +281,7 @@ class CommonButton extends StatelessWidget {
       case CommonButtonVariant.dark:
         return _wrapWidth(
           FilledButton(
-            onPressed: onPressed,
+            onPressed: _effectiveOnPressed,
             style: FilledButton.styleFrom(
               backgroundColor: _backgroundColor(tokens),
               foregroundColor: textStyle.color,
@@ -275,7 +299,7 @@ class CommonButton extends StatelessWidget {
       case CommonButtonVariant.neutral:
         return _wrapWidth(
           FilledButton(
-            onPressed: onPressed,
+            onPressed: _effectiveOnPressed,
             style: FilledButton.styleFrom(
               backgroundColor: _backgroundColor(tokens),
               foregroundColor: textStyle.color,
@@ -293,7 +317,7 @@ class CommonButton extends StatelessWidget {
       case CommonButtonVariant.text:
         return _wrapWidth(
           TextButton(
-            onPressed: onPressed,
+            onPressed: _effectiveOnPressed,
             style: TextButton.styleFrom(
               backgroundColor: _backgroundColor(tokens),
               foregroundColor: textStyle.color,

--- a/test/features/login/presentation/pages/profile_setup_page_test.dart
+++ b/test/features/login/presentation/pages/profile_setup_page_test.dart
@@ -71,6 +71,26 @@ void main() {
     );
   });
 
+  testWidgets('프로필 설정 화면은 짧은 닉네임에 오류 메시지를 표시한다', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(375, 812);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(_profileSetupApp());
+
+    await tester.enterText(find.byType(TextField), '커');
+    await tester.pump();
+
+    expect(find.text('2~10자의 닉네임으로 입력해 주세요'), findsOneWidget);
+
+    final completeButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '완료'),
+    );
+
+    expect(completeButton.onPressed, isNull);
+  });
+
   testWidgets('프로필 설정 화면은 낮은 높이에서 주요 요소를 세로 축소 배치한다', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(320, 640);

--- a/test/features/place/presentation/pages/place_form_page_test.dart
+++ b/test/features/place/presentation/pages/place_form_page_test.dart
@@ -1,4 +1,11 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_form_page.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -44,4 +51,46 @@ void main() {
     expect(completeButton.onPressed, isNotNull);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('장소 등록 화면은 원격 제출 중 다음 버튼을 잠근다', (tester) async {
+    final repository = _PendingPlaceRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(home: PlaceFormPage()),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), '거실');
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, '다음'));
+    await tester.pump();
+
+    expect(repository.createCalls, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    final nextButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '다음'),
+    );
+
+    expect(nextButton.onPressed, isNull);
+  });
+}
+
+class _PendingPlaceRepository extends PlaceRepository {
+  _PendingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  final Completer<void> _completer = Completer<void>();
+  int createCalls = 0;
+
+  @override
+  Future<void> createPlace(CreatePlaceRequest request) {
+    createCalls++;
+    return _completer.future;
+  }
 }

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -1,4 +1,11 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,4 +44,52 @@ void main() {
     );
     expect(completeButton.onPressed, isNull);
   });
+
+  testWidgets('식물 수정 화면은 원격 제출 중 완료 버튼을 잠근다', (tester) async {
+    final repository = _PendingPlantRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(
+          home: PlantFormPage(plantId: 'plant-1', placeId: 'place-1'),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), '몬테라');
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, '완료'));
+    await tester.pump();
+
+    expect(repository.updateCalls, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    final completeButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '완료'),
+    );
+
+    expect(completeButton.onPressed, isNull);
+  });
+}
+
+class _PendingPlantRepository extends PlantRepository {
+  _PendingPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  final Completer<void> _completer = Completer<void>();
+  int updateCalls = 0;
+
+  @override
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeId,
+    required UpdatePlantRequest request,
+  }) {
+    updateCalls++;
+    return _completer.future;
+  }
 }

--- a/test/shared/widgets/common_button_test.dart
+++ b/test/shared/widgets/common_button_test.dart
@@ -1,0 +1,34 @@
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CommonButton은 로딩 중 탭을 막고 진행 상태를 표시한다', (tester) async {
+    var tapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CommonButton(
+            label: '저장',
+            isLoading: true,
+            onPressed: () => tapCount++,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('저장'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, '저장'));
+    await tester.pump();
+
+    final button = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '저장'),
+    );
+
+    expect(button.onPressed, isNull);
+    expect(tapCount, 0);
+  });
+}


### PR DESCRIPTION
## 관련 이슈
Closes #48

## 구현 범위
- 공통 버튼에 로딩 상태를 추가해 제출 중 중복 탭을 방지했습니다.
- 프로필 설정 닉네임 입력에 로컬 오류 메시지를 추가했습니다.
- 장소/식물 폼의 원격 제출 중 CTA 비활성화와 진행 상태 표시를 연결했습니다.
- 관련 widget test를 추가/갱신했습니다.

## 주요 변경사항
- `CommonButton.isLoading` 추가
- 제출 중 버튼 `onPressed` 차단 및 `CircularProgressIndicator` 표시
- 짧은 닉네임 입력 시 `2~10자의 닉네임으로 입력해 주세요` 표시
- 장소 등록, 식물 등록/수정 제출 중 상태 관리

## 테스트 여부
- `fvm dart format --output=none --set-exit-if-changed .` 통과
- `fvm flutter analyze` 통과
- `fvm flutter test` 통과
- `git diff --check` 통과

## 리뷰 포인트
- 공통 버튼 로딩 UI가 현재 디자인 톤과 맞는지
- 폼 제출 중 버튼 잠금 범위가 충분한지

## 문서 반영 여부
- 기존 `docs/form-validation-error-guide.md`, `docs/state-management-guide.md` 기준 내에서 구현되어 별도 문서 변경 없음

## Breaking change 여부
- 없음
