### PR TITLE
Feat: 식물 검색 로컬 UX 보강 #56

### DIFF
--- a/lib/features/plant/presentation/pages/plant_search_page.dart
+++ b/lib/features/plant/presentation/pages/plant_search_page.dart
@@ -33,6 +33,7 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
 
   @override
   Widget build(BuildContext context) {
+    final hasQuery = _normalize(_searchController.text).isNotEmpty;
     final results = _matchingPlants(_searchController.text);
 
     return CommonScaffold(
@@ -65,7 +66,8 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
                   ).toString(),
                 ),
               ),
-            ],
+            ] else if (hasQuery)
+              const _PlantSearchEmptyState(),
           ],
         ),
       ),
@@ -148,6 +150,41 @@ class _PlantSearchResultTile extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _PlantSearchEmptyState extends StatelessWidget {
+  const _PlantSearchEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        AppSpacing.x40,
+        AppSpacing.x20,
+        0,
+      ),
+      child: Column(
+        children: [
+          Text(
+            '검색 결과가 없어요',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.size16Bold.copyWith(
+              color: AppColors.textHeadline,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.x8),
+          Text(
+            '다른 이름으로 다시 검색해 주세요',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.size14Medium.copyWith(
+              color: AppColors.textBody,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/features/plant/presentation/pages/plant_search_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_search_page_test.dart
@@ -1,5 +1,9 @@
+import 'package:commonplant_frontend/app/common_plant_app.dart';
+import 'package:commonplant_frontend/app/router/app_router.dart';
+import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_search_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -9,6 +13,7 @@ void main() {
     expect(find.text('식물 등록  (1/2)'), findsOneWidget);
     expect(find.text('식물을 입력해 주세요.'), findsOneWidget);
     expect(find.text('몬스테라 델리오사'), findsNothing);
+    expect(find.text('검색 결과가 없어요'), findsNothing);
   });
 
   testWidgets('식물 검색어를 입력하면 Figma 기준 결과 목록을 표시한다', (tester) async {
@@ -21,6 +26,39 @@ void main() {
     expect(find.text('몬스테라 알보 바리에가타'), findsOneWidget);
     expect(find.text('몬스테라 보르시지아나'), findsOneWidget);
     expect(find.text('무늬 몬스테라'), findsOneWidget);
+    expect(find.text('검색 결과가 없어요'), findsNothing);
+  });
+
+  testWidgets('식물 검색 결과가 없으면 빈 상태 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+
+    await tester.enterText(find.byType(TextField), '선인장');
+    await tester.pump();
+
+    expect(find.text('검색 결과가 없어요'), findsOneWidget);
+    expect(find.text('다른 이름으로 다시 검색해 주세요'), findsOneWidget);
+    expect(find.text('몬스테라 델리오사'), findsNothing);
+  });
+
+  testWidgets('식물 검색 결과를 선택하면 등록 정보 입력 화면으로 이동한다', (tester) async {
+    final router = createAppRouter(initialLocation: AppRoutePaths.plantSearch);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [appRouterProvider.overrideWithValue(router)],
+        child: const CommonPlantApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '몬스테라');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('몬스테라 델리오사'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('식물 등록 (2/2)'), findsOneWidget);
+    expect(find.text('장소 선택'), findsOneWidget);
   });
 
   testWidgets('검색어 삭제를 누르면 결과 목록을 닫는다', (tester) async {


### PR DESCRIPTION
## 관련 이슈
- Closes #56

## 작업 내용
- 식물 검색어가 있고 정적 후보가 없을 때 빈 상태 안내를 표시하도록 했습니다.
- 검색어 없음 상태에서는 기존 Figma 기본 화면처럼 결과/빈 상태를 표시하지 않도록 유지했습니다.
- 식물 검색 화면 widget test에 결과 없음 상태와 결과 선택 후 등록 정보 입력 화면 이동 검증을 추가했습니다.

## 검증
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 리뷰 포인트
- 실제 식물 검색 API나 후보 정책은 아직 연결하지 않았고, 현재 정적 후보 목록 기준의 로컬 UX만 다룹니다.
