### PR TITLE
Docs: 남은 작업 순서 정리 #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,17 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 - `flutter analyze`
 - `flutter test`
 
-## Phase 0 이후 필요 작업
+## 진행해야 할 작업 내역
 
-- [ ] 홈 화면 Figma 기본/요청/로그인 필요 상태의 node-id를 `docs/figma-frame-map.md`에 확정 반영합니다.
-- [ ] 메모 목록 기본/메뉴/삭제 alert 상태의 Figma node-id를 확정합니다.
-- [ ] API 연동을 위해 `dio`, `freezed`, `json_serializable` 기반 모델/클라이언트 구조를 도입합니다.
-- [ ] 인증 토큰 저장은 `flutter_secure_storage` 기준으로 구현하고 인증 redirect 정책을 확정합니다.
-- [ ] 백엔드 에러 코드와 사용자 메시지 매핑표를 확정합니다.
-- [ ] mock 데이터 화면을 실제 repository/provider 흐름으로 전환합니다.
-- [ ] Golden test 및 integration test 도입 범위와 실행 환경을 확정합니다.
-- [ ] Android/iOS 스토어 계정, signing secret, 배포 대상과 release 자동화 값을 확정합니다.
+남은 작업은 한 번에 묶지 않고 `이슈 생성 -> Project 10 등록 -> develop 기반 브랜치 생성 -> 작업 -> 검증 -> 커밋/푸시 -> PR 생성` 순서로 하나씩 진행합니다.
+세부 순서와 이슈/브랜치 단위는 [남은 작업 진행 계획](docs/remaining-work-plan.md)을 기준으로 관리합니다.
+
+우선순위:
+
+1. [ ] Figma frame map의 `확인 필요` node-id를 최신화합니다.
+2. [ ] 프로필 설정, 식물 검색, 메모 화면처럼 백엔드와 무관한 프론트 UX를 보강합니다.
+3. [ ] 장소/식물 상세 화면의 mock fallback과 loading/empty/error 상태를 정리합니다.
+4. [ ] 공통 form submit/loading/error 패턴을 재사용 가능한 형태로 정리합니다.
+5. [ ] User, Place, Plant, Image API 계층을 화면 Provider/Controller에 단계적으로 연결합니다.
+6. [ ] 백엔드 확인 필요 항목을 별도 이슈로 분리하고 Swagger 문서를 갱신합니다.
+7. [ ] Golden test, integration test, release/signing 정책처럼 아직 결정되지 않은 품질/배포 항목을 확정합니다.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -179,6 +179,25 @@ Docs: 프로젝트 작업 가이드 추가
 
 ## GitHub Project 연결
 
+## GitHub 본문 작성 기준
+
+`gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`처럼 Markdown 본문을 남기는 명령은 실제 줄바꿈이 보존되도록 `--body-file -` 또는 heredoc 기반 입력을 사용합니다.
+쉘 문자열 안에 `\n`을 넣으면 GitHub 화면에 줄바꿈이 아니라 문자 `\n`이 그대로 보일 수 있으므로 사용하지 않습니다.
+
+권장 예시:
+
+```bash
+gh pr create --body-file - <<'EOF'
+## 관련 이슈
+- Closes #50
+
+## 테스트
+- git diff --check
+EOF
+```
+
+코멘트도 여러 줄이면 같은 방식을 사용합니다.
+
 일반 작업 PR을 생성한 뒤에는 CommonPlant GitHub Project 10에 PR을 함께 연결합니다.
 
 - Project URL: https://github.com/orgs/UMC-CommonPlant/projects/10/views/1

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -182,7 +182,7 @@ Docs: 프로젝트 작업 가이드 추가
 ## GitHub 본문 작성 기준
 
 `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`처럼 Markdown 본문을 남기는 명령은 실제 줄바꿈이 보존되도록 `--body-file -` 또는 heredoc 기반 입력을 사용합니다.
-쉘 문자열 안에 `\n`을 넣으면 GitHub 화면에 줄바꿈이 아니라 문자 `\n`이 그대로 보일 수 있으므로 사용하지 않습니다.
+쉘 문자열 안에 백슬래시+n 조합을 넣으면 GitHub 화면에 줄바꿈이 아니라 문자 그대로 보일 수 있으므로 사용하지 않습니다.
 
 권장 예시:
 

