### PR TITLE
Feat: 식물 상세 상태 UI 정리 #62

### DIFF
--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -9,6 +9,7 @@ import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
@@ -19,7 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class PlantDetailPage extends StatelessWidget {
+class PlantDetailPage extends ConsumerWidget {
   const PlantDetailPage({super.key, required this.plantId, this.placeId});
 
   final String plantId;
@@ -89,24 +90,41 @@ class PlantDetailPage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final mockDetail = _PlantDetailData.mock();
 
-    if (AppEnvironment.useRemoteApi) {
-      return Consumer(
-        builder: (context, ref, _) {
-          final remoteDetail = ref.watch(remotePlantDetailProvider(plantId));
-          final detail = switch (remoteDetail) {
-            AsyncData(:final value) => mockDetail.applyRemote(value),
-            _ => mockDetail,
-          };
-
-          return _buildScaffold(context, detail);
-        },
-      );
+    if (!ref.watch(useRemoteApiProvider)) {
+      return _buildScaffold(context, mockDetail);
     }
 
-    return _buildScaffold(context, mockDetail);
+    final remoteDetail = ref.watch(remotePlantDetailProvider(plantId));
+
+    return remoteDetail.when(
+      data: (detail) {
+        if (_isEmptyRemoteDetail(detail)) {
+          return const PlantStateScaffold(
+            title: 'My plant',
+            statusTitle: '식물 정보를 찾을 수 없어요',
+            message: '다시 식물 목록에서 선택해 주세요',
+          );
+        }
+
+        return _buildScaffold(context, mockDetail.applyRemote(detail));
+      },
+      error: (error, stackTrace) => PlantStateScaffold(
+        title: 'My plant',
+        statusTitle: '식물 정보를 불러오지 못했어요',
+        message: '잠시 후 다시 시도해 주세요',
+        actionLabel: '다시 시도',
+        onAction: () => ref.invalidate(remotePlantDetailProvider(plantId)),
+      ),
+      loading: () => const PlantStateScaffold(
+        title: 'My plant',
+        statusTitle: '식물 정보를 불러오고 있어요',
+        message: '식물과 메모 정보를 준비하고 있어요',
+        isLoading: true,
+      ),
+    );
   }
 
   Widget _buildScaffold(BuildContext context, _PlantDetailData detail) {
@@ -134,6 +152,10 @@ class PlantDetailPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  bool _isEmptyRemoteDetail(PlantDetail detail) {
+    return detail.name.trim().isEmpty;
   }
 }
 

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -10,7 +10,9 @@ import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
@@ -46,6 +48,8 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   late final String _selectedPlantName;
   String? _selectedPlaceId;
   bool _isSubmitting = false;
+  String _initialEditPlantName = _defaultEditPlantName;
+  bool _hasAppliedRemoteEditInfo = false;
 
   static const List<_PlantRegistrationPlace> _places = [
     _PlantRegistrationPlace(
@@ -89,19 +93,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   @override
   Widget build(BuildContext context) {
     if (widget.isEdit) {
-      final trimmedName = _nameController.text.trim();
-      final canSubmit =
-          trimmedName.isNotEmpty &&
-          trimmedName != _defaultEditPlantName &&
-          !_isSubmitting;
-
-      return _PlantEditScaffold(
-        nameController: _nameController,
-        canSubmit: canSubmit,
-        isSubmitting: _isSubmitting,
-        onChanged: (_) => setState(() {}),
-        onSubmit: () => _submitEdit(),
-      );
+      return _buildEditMode();
     }
 
     final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
@@ -120,6 +112,77 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       onCancel: _cancelCreate,
       onSubmit: () => _submitCreate(),
     );
+  }
+
+  Widget _buildEditMode() {
+    if (!ref.watch(useRemoteApiProvider)) {
+      return _buildEditScaffold();
+    }
+
+    final plantId = widget.plantId!;
+    final editInfo = ref.watch(remotePlantEditInfoProvider(plantId));
+
+    return editInfo.when(
+      data: (info) {
+        if (_isEmptyRemoteEditInfo(info)) {
+          return const PlantStateScaffold(
+            title: '식물 수정',
+            statusTitle: '식물 수정 정보를 찾을 수 없어요',
+            message: '다시 식물 상세에서 수정해 주세요',
+          );
+        }
+
+        _applyRemoteEditInfo(info);
+
+        return _buildEditScaffold();
+      },
+      error: (error, stackTrace) => PlantStateScaffold(
+        title: '식물 수정',
+        statusTitle: '식물 수정 정보를 불러오지 못했어요',
+        message: '잠시 후 다시 시도해 주세요',
+        actionLabel: '다시 시도',
+        onAction: () => ref.invalidate(remotePlantEditInfoProvider(plantId)),
+      ),
+      loading: () => const PlantStateScaffold(
+        title: '식물 수정',
+        statusTitle: '식물 수정 정보를 불러오고 있어요',
+        message: '식물 이름과 사진 정보를 준비하고 있어요',
+        isLoading: true,
+      ),
+    );
+  }
+
+  Widget _buildEditScaffold() {
+    final trimmedName = _nameController.text.trim();
+    final canSubmit =
+        trimmedName.isNotEmpty &&
+        trimmedName != _initialEditPlantName &&
+        !_isSubmitting;
+
+    return _PlantEditScaffold(
+      nameController: _nameController,
+      canSubmit: canSubmit,
+      isSubmitting: _isSubmitting,
+      onChanged: (_) => setState(() {}),
+      onSubmit: () => _submitEdit(),
+    );
+  }
+
+  void _applyRemoteEditInfo(PlantEditInfo info) {
+    if (_hasAppliedRemoteEditInfo) {
+      return;
+    }
+
+    final name = info.name.trim();
+
+    _initialEditPlantName = name;
+    _nameController.text = name;
+    _nameController.selection = TextSelection.collapsed(offset: name.length);
+    _hasAppliedRemoteEditInfo = true;
+  }
+
+  bool _isEmptyRemoteEditInfo(PlantEditInfo info) {
+    return info.name.trim().isEmpty;
   }
 
   String _normalizedInitialPlantName() {

--- a/lib/features/plant/presentation/providers/plant_list_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_list_provider.dart
@@ -23,19 +23,19 @@ final plantSummariesProvider = Provider<AsyncValue<List<PlantSummary>>>((ref) {
   return AsyncData(ref.watch(plantListProvider));
 });
 
-final remotePlantDetailProvider = FutureProvider.family<PlantDetail, String>((
-  ref,
-  plantId,
-) {
-  return ref.watch(plantRepositoryProvider).fetchPlant(plantId: plantId);
-});
+final remotePlantDetailProvider = FutureProvider.family<PlantDetail, String>(
+  (ref, plantId) =>
+      ref.watch(plantRepositoryProvider).fetchPlant(plantId: plantId),
+  retry: (retryCount, error) => null,
+);
 
 final remotePlantEditInfoProvider =
-    FutureProvider.family<PlantEditInfo, String>((ref, plantId) {
-      return ref
+    FutureProvider.family<PlantEditInfo, String>(
+      (ref, plantId) => ref
           .watch(plantRepositoryProvider)
-          .fetchPlantEditInfo(plantId: plantId);
-    });
+          .fetchPlantEditInfo(plantId: plantId),
+      retry: (retryCount, error) => null,
+    );
 
 class PlantListNotifier extends Notifier<List<PlantSummary>> {
   int _nextId = 1;

--- a/lib/features/plant/presentation/widgets/plant_state_view.dart
+++ b/lib/features/plant/presentation/widgets/plant_state_view.dart
@@ -1,0 +1,139 @@
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:flutter/material.dart';
+
+class PlantStateScaffold extends StatelessWidget {
+  const PlantStateScaffold({
+    super.key,
+    required this.title,
+    required this.statusTitle,
+    required this.message,
+    this.isLoading = false,
+    this.actionLabel,
+    this.onAction,
+    this.showNavigationBar = true,
+    this.showBackButton = true,
+  });
+
+  final String title;
+  final String statusTitle;
+  final String message;
+  final bool isLoading;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final bool showNavigationBar;
+  final bool showBackButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return CommonScaffold(
+      title: title,
+      showNavigationBar: showNavigationBar,
+      showBackButton: showBackButton,
+      navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
+        color: AppColors.textStrong,
+        fontWeight: FontWeight.w700,
+      ),
+      bodyPadding: EdgeInsets.zero,
+      child: SizedBox(
+        width: double.infinity,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
+            child: SizedBox(
+              height: AppSizes.mobileWidth,
+              child: _PlantStateContent(
+                title: statusTitle,
+                message: message,
+                isLoading: isLoading,
+                actionLabel: actionLabel,
+                onAction: onAction,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlantStateContent extends StatelessWidget {
+  const _PlantStateContent({
+    required this.title,
+    required this.message,
+    required this.isLoading,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final String title;
+  final String message;
+  final bool isLoading;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isLoading)
+              SizedBox.square(
+                dimension: AppSizes.iconLarge,
+                child: CircularProgressIndicator(
+                  strokeWidth: 3,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    AppColors.brandStrong,
+                  ),
+                ),
+              )
+            else
+              const CommonSvgIcon(
+                AppIconAssets.plantEmpty,
+                width: AppSizes.iconLarge,
+                height: AppSizes.iconLarge,
+                color: AppColors.iconInactive,
+                semanticsLabel: '식물 정보 없음',
+              ),
+            const SizedBox(height: AppSpacing.x16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size14Medium.copyWith(
+                color: AppColors.textBody,
+              ),
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: AppSpacing.x24),
+              SizedBox(
+                width: AppSizes.smallButtonWidth,
+                child: CommonButton.secondary(
+                  label: actionLabel!,
+                  size: CommonButtonSize.medium,
+                  onPressed: onAction,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -1,11 +1,19 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_detail_page.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('식물 상세는 Figma 주요 정보와 더보기 메뉴를 표시한다', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: PlantDetailPage(plantId: 'plant-1')),
+      _buildPlantDetailApp(const PlantDetailPage(plantId: 'plant-1')),
     );
     await tester.pumpAndSettle();
 
@@ -47,7 +55,7 @@ void main() {
 
   testWidgets('식물 삭제 메뉴는 확인 dialog를 표시한다', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: PlantDetailPage(plantId: 'plant-1')),
+      _buildPlantDetailApp(const PlantDetailPage(plantId: 'plant-1')),
     );
     await tester.pumpAndSettle();
 
@@ -59,4 +67,119 @@ void main() {
     expect(find.text('식물을 삭제할까요?'), findsOneWidget);
     expect(find.text('삭제하면 기록된 메모도 함께 사라져요.'), findsOneWidget);
   });
+
+  testWidgets('remote loading 상태는 식물 상세 대신 로딩 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(_PendingPlantRepository()),
+        ],
+        child: const MaterialApp(
+          home: PlantDetailPage(plantId: 'plant-remote'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('식물 정보를 불러오고 있어요'), findsOneWidget);
+    expect(find.text('몬테'), findsNothing);
+  });
+
+  testWidgets('remote empty 상태는 식물 없음 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(
+            _StaticPlantRepository(
+              detail: const PlantDetail(id: 'plant-empty', name: ''),
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: PlantDetailPage(plantId: 'plant-empty')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('식물 정보를 찾을 수 없어요'), findsOneWidget);
+    expect(find.text('다시 식물 목록에서 선택해 주세요'), findsOneWidget);
+    expect(find.text('몬테'), findsNothing);
+  });
+
+  testWidgets('remote error 상태는 재시도 후 식물 상세 정보를 표시한다', (tester) async {
+    final repository = _RetryPlantRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(home: PlantDetailPage(plantId: 'plant-retry')),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('식물 정보를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.tap(find.text('다시 시도'));
+    await tester.pumpAndSettle();
+
+    expect(repository.detailFetchCalls, 2);
+    expect(find.text('필로덴드론'), findsOneWidget);
+    expect(find.text('식물 정보를 불러오지 못했어요'), findsNothing);
+  });
+}
+
+Widget _buildPlantDetailApp(Widget home) {
+  return ProviderScope(child: MaterialApp(home: home));
+}
+
+class _PendingPlantRepository extends PlantRepository {
+  _PendingPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  final Completer<PlantDetail> _detailCompleter = Completer<PlantDetail>();
+
+  @override
+  Future<PlantDetail> fetchPlant({required String plantId}) {
+    return _detailCompleter.future;
+  }
+}
+
+class _StaticPlantRepository extends PlantRepository {
+  _StaticPlantRepository({required this.detail})
+    : super(PlantRemoteDataSource(Dio()));
+
+  final PlantDetail detail;
+
+  @override
+  Future<PlantDetail> fetchPlant({required String plantId}) async {
+    return detail;
+  }
+}
+
+class _RetryPlantRepository extends PlantRepository {
+  _RetryPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int detailFetchCalls = 0;
+
+  @override
+  Future<PlantDetail> fetchPlant({required String plantId}) async {
+    detailFetchCalls++;
+
+    if (detailFetchCalls == 1) {
+      throw Exception('network');
+    }
+
+    return const PlantDetail(
+      id: 'plant-retry',
+      name: '필로덴드론',
+      placeName: '스윗홈_거실',
+      species: 'Philodendron',
+      lastWateredDate: '2026.05.25',
+    );
+  }
 }

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -4,6 +4,7 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -59,6 +60,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(TextField), '몬테라');
     await tester.pump();
@@ -74,6 +76,69 @@ void main() {
     );
 
     expect(completeButton.onPressed, isNull);
+  });
+
+  testWidgets('remote loading 상태는 식물 수정 폼 대신 로딩 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(
+            _PendingEditInfoPlantRepository(),
+          ),
+        ],
+        child: const MaterialApp(home: PlantFormPage(plantId: 'plant-remote')),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('식물 수정 정보를 불러오고 있어요'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+  });
+
+  testWidgets('remote empty 상태는 식물 수정 정보 없음 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(
+            _StaticEditInfoPlantRepository(const PlantEditInfo(name: '')),
+          ),
+        ],
+        child: const MaterialApp(home: PlantFormPage(plantId: 'plant-empty')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('식물 수정 정보를 찾을 수 없어요'), findsOneWidget);
+    expect(find.text('다시 식물 상세에서 수정해 주세요'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+  });
+
+  testWidgets('remote error 상태는 재시도 후 식물 수정 폼을 표시한다', (tester) async {
+    final repository = _RetryEditInfoPlantRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(home: PlantFormPage(plantId: 'plant-retry')),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('식물 수정 정보를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.tap(find.text('다시 시도'));
+    await tester.pumpAndSettle();
+
+    expect(repository.editInfoFetchCalls, 2);
+    expect(find.text('필로덴드론'), findsOneWidget);
+    expect(find.text('식물 수정 정보를 불러오지 못했어요'), findsNothing);
   });
 }
 
@@ -91,5 +156,50 @@ class _PendingPlantRepository extends PlantRepository {
   }) {
     updateCalls++;
     return _completer.future;
+  }
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    return const PlantEditInfo(name: '몬테');
+  }
+}
+
+class _PendingEditInfoPlantRepository extends PlantRepository {
+  _PendingEditInfoPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  final Completer<PlantEditInfo> _completer = Completer<PlantEditInfo>();
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) {
+    return _completer.future;
+  }
+}
+
+class _StaticEditInfoPlantRepository extends PlantRepository {
+  _StaticEditInfoPlantRepository(this.editInfo)
+    : super(PlantRemoteDataSource(Dio()));
+
+  final PlantEditInfo editInfo;
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    return editInfo;
+  }
+}
+
+class _RetryEditInfoPlantRepository extends PlantRepository {
+  _RetryEditInfoPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int editInfoFetchCalls = 0;
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    editInfoFetchCalls++;
+
+    if (editInfoFetchCalls == 1) {
+      throw Exception('network');
+    }
+
+    return const PlantEditInfo(name: '필로덴드론');
   }
 }


### PR DESCRIPTION
## 작업 내용
- 식물 상세 화면의 원격 loading, empty, error 상태 UI를 mock fallback과 분리했습니다.
- 식물 수정 화면의 원격 edit info loading, empty, error 상태 UI와 재시도 흐름을 추가했습니다.
- 식물 상태 안내 UI를 공통 위젯으로 분리하고 관련 widget test를 보강했습니다.

## 검증
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #62
