### PR TITLE
Feat: 장소 상세 상태 UI 정리 #60

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -9,6 +9,7 @@ import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
 import 'package:commonplant_frontend/shared/widgets/common_plant_card.dart';
@@ -29,7 +30,7 @@ PlaceDetailRole? placeDetailRoleFromQuery(String? value) {
   };
 }
 
-class PlaceDetailPage extends StatelessWidget {
+class PlaceDetailPage extends ConsumerWidget {
   const PlaceDetailPage({super.key, required this.placeId, this.role});
 
   final String placeId;
@@ -58,24 +59,55 @@ class PlaceDetailPage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final mockDetail = _PlaceDetailData.mock(placeId, role: role);
 
-    if (AppEnvironment.useRemoteApi) {
-      return Consumer(
-        builder: (context, ref, _) {
-          final remoteDetail = ref.watch(placeDetailProvider(placeId));
-          final detail = switch (remoteDetail) {
-            AsyncData(:final value) => mockDetail.applySummary(value),
-            _ => mockDetail,
-          };
-
-          return _buildScaffold(context, detail);
-        },
-      );
+    if (!ref.watch(useRemoteApiProvider)) {
+      return _buildScaffold(context, mockDetail);
     }
 
-    return _buildScaffold(context, mockDetail);
+    final remoteDetail = ref.watch(placeDetailProvider(placeId));
+
+    return remoteDetail.when(
+      data: (summary) {
+        if (_isEmptyRemoteSummary(summary)) {
+          return _buildStatusScaffold(
+            context,
+            const _PlaceDetailStatusView(
+              icon: AppIconAssets.placeEmpty,
+              title: '장소 정보를 찾을 수 없어요',
+              message: '다시 장소 목록에서 선택해 주세요',
+              semanticsLabel: '장소 정보 없음',
+            ),
+          );
+        }
+
+        return _buildScaffold(context, mockDetail.applySummary(summary));
+      },
+      error: (error, stackTrace) {
+        return _buildStatusScaffold(
+          context,
+          _PlaceDetailStatusView(
+            icon: AppIconAssets.placeEmpty,
+            title: '장소 정보를 불러오지 못했어요',
+            message: '잠시 후 다시 시도해 주세요',
+            semanticsLabel: '장소 정보 오류',
+            actionLabel: '다시 시도',
+            onAction: () => ref.invalidate(placeDetailProvider(placeId)),
+          ),
+        );
+      },
+      loading: () {
+        return _buildStatusScaffold(
+          context,
+          const _PlaceDetailStatusView(
+            title: '장소 정보를 불러오고 있어요',
+            message: '장소와 식물 정보를 준비하고 있어요',
+            isLoading: true,
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildScaffold(BuildContext context, _PlaceDetailData detail) {
@@ -103,6 +135,109 @@ class PlaceDetailPage extends StatelessWidget {
               ],
             ),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusScaffold(BuildContext context, Widget child) {
+    return CommonScaffold(
+      title: 'My place',
+      navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
+        color: AppColors.textStrong,
+        fontWeight: FontWeight.w700,
+      ),
+      bodyPadding: EdgeInsets.zero,
+      child: SizedBox(
+        width: double.infinity,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
+            child: SizedBox(height: AppSizes.mobileWidth, child: child),
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool _isEmptyRemoteSummary(PlaceSummary summary) {
+    return summary.name.trim().isEmpty;
+  }
+}
+
+class _PlaceDetailStatusView extends StatelessWidget {
+  const _PlaceDetailStatusView({
+    required this.title,
+    required this.message,
+    this.icon,
+    this.semanticsLabel,
+    this.actionLabel,
+    this.onAction,
+    this.isLoading = false,
+  });
+
+  final String title;
+  final String message;
+  final String? icon;
+  final String? semanticsLabel;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isLoading)
+              SizedBox.square(
+                dimension: AppSizes.iconLarge,
+                child: CircularProgressIndicator(
+                  strokeWidth: 3,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    AppColors.brandStrong,
+                  ),
+                ),
+              )
+            else if (icon case final icon?)
+              CommonSvgIcon(
+                icon,
+                width: AppSizes.iconLarge,
+                height: AppSizes.iconLarge,
+                color: AppColors.iconInactive,
+                semanticsLabel: semanticsLabel,
+              ),
+            const SizedBox(height: AppSpacing.x16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size14Medium.copyWith(
+                color: AppColors.textBody,
+              ),
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: AppSpacing.x24),
+              SizedBox(
+                width: AppSizes.smallButtonWidth,
+                child: CommonButton.secondary(
+                  label: actionLabel!,
+                  size: CommonButtonSize.medium,
+                  onPressed: onAction,
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/lib/features/place/presentation/providers/place_list_provider.dart
+++ b/lib/features/place/presentation/providers/place_list_provider.dart
@@ -32,12 +32,10 @@ final plantRegistrationPlaceProvider = FutureProvider<List<PlaceSummary>>((
   return ref.watch(placeListProvider);
 });
 
-final placeDetailProvider = FutureProvider.family<PlaceSummary, String>((
-  ref,
-  code,
-) {
-  return ref.watch(placeRepositoryProvider).fetchPlace(code);
-});
+final placeDetailProvider = FutureProvider.family<PlaceSummary, String>(
+  (ref, code) => ref.watch(placeRepositoryProvider).fetchPlace(code),
+  retry: (retryCount, error) => null,
+);
 
 class PlaceListNotifier extends Notifier<List<PlaceSummary>> {
   int _nextId = 1;

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -1,12 +1,20 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_detail_page.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('리더는 FAB에서 장소 수정 액션을 확인할 수 있다', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: PlaceDetailPage(placeId: 'place-1', role: PlaceDetailRole.leader),
+      _buildPlaceDetailApp(
+        const PlaceDetailPage(placeId: 'place-1', role: PlaceDetailRole.leader),
       ),
     );
     await tester.pumpAndSettle();
@@ -21,8 +29,8 @@ void main() {
 
   testWidgets('팀원은 FAB에서 장소 수정 액션을 보지 않는다', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: PlaceDetailPage(placeId: 'place-1', role: PlaceDetailRole.member),
+      _buildPlaceDetailApp(
+        const PlaceDetailPage(placeId: 'place-1', role: PlaceDetailRole.member),
       ),
     );
     await tester.pumpAndSettle();
@@ -37,7 +45,7 @@ void main() {
 
   testWidgets('장소 나가기는 확인 dialog를 표시한다', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: PlaceDetailPage(placeId: 'place-1')),
+      _buildPlaceDetailApp(const PlaceDetailPage(placeId: 'place-1')),
     );
     await tester.pumpAndSettle();
 
@@ -49,4 +57,116 @@ void main() {
     expect(find.text('장소를 나가시겠어요?'), findsOneWidget);
     expect(find.text('나가면 더 이상 식물을 관리할 수 없어요.'), findsOneWidget);
   });
+
+  testWidgets('remote loading 상태는 상세 정보 대신 로딩 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(_PendingPlaceRepository()),
+        ],
+        child: const MaterialApp(
+          home: PlaceDetailPage(placeId: 'remote-place'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('장소 정보를 불러오고 있어요'), findsOneWidget);
+    expect(find.text('스윗 홈_거실'), findsNothing);
+  });
+
+  testWidgets('remote empty 상태는 장소 없음 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(
+            _StaticPlaceRepository(
+              const PlaceSummary(id: 'empty-place', name: ''),
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: PlaceDetailPage(placeId: 'empty-place')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('장소 정보를 찾을 수 없어요'), findsOneWidget);
+    expect(find.text('다시 장소 목록에서 선택해 주세요'), findsOneWidget);
+    expect(find.text('스윗 홈_거실'), findsNothing);
+  });
+
+  testWidgets('remote error 상태는 재시도 후 상세 정보를 표시한다', (tester) async {
+    final repository = _RetryPlaceRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(home: PlaceDetailPage(placeId: 'retry-place')),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('장소 정보를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.tap(find.text('다시 시도'));
+    await tester.pumpAndSettle();
+
+    expect(repository.fetchCalls, 2);
+    expect(find.text('옥상 정원'), findsOneWidget);
+    expect(find.text('장소 정보를 불러오지 못했어요'), findsNothing);
+  });
+}
+
+Widget _buildPlaceDetailApp(Widget home) {
+  return ProviderScope(child: MaterialApp(home: home));
+}
+
+class _PendingPlaceRepository extends PlaceRepository {
+  _PendingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  final Completer<PlaceSummary> _completer = Completer<PlaceSummary>();
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) {
+    return _completer.future;
+  }
+}
+
+class _StaticPlaceRepository extends PlaceRepository {
+  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    return summary;
+  }
+}
+
+class _RetryPlaceRepository extends PlaceRepository {
+  _RetryPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  int fetchCalls = 0;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    fetchCalls++;
+
+    if (fetchCalls == 1) {
+      throw Exception('network');
+    }
+
+    return const PlaceSummary(
+      id: 'retry-place',
+      name: '옥상 정원',
+      address: '서울시 노원구 광운로 20',
+    );
+  }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #60

## 구현 범위
- 장소 상세 화면이 `useRemoteApiProvider`를 기준으로 mock fallback과 remote mode를 분기하도록 정리했습니다.
- remote loading, empty, error 상태 UI를 `CommonScaffold` 안에서 분리했습니다.
- remote error 상태에는 `다시 시도` 액션을 제공하고 `placeDetailProvider`를 invalidate하도록 연결했습니다.
- Place 상세 Provider의 자동 retry를 끄고 화면의 명시적 재시도 UX가 드러나도록 정리했습니다.

## 테스트
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

## 문서 반영
- 기존 남은 작업 계획의 순서 5 범위에 해당하는 코드 작업이며, 별도 문서 정책 변경은 없습니다.

## 리뷰 포인트
- Place 성공 response body schema가 아직 확인 필요라 상세 식물/친구 데이터는 기존 mock fallback을 유지합니다.
- remote 성공 시 Swagger에서 확인 가능한 장소 이름/주소만 mock 상세 데이터에 덮어씁니다.

## Breaking change
- 없음