--- a/docs/remaining-work-plan.md
+++ b/docs/remaining-work-plan.md
@@ -1,0 +1,56 @@
+# 남은 작업 진행 계획
+
+이 문서는 #47 API 연계 보강과 #49 폼 UX 보강이 `develop`에 병합된 뒤 남은 작업을 하나씩 진행하기 위한 실행 순서 문서이다.
+각 항목은 별도 GitHub 이슈, Project 10 항목, 브랜치, PR로 분리한다.
+
+## 진행 규칙
+
+- 작업 전 `README.md`의 프로젝트 문서 섹션과 작업 유형별 필수 문서를 확인한다.
+- 모든 작업 브랜치는 최신 `develop`에서 생성한다.
+- 한 브랜치는 아래 표의 한 행만 다룬다.
+- 이슈 제목은 `[Task]`, `[Feature]`, `[Bug]` 중 하나로 시작한다.
+- 신규 이슈와 PR은 `ywkim95`, `allmanLee`를 assignee로 지정한다.
+- 신규 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정한다.
+- Project 10 status는 작업 시작 시 `In Progress`, PR 생성 후 `In Review`, 병합 후 `Done`으로 맞춘다.
+- 문서만 바꾸면 `git diff --check`를 실행한다.
+- Flutter 코드가 바뀌면 `fvm dart format --output=none --set-exit-if-changed .`, `fvm flutter analyze`, `fvm flutter test`, `git diff --check`를 실행한다.
+
+## 작업 순서
+
+| 순서 | 이슈 제목 | 권장 브랜치 | Project category | 범위 | 완료 기준 |
+| --- | --- | --- | --- | --- | --- |
+| 0 | `[Task] 남은 작업 순서 문서화` | `docs/remaining-work-order-50` | Story | README의 진행 작업 항목과 이 문서 추가 | 문서가 병합되고 이후 작업 순서가 확인 가능 |
+| 1 | `[Task] Figma 프레임 매핑 최신화` | `docs/figma-frame-node-map` | Story | `docs/figma-frame-map.md`의 Home, Memo `확인 필요` node-id 정리 | Home/Memo node-id 또는 확인 불가 사유가 문서에 반영 |
+| 2 | `[Task] 프로필 설정 이미지 UX 보강` | `feature/profile-image-ux` | User | 프로필 설정 화면의 이미지 선택/삭제/상태 표시를 화면 내부 로컬 UX로 보강 | 이미지 선택 전/후/삭제 상태 widget test 통과 |
+| 3 | `[Task] 식물 검색 로컬 UX 보강` | `feature/plant-search-local-ux` | Plant | 식물 검색 화면의 정적 후보, 빈 결과, 선택 흐름을 정리 | 검색어 없음/결과 있음/결과 없음/선택 이동 테스트 통과 |
+| 4 | `[Task] 메모 화면 로컬 UX 보강` | `feature/memo-local-ux` | Memo | 메모 목록/작성 화면의 로컬 작성, 삭제, empty 상태를 정리 | 작성 후 목록 복귀, 삭제 후 empty 상태 테스트 통과 |
+| 5 | `[Task] 장소 상세 상태 UI 정리` | `feature/place-detail-state-ui` | Place | 장소 상세 화면의 mock fallback, remote loading, empty, error 표시 정리 | API mode별 상태 UI 테스트 통과 |
+| 6 | `[Task] 식물 상세 상태 UI 정리` | `feature/plant-detail-state-ui` | Plant | 식물 상세/수정 화면의 mock fallback, remote loading, empty, error 표시 정리 | 상세/수정 정보 상태 UI 테스트 통과 |
+| 7 | `[Task] 공통 폼 제출 상태 패턴 정리` | `refactor/form-submit-state` | Story | 중복된 submit/loading/error 처리 방식을 공통 helper 또는 controller 패턴으로 정리 | 장소/식물/프로필 폼 회귀 테스트 통과 |
+| 8 | `[Feature] User API 화면 연결` | `feature/user-api-ui-binding` | User | User 조회/수정/검색 repository를 프로필 또는 친구 검색 화면에 연결 | API mode provider 테스트와 화면 상태 테스트 통과 |
+| 9 | `[Feature] Place API 화면 연결` | `feature/place-api-ui-binding` | Place | 장소 수정, 상세 조회, 삭제 흐름을 repository/provider에 연결 | Place create/update/detail/delete 관련 테스트 통과 |
+| 10 | `[Feature] Plant API 화면 연결` | `feature/plant-api-ui-binding` | Plant | 식물 상세, 수정 정보, 수정, 삭제 흐름을 repository/provider에 연결 | Plant detail/edit/update/delete 관련 테스트 통과 |
+| 11 | `[Feature] Image API 화면 연결` | `feature/image-api-ui-binding` | Story | 프로필, 장소, 식물, 메모 이미지 선택 흐름과 image repository 연결 가능 지점 정리 | 이미지 key/url 정책 확인 범위 내 테스트 통과 |
+| 12 | `[Task] 백엔드 확인 항목 이슈 분리` | `docs/backend-api-open-questions` | Story | `docs/api-swagger-reference.md`의 백엔드 확인 필요 항목을 질문 단위로 정리 | Auth/Friend/Image/Error/Token/검색/Memo 질문 목록 반영 |
+| 13 | `[Task] 테스트 전략 확정` | `docs/test-strategy-follow-up` | Story | Golden test, integration test 도입 범위와 실행 환경 결정 문서화 | 테스트 종류별 적용/보류 기준 문서화 |
+| 14 | `[Task] 릴리즈 정책 확정` | `docs/release-policy-follow-up` | Story | signing secret, store 계정, release 자동화 결정 항목 정리 | 배포 전 확인 항목과 보류 사유 문서화 |
+
+## 백엔드 확인이 필요한 항목
+
+아래 항목은 Swagger만 보고 화면 동작을 확정하지 않는다.
+
+- `POST /auth/register` request schema와 multipart JSON part 필드
+- multipart JSON part의 `Content-Type: application/json` 필요 여부
+- Place 조회/생성/수정/삭제 성공 response body schema
+- Friend 요청 목록, 요청 전송, 수락, 거절 response schema
+- `sendFriendReq.receiverName`과 `friendDecisionReq.friendId`의 실제 의미
+- Image upload/download/update/delete 성공 response의 image key/url 필드
+- 에러 response body의 `code`, `message` 필드명
+- refresh token 재발급과 로그아웃 API 제공 여부
+- 주소 검색, 식물 검색, 메모 API 제공 계획
+- 서버 full base URL과 flavor별 base URL 정책
+
+## 다음 작업 후보
+
+이 문서가 병합되면 다음 작업은 순서 1번인 `[Task] Figma 프레임 매핑 최신화`로 시작한다.
+Figma node-id 확인이 당장 어렵다면 순서 2번인 `[Task] 프로필 설정 이미지 UX 보강`을 먼저 진행한다.

