### PR TITLE
Feat: 메모 로컬 UX 보강 #58

### DIFF
--- a/lib/features/memo/presentation/pages/memo_list_page.dart
+++ b/lib/features/memo/presentation/pages/memo_list_page.dart
@@ -1,67 +1,37 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_list_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class MemoListPage extends StatefulWidget {
+class MemoListPage extends ConsumerWidget {
   const MemoListPage({super.key, required this.plantId});
 
   final String plantId;
 
-  @override
-  State<MemoListPage> createState() => _MemoListPageState();
-}
-
-class _MemoListPageState extends State<MemoListPage> {
   static const double _writeActionWidth = AppSpacing.x20 * 4;
   static const double _actionPopupTopAdjustment = 50;
 
-  final List<_MemoItem> _memos = [
-    const _MemoItem(
-      author: '커먼플랜트',
-      content:
-          '장마여서 물주는 날짜를 조금 늦춤 하지만 해는 맑구나 몬테랑 함께한 지 벌써 56일이 되었구나 요즘 잎이 갈라지니 채광이 더 드는 곳으로 자리를 옮겨야 할 것 같다.',
-      dateLabel: '2022.11.20',
-      avatarAsset: AppImageAssets.profileSetupSampleAvatar,
-      imageAsset: AppImageAssets.memoListMonstera,
-    ),
-    const _MemoItem(
-      author: '커먼맘',
-      content: '오늘은 잎이 조금 시들하구나 커먼아 해결책은?',
-      dateLabel: '2022.11.20',
-      avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
-    ),
-    const _MemoItem(
-      author: '커먼맘',
-      content:
-          '오늘은 잎의 상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물 주기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다.',
-      dateLabel: '2022.11.20',
-      avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
-      imageAsset: AppImageAssets.memoListMonstera,
-      imageAlignment: Alignment.topCenter,
-    ),
-    const _MemoItem(
-      author: '커먼 파파',
-      content: '오늘도 맑음',
-      dateLabel: '2022.11.20',
-    ),
-  ];
-
-  void _openWritePage() {
-    context.push(AppRoutePaths.memoWriteLocation(widget.plantId));
+  void _openWritePage(BuildContext context) {
+    context.push(AppRoutePaths.memoWriteLocation(plantId));
   }
 
-  void _showActionPopup(_MemoItem memo, BuildContext anchorContext) {
+  void _showActionPopup({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MemoItem memo,
+    required BuildContext anchorContext,
+  }) {
     final anchorRenderObject = anchorContext.findRenderObject();
     final overlayRenderObject = Overlay.maybeOf(
       context,
@@ -118,7 +88,7 @@ class _MemoListPageState extends State<MemoListPage> {
                     onEdit: closePopup,
                     onDelete: () {
                       closePopup();
-                      _showDeleteDialog(memo);
+                      _showDeleteDialog(context: context, ref: ref, memo: memo);
                     },
                   ),
                 ),
@@ -130,7 +100,13 @@ class _MemoListPageState extends State<MemoListPage> {
     );
   }
 
-  void _showDeleteDialog(_MemoItem memo) {
+  void _showDeleteDialog({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MemoItem memo,
+  }) {
+    final navigator = Navigator.of(context);
+
     showCommonDialog<void>(
       context: context,
       child: CommonDialogCard(
@@ -140,14 +116,16 @@ class _MemoListPageState extends State<MemoListPage> {
           CommonDialogActionButton(
             label: '취소',
             foregroundColor: AppColors.textBody,
-            onPressed: () => Navigator.of(context).pop(),
+            onPressed: navigator.pop,
           ),
           CommonDialogActionButton.confirm(
             label: '삭제',
             foregroundColor: AppColors.danger,
             onPressed: () {
-              setState(() => _memos.remove(memo));
-              Navigator.of(context).pop();
+              navigator.pop();
+              ref
+                  .read(memoListProvider.notifier)
+                  .deleteMemo(plantId: plantId, memoId: memo.id);
             },
           ),
         ],
@@ -155,11 +133,11 @@ class _MemoListPageState extends State<MemoListPage> {
     );
   }
 
-  Widget _buildWriteAction() {
+  Widget _buildWriteAction(BuildContext context) {
     return SizedBox(
       width: _writeActionWidth,
       child: TextButton(
-        onPressed: _openWritePage,
+        onPressed: () => _openWritePage(context),
         style: TextButton.styleFrom(
           foregroundColor: AppColors.brandStrong,
           padding: EdgeInsets.zero,
@@ -177,22 +155,77 @@ class _MemoListPageState extends State<MemoListPage> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memos = ref.watch(memoItemsProvider(plantId));
+
     return CommonScaffold(
       title: 'Memo',
       bodyPadding: EdgeInsets.zero,
       trailingWidth: _writeActionWidth,
-      trailing: _buildWriteAction(),
+      trailing: _buildWriteAction(context),
       floatingActionButton: FloatingActionButton(
         tooltip: '메모 작성',
-        onPressed: _openWritePage,
+        onPressed: () => _openWritePage(context),
         elevation: 0,
         backgroundColor: AppColors.brandStrong,
         foregroundColor: AppColors.white,
         shape: const CircleBorder(),
         child: const Icon(Icons.add, size: AppSizes.iconLarge),
       ),
-      child: _MemoFeedList(memos: _memos, onOpenMenu: _showActionPopup),
+      child: memos.isEmpty
+          ? const _MemoEmptyView()
+          : _MemoFeedList(
+              memos: memos,
+              onOpenMenu: (memo, anchorContext) {
+                _showActionPopup(
+                  context: context,
+                  ref: ref,
+                  memo: memo,
+                  anchorContext: anchorContext,
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _MemoEmptyView extends StatelessWidget {
+  const _MemoEmptyView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CommonSvgIcon(
+              AppIconAssets.plantEmpty,
+              width: AppSizes.iconLarge,
+              height: AppSizes.iconLarge,
+              color: AppColors.iconInactive,
+              semanticsLabel: '메모 없음',
+            ),
+            const SizedBox(height: AppSpacing.x16),
+            Text(
+              '아직 작성된 메모가 없어요',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x8),
+            Text(
+              '식물의 변화를 메모로 남겨보세요',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size14Medium.copyWith(
+                color: AppColors.textBody,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -200,8 +233,8 @@ class _MemoListPageState extends State<MemoListPage> {
 class _MemoFeedList extends StatelessWidget {
   const _MemoFeedList({required this.memos, required this.onOpenMenu});
 
-  final List<_MemoItem> memos;
-  final void Function(_MemoItem memo, BuildContext anchorContext) onOpenMenu;
+  final List<MemoItem> memos;
+  final void Function(MemoItem memo, BuildContext anchorContext) onOpenMenu;
 
   @override
   Widget build(BuildContext context) {
@@ -230,7 +263,7 @@ class _MemoFeedList extends StatelessWidget {
 class _MemoFeedItem extends StatelessWidget {
   const _MemoFeedItem({required this.memo, required this.onOpenMenu});
 
-  final _MemoItem memo;
+  final MemoItem memo;
   final ValueChanged<BuildContext> onOpenMenu;
 
   @override
@@ -350,22 +383,4 @@ class _MemoAvatar extends StatelessWidget {
       ),
     );
   }
-}
-
-class _MemoItem {
-  const _MemoItem({
-    required this.author,
-    required this.content,
-    required this.dateLabel,
-    this.avatarAsset,
-    this.imageAsset,
-    this.imageAlignment = Alignment.center,
-  });
-
-  final String author;
-  final String content;
-  final String dateLabel;
-  final String? avatarAsset;
-  final String? imageAsset;
-  final Alignment imageAlignment;
 }

--- a/lib/features/memo/presentation/pages/memo_write_page.dart
+++ b/lib/features/memo/presentation/pages/memo_write_page.dart
@@ -5,22 +5,24 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_list_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_photo_add_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class MemoWritePage extends StatefulWidget {
+class MemoWritePage extends ConsumerStatefulWidget {
   const MemoWritePage({super.key, required this.plantId});
 
   final String plantId;
 
   @override
-  State<MemoWritePage> createState() => _MemoWritePageState();
+  ConsumerState<MemoWritePage> createState() => _MemoWritePageState();
 }
 
-class _MemoWritePageState extends State<MemoWritePage> {
+class _MemoWritePageState extends ConsumerState<MemoWritePage> {
   static const int _maxMemoLength = 200;
   static const int _maxPhotoCount = 1;
 
@@ -55,6 +57,13 @@ class _MemoWritePageState extends State<MemoWritePage> {
   }
 
   void _submit() {
+    ref
+        .read(memoListProvider.notifier)
+        .addMemo(
+          plantId: widget.plantId,
+          content: _memoController.text.trim(),
+          hasPhoto: _hasPhoto,
+        );
     context.go(AppRoutePaths.memoListLocation(widget.plantId));
   }
 

--- a/lib/features/memo/presentation/providers/memo_list_provider.dart
+++ b/lib/features/memo/presentation/providers/memo_list_provider.dart
@@ -1,0 +1,118 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final memoListProvider =
+    NotifierProvider<MemoListNotifier, Map<String, List<MemoItem>>>(
+      MemoListNotifier.new,
+    );
+
+final memoItemsProvider = Provider.family<List<MemoItem>, String>((
+  ref,
+  plantId,
+) {
+  return ref.watch(
+    memoListProvider.select(
+      (memosByPlant) => memosByPlant[plantId] ?? const <MemoItem>[],
+    ),
+  );
+});
+
+class MemoItem {
+  const MemoItem({
+    required this.id,
+    required this.author,
+    required this.content,
+    required this.dateLabel,
+    this.avatarAsset,
+    this.imageAsset,
+    this.imageAlignment = Alignment.center,
+  });
+
+  final String id;
+  final String author;
+  final String content;
+  final String dateLabel;
+  final String? avatarAsset;
+  final String? imageAsset;
+  final Alignment imageAlignment;
+}
+
+class MemoListNotifier extends Notifier<Map<String, List<MemoItem>>> {
+  int _nextId = 1;
+
+  @override
+  Map<String, List<MemoItem>> build() {
+    return const {'plant-1': _defaultMemoItems};
+  }
+
+  MemoItem addMemo({
+    required String plantId,
+    required String content,
+    bool hasPhoto = false,
+  }) {
+    final memo = MemoItem(
+      id: 'local-memo-${_nextId++}',
+      author: '커먼플랜트',
+      content: content,
+      dateLabel: '오늘',
+      avatarAsset: AppImageAssets.profileSetupSampleAvatar,
+      imageAsset: hasPhoto ? AppImageAssets.placeDetailMonstera : null,
+    );
+    final currentMemos = state[plantId] ?? const <MemoItem>[];
+
+    state = {
+      ...state,
+      plantId: [memo, ...currentMemos],
+    };
+
+    return memo;
+  }
+
+  void deleteMemo({required String plantId, required String memoId}) {
+    final currentMemos = state[plantId] ?? const <MemoItem>[];
+
+    state = {
+      ...state,
+      plantId: [
+        for (final memo in currentMemos)
+          if (memo.id != memoId) memo,
+      ],
+    };
+  }
+}
+
+const List<MemoItem> _defaultMemoItems = [
+  MemoItem(
+    id: 'sample-memo-1',
+    author: '커먼플랜트',
+    content:
+        '장마여서 물주는 날짜를 조금 늦춤 하지만 해는 맑구나 몬테랑 함께한 지 벌써 56일이 되었구나 요즘 잎이 갈라지니 채광이 더 드는 곳으로 자리를 옮겨야 할 것 같다.',
+    dateLabel: '2022.11.20',
+    avatarAsset: AppImageAssets.profileSetupSampleAvatar,
+    imageAsset: AppImageAssets.memoListMonstera,
+  ),
+  MemoItem(
+    id: 'sample-memo-2',
+    author: '커먼맘',
+    content: '오늘은 잎이 조금 시들하구나 커먼아 해결책은?',
+    dateLabel: '2022.11.20',
+    avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
+  ),
+  MemoItem(
+    id: 'sample-memo-3',
+    author: '커먼맘',
+    content:
+        '오늘은 잎의 상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기가 아주 딱 맞는 것 같구나. 요즘 내가 물 주기 누르는 거 자꾸 깜빡깜빡하니 커먼이 네가 조금 더 신경써주길 바란다.',
+    dateLabel: '2022.11.20',
+    avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
+    imageAsset: AppImageAssets.memoListMonstera,
+    imageAlignment: Alignment.topCenter,
+  ),
+  MemoItem(
+    id: 'sample-memo-4',
+    author: '커먼 파파',
+    content: '오늘도 맑음',
+    dateLabel: '2022.11.20',
+  ),
+];

--- a/test/features/memo/presentation/pages/memo_list_page_test.dart
+++ b/test/features/memo/presentation/pages/memo_list_page_test.dart
@@ -1,13 +1,15 @@
+import 'package:commonplant_frontend/app/common_plant_app.dart';
+import 'package:commonplant_frontend/app/router/app_router.dart';
+import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/features/memo/presentation/pages/memo_list_page.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('메모 목록 기본 화면은 피드형 메모와 작성 액션을 표시한다', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: MemoListPage(plantId: 'plant-1')),
-    );
+    await tester.pumpWidget(_buildMemoListApp('plant-1'));
     await tester.pumpAndSettle();
 
     expect(find.text('Memo'), findsOneWidget);
@@ -24,9 +26,7 @@ void main() {
   });
 
   testWidgets('메모 더보기는 수정삭제 메뉴와 삭제 확인 알럿을 표시한다', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: MemoListPage(plantId: 'plant-1')),
-    );
+    await tester.pumpWidget(_buildMemoListApp('plant-1'));
     await tester.pumpAndSettle();
 
     final menuButton = find.bySemanticsLabel('메모 메뉴 열기: 커먼플랜트');
@@ -57,4 +57,66 @@ void main() {
     expect(find.text('커먼플랜트'), findsNothing);
     expect(find.textContaining('장마여서 물주는 날짜를 조금 늦춤'), findsNothing);
   });
+
+  testWidgets('메모 작성 완료 후 목록으로 돌아와 입력한 메모를 표시한다', (tester) async {
+    final router = createAppRouter(
+      initialLocation: AppRoutePaths.memoWriteLocation('local-memo-plant'),
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [appRouterProvider.overrideWithValue(router)],
+        child: const CommonPlantApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '새 잎이 올라왔다');
+    await tester.pump();
+    await tester.tap(find.text('완료'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Memo'), findsOneWidget);
+    expect(find.text('새 잎이 올라왔다'), findsOneWidget);
+  });
+
+  testWidgets('마지막 로컬 메모를 삭제하면 빈 상태를 표시한다', (tester) async {
+    final router = createAppRouter(
+      initialLocation: AppRoutePaths.memoWriteLocation('single-local-memo'),
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [appRouterProvider.overrideWithValue(router)],
+        child: const CommonPlantApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '삭제될 메모');
+    await tester.pump();
+    await tester.tap(find.text('완료'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('삭제될 메모'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('메모 메뉴 열기'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('삭제하기'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('삭제'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('삭제될 메모'), findsNothing);
+    expect(find.text('아직 작성된 메모가 없어요'), findsOneWidget);
+    expect(find.text('식물의 변화를 메모로 남겨보세요'), findsOneWidget);
+  });
+}
+
+Widget _buildMemoListApp(String plantId) {
+  return ProviderScope(
+    child: MaterialApp(home: MemoListPage(plantId: plantId)),
+  );
 }

--- a/test/features/memo/presentation/pages/memo_write_page_test.dart
+++ b/test/features/memo/presentation/pages/memo_write_page_test.dart
@@ -1,12 +1,11 @@
 import 'package:commonplant_frontend/features/memo/presentation/pages/memo_write_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('메모 작성 기본 화면은 빈 사진과 비활성 완료 버튼을 표시한다', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
-    );
+    await tester.pumpWidget(_buildMemoWriteApp());
     await tester.pumpAndSettle();
 
     expect(find.text('메모 작성'), findsOneWidget);
@@ -21,9 +20,7 @@ void main() {
   });
 
   testWidgets('메모를 입력하면 글자 수와 완료 버튼 상태를 갱신한다', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
-    );
+    await tester.pumpWidget(_buildMemoWriteApp());
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(TextField), '오늘도 맑음');
@@ -38,9 +35,7 @@ void main() {
   });
 
   testWidgets('사진 추가 버튼은 첨부 사진과 삭제 버튼을 표시한다', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
-    );
+    await tester.pumpWidget(_buildMemoWriteApp());
     await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('사진 추가'));
@@ -56,4 +51,10 @@ void main() {
     expect(find.text('0/1', findRichText: true), findsOneWidget);
     expect(find.bySemanticsLabel('첨부된 메모 사진'), findsNothing);
   });
+}
+
+Widget _buildMemoWriteApp() {
+  return const ProviderScope(
+    child: MaterialApp(home: MemoWritePage(plantId: 'plant-1')),
+  );
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #58

## 구현 범위
- 메모 목록/작성 화면의 로컬 상태를 `memoListProvider`로 분리했습니다.
- 메모 작성 완료 시 입력한 메모를 해당 식물의 메모 목록에 추가하고 목록으로 복귀하도록 연결했습니다.
- 메모 삭제 시 Provider 상태에서 제거하고, 마지막 메모 삭제 후 empty 상태를 표시하도록 정리했습니다.
- 기존 `plant-1` 샘플 메모는 유지하고, 새 식물 ID는 빈 목록에서 시작하도록 분리했습니다.

## 테스트
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

## 문서 반영
- 기존 남은 작업 계획의 순서 4 범위에 해당하는 코드 작업이며, 별도 정책 변경은 없습니다.

## 리뷰 포인트
- 메모 API가 확정되지 않아 API 호출이나 임의 request/response 구현은 추가하지 않았습니다.
- 로컬 UX 검증을 위한 Provider이므로 추후 Memo API 확정 시 repository/controller 구조로 교체할 수 있습니다.

## Breaking change
- 없음