--- a/docs/remaining-work-plan.md
+++ b/docs/remaining-work-plan.md
@@ -12,6 +12,7 @@
 - 신규 이슈와 PR은 `ywkim95`, `allmanLee`를 assignee로 지정한다.
 - 신규 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정한다.
 - Project 10 status는 작업 시작 시 `In Progress`, PR 생성 후 `In Review`, 병합 후 `Done`으로 맞춘다.
+- GitHub 이슈, PR, 코멘트 본문은 실제 줄바꿈 보존을 위해 `--body-file -` 또는 heredoc 입력을 사용한다.
 - 문서만 바꾸면 `git diff --check`를 실행한다.
 - Flutter 코드가 바뀌면 `fvm dart format --output=none --set-exit-if-changed .`, `fvm flutter analyze`, `fvm flutter test`, `git diff --check`를 실행한다.
 


### PR DESCRIPTION
## 관련 이슈
- Closes #50

## 구현 범위
- README의 Phase 0 이후 필요 작업 섹션을 진행해야 할 작업 내역으로 최신화했습니다.
- 남은 작업을 하나씩 이슈/브랜치/PR로 진행할 수 있도록 docs/remaining-work-plan.md를 추가했습니다.
- 각 작업의 권장 이슈 제목, 브랜치, Project category, 범위, 완료 기준을 정리했습니다.
- GitHub 이슈/PR/코멘트 본문 작성 시 백슬래시+n 조합이 노출되지 않도록 `--body-file -` 또는 heredoc 입력 규칙을 문서화했습니다.

## 테스트
- git diff --check

## 문서 반영
- README.md
- docs/remaining-work-plan.md
- docs/git-workflow.md

## Breaking change
- 없음
