### PR TITLE
Refactor: 폼 제출 상태 공통화 #64

### DIFF
--- a/docs/form-validation-error-guide.md
+++ b/docs/form-validation-error-guide.md
@@ -99,6 +99,14 @@ CommonTextField(
 
 버튼 UI는 `CommonButton`의 `onPressed: null` 상태를 활용합니다.
 
+여러 폼에서 제출 상태가 반복되면 `shared/forms/form_submit_controller.dart`의
+`FormSubmitController`와 `FormSubmitState`를 사용합니다.
+
+- 화면은 `FormSubmitController.state.isSubmitting`을 버튼 `isLoading`과 `onPressed` 조건에 반영합니다.
+- 제출 로직은 `submit`에 전달하고, 화면별 실패 문구는 `failureMessage`로 주입합니다.
+- 실패 후에는 `state.errorMessage`를 Snackbar, Dialog 등 화면 정책에 맞게 사용자 메시지로 표시합니다.
+- repository 호출, route 이동, Provider invalidate는 각 feature 화면 또는 controller 책임으로 유지합니다.
+
 ## 서버 에러 처리
 
 API 연동이 들어오면 아래 순서로 처리합니다.

--- a/lib/features/login/presentation/pages/profile_setup_page.dart
+++ b/lib/features/login/presentation/pages/profile_setup_page.dart
@@ -9,6 +9,7 @@ import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/login/presentation/providers/profile_setup_state_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
@@ -49,18 +50,37 @@ class ProfileSetupPage extends ConsumerStatefulWidget {
 class _ProfileSetupPageState extends ConsumerState<ProfileSetupPage> {
   final TextEditingController _nicknameController = TextEditingController();
   final FocusNode _nicknameFocusNode = FocusNode();
+  late final FormSubmitController _submitController;
   bool _hasImage = false;
 
-  bool get _canSubmit {
+  bool get _hasValidNickname {
     final nickname = _nicknameController.text.trim();
     return nickname.length >= 2 && nickname.length <= 10;
   }
 
+  bool get _isSubmitting => _submitController.state.isSubmitting;
+
+  @override
+  void initState() {
+    super.initState();
+    _submitController = FormSubmitController()
+      ..addListener(_handleSubmitStateChanged);
+  }
+
   @override
   void dispose() {
+    _submitController
+      ..removeListener(_handleSubmitStateChanged)
+      ..dispose();
     _nicknameFocusNode.dispose();
     _nicknameController.dispose();
     super.dispose();
+  }
+
+  void _handleSubmitStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   Future<void> _openProfileImageSheet() async {
@@ -130,13 +150,19 @@ class _ProfileSetupPageState extends ConsumerState<ProfileSetupPage> {
     _openTerms(TermsReturnDestination.profile);
   }
 
-  void _handleComplete(bool isTermsAccepted) {
-    if (isTermsAccepted) {
-      context.go(AppRoutePaths.home);
-      return;
-    }
+  Future<void> _handleComplete(bool isTermsAccepted) async {
+    await _submitController.submit(() async {
+      if (!mounted) {
+        return;
+      }
 
-    _openTerms(TermsReturnDestination.home);
+      if (isTermsAccepted) {
+        context.go(AppRoutePaths.home);
+        return;
+      }
+
+      _openTerms(TermsReturnDestination.home);
+    });
   }
 
   @override
@@ -246,7 +272,8 @@ class _ProfileSetupPageState extends ConsumerState<ProfileSetupPage> {
                         horizontal: horizontalInset,
                       ),
                       child: _ProfileCompleteButton(
-                        enabled: _canSubmit,
+                        enabled: _hasValidNickname,
+                        isSubmitting: _isSubmitting,
                         onPressed: () => _handleComplete(isTermsAccepted),
                       ),
                     ),
@@ -792,15 +819,17 @@ class _TermsAgreementRow extends StatelessWidget {
 class _ProfileCompleteButton extends StatelessWidget {
   const _ProfileCompleteButton({
     required this.enabled,
+    required this.isSubmitting,
     required this.onPressed,
   });
 
   final bool enabled;
-  final VoidCallback onPressed;
+  final bool isSubmitting;
+  final Future<void> Function() onPressed;
 
   @override
   Widget build(BuildContext context) {
-    if (!enabled) {
+    if (!enabled && !isSubmitting) {
       return CommonButton(
         key: const ValueKey('profileCompleteButton'),
         label: '완료',
@@ -816,7 +845,8 @@ class _ProfileCompleteButton extends StatelessWidget {
       backgroundColor: AppColors.white,
       foregroundColor: AppColors.brandPrimary,
       borderColor: AppColors.brandPrimary,
-      onPressed: onPressed,
+      isLoading: isSubmitting,
+      onPressed: enabled && !isSubmitting ? onPressed : null,
     );
   }
 }

--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -8,6 +8,7 @@ import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_image_add_button.dart';
@@ -34,8 +35,10 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   late final TextEditingController _nameController;
   late final String _initialName;
   late final String? _initialAddress;
+  late final FormSubmitController _submitController;
   String? _address;
-  bool _isSubmitting = false;
+
+  bool get _isSubmitting => _submitController.state.isSubmitting;
 
   @override
   void initState() {
@@ -43,13 +46,24 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     _initialName = widget.isEdit ? _placeEditInitialName : '';
     _initialAddress = null;
     _nameController = TextEditingController(text: _initialName);
+    _submitController = FormSubmitController()
+      ..addListener(_handleSubmitStateChanged);
     _address = _initialAddress;
   }
 
   @override
   void dispose() {
+    _submitController
+      ..removeListener(_handleSubmitStateChanged)
+      ..dispose();
     _nameController.dispose();
     super.dispose();
+  }
+
+  void _handleSubmitStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -106,9 +120,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       return;
     }
 
-    setState(() => _isSubmitting = true);
-
-    try {
+    await _submitController.submit(() async {
       if (widget.placeId case final placeId?) {
         notifier.updatePlace(id: placeId, name: name, address: _address);
         if (mounted) {
@@ -116,21 +128,10 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
         }
       } else {
         if (ref.read(useRemoteApiProvider)) {
-          try {
-            await ref
-                .read(placeRepositoryProvider)
-                .createPlace(CreatePlaceRequest(name: name, address: address!));
-            ref.invalidate(remotePlaceListProvider);
-          } catch (error) {
-            if (!mounted) {
-              return;
-            }
-
-            ScaffoldMessenger.of(
-              context,
-            ).showSnackBar(SnackBar(content: Text('장소 생성에 실패했어요: $error')));
-            return;
-          }
+          await ref
+              .read(placeRepositoryProvider)
+              .createPlace(CreatePlaceRequest(name: name, address: address!));
+          ref.invalidate(remotePlaceListProvider);
         }
 
         if (!mounted) {
@@ -140,11 +141,21 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
         notifier.addPlace(name: name, address: _address);
         context.push(AppRoutePaths.placeFriendAdd);
       }
-    } finally {
-      if (mounted) {
-        setState(() => _isSubmitting = false);
-      }
+    }, failureMessage: widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요');
+
+    _showSubmitErrorIfNeeded();
+  }
+
+  void _showSubmitErrorIfNeeded() {
+    final errorMessage = _submitController.state.errorMessage;
+
+    if (!mounted || errorMessage == null) {
+      return;
     }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 }
 

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -13,6 +13,7 @@ import 'package:commonplant_frontend/features/plant/data/repositories/plant_repo
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
@@ -46,10 +47,12 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
   late final TextEditingController _nameController;
   late final String _selectedPlantName;
+  late final FormSubmitController _submitController;
   String? _selectedPlaceId;
-  bool _isSubmitting = false;
   String _initialEditPlantName = _defaultEditPlantName;
   bool _hasAppliedRemoteEditInfo = false;
+
+  bool get _isSubmitting => _submitController.state.isSubmitting;
 
   static const List<_PlantRegistrationPlace> _places = [
     _PlantRegistrationPlace(
@@ -81,13 +84,24 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     _nameController = TextEditingController(
       text: widget.isEdit ? _defaultEditPlantName : '',
     );
+    _submitController = FormSubmitController()
+      ..addListener(_handleSubmitStateChanged);
     _selectedPlaceId = widget.isEdit ? null : _places.first.id;
   }
 
   @override
   void dispose() {
+    _submitController
+      ..removeListener(_handleSubmitStateChanged)
+      ..dispose();
     _nameController.dispose();
     super.dispose();
+  }
+
+  void _handleSubmitStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override
@@ -248,31 +262,18 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       return;
     }
 
-    setState(() => _isSubmitting = true);
-
-    try {
+    await _submitController.submit(() async {
       if (ref.read(useRemoteApiProvider)) {
-        try {
-          await ref
-              .read(plantRepositoryProvider)
-              .createPlant(
-                CreatePlantRequest(
-                  placeCode: selectedPlace.id,
-                  nickname: _selectedPlantName,
-                  scientificNameKo: _selectedPlantName,
-                ),
-              );
-          ref.invalidate(remotePlantListProvider);
-        } catch (error) {
-          if (!mounted) {
-            return;
-          }
-
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('식물 등록에 실패했어요: $error')));
-          return;
-        }
+        await ref
+            .read(plantRepositoryProvider)
+            .createPlant(
+              CreatePlantRequest(
+                placeCode: selectedPlace.id,
+                nickname: _selectedPlantName,
+                scientificNameKo: _selectedPlantName,
+              ),
+            );
+        ref.invalidate(remotePlantListProvider);
       }
 
       if (!mounted) {
@@ -287,11 +288,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
             placeName: selectedPlace.name,
           );
       context.go(AppRoutePaths.home);
-    } finally {
-      if (mounted) {
-        setState(() => _isSubmitting = false);
-      }
-    }
+    }, failureMessage: '식물 등록에 실패했어요');
+
+    _showSubmitErrorIfNeeded();
   }
 
   Future<void> _submitEdit() async {
@@ -301,29 +300,16 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
     final name = _nameController.text.trim();
 
-    setState(() => _isSubmitting = true);
-
-    try {
+    await _submitController.submit(() async {
       if (ref.read(useRemoteApiProvider) && widget.placeId != null) {
-        try {
-          await ref
-              .read(plantRepositoryProvider)
-              .updatePlant(
-                plantId: widget.plantId!,
-                placeCode: widget.placeId!,
-                request: UpdatePlantRequest(nickname: name),
-              );
-          ref.invalidate(remotePlantListProvider);
-        } catch (error) {
-          if (!mounted) {
-            return;
-          }
-
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('식물 수정에 실패했어요: $error')));
-          return;
-        }
+        await ref
+            .read(plantRepositoryProvider)
+            .updatePlant(
+              plantId: widget.plantId!,
+              placeCode: widget.placeId!,
+              request: UpdatePlantRequest(nickname: name),
+            );
+        ref.invalidate(remotePlantListProvider);
       }
 
       if (!mounted) {
@@ -339,11 +325,21 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
           placeId: widget.placeId,
         ),
       );
-    } finally {
-      if (mounted) {
-        setState(() => _isSubmitting = false);
-      }
+    }, failureMessage: '식물 수정에 실패했어요');
+
+    _showSubmitErrorIfNeeded();
+  }
+
+  void _showSubmitErrorIfNeeded() {
+    final errorMessage = _submitController.state.errorMessage;
+
+    if (!mounted || errorMessage == null) {
+      return;
     }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
   List<_PlantRegistrationPlace> _registrationPlacesFromSummaries(

--- a/lib/shared/forms/form_submit_controller.dart
+++ b/lib/shared/forms/form_submit_controller.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+
+enum FormSubmitStatus { idle, submitting, failure }
+
+class FormSubmitState {
+  const FormSubmitState.idle() : this._(FormSubmitStatus.idle);
+
+  const FormSubmitState.submitting() : this._(FormSubmitStatus.submitting);
+
+  const FormSubmitState.failure(String message)
+    : this._(FormSubmitStatus.failure, errorMessage: message);
+
+  const FormSubmitState._(this.status, {this.errorMessage});
+
+  final FormSubmitStatus status;
+  final String? errorMessage;
+
+  bool get isSubmitting => status == FormSubmitStatus.submitting;
+
+  bool get hasError =>
+      status == FormSubmitStatus.failure && errorMessage != null;
+
+  @override
+  bool operator ==(Object other) {
+    return other is FormSubmitState &&
+        other.status == status &&
+        other.errorMessage == errorMessage;
+  }
+
+  @override
+  int get hashCode => Object.hash(status, errorMessage);
+
+  @override
+  String toString() {
+    return 'FormSubmitState(status: $status, errorMessage: $errorMessage)';
+  }
+}
+
+class FormSubmitController extends ChangeNotifier {
+  FormSubmitController({
+    FormSubmitState initialState = const FormSubmitState.idle(),
+  }) : _state = initialState;
+
+  FormSubmitState _state;
+  bool _isDisposed = false;
+
+  FormSubmitState get state => _state;
+
+  Future<void> submit(
+    Future<void> Function() action, {
+    String failureMessage = '요청 처리에 실패했어요',
+    String Function(Object error)? failureMessageBuilder,
+  }) async {
+    if (_state.isSubmitting) {
+      return;
+    }
+
+    _setState(const FormSubmitState.submitting());
+
+    try {
+      await action();
+      _setState(const FormSubmitState.idle());
+    } catch (error) {
+      final message = failureMessageBuilder?.call(error) ?? failureMessage;
+      _setState(FormSubmitState.failure(message));
+    }
+  }
+
+  void reset() {
+    _setState(const FormSubmitState.idle());
+  }
+
+  void fail(String message) {
+    _setState(FormSubmitState.failure(message));
+  }
+
+  void _setState(FormSubmitState nextState) {
+    if (_isDisposed || _state == nextState) {
+      return;
+    }
+
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -78,6 +78,37 @@ void main() {
     expect(completeButton.onPressed, isNull);
   });
 
+  testWidgets('식물 수정 실패는 공통 제출 오류 메시지를 표시하고 재시도 가능하다', (tester) async {
+    final repository = _FailingPlantUpdateRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(
+          home: PlantFormPage(plantId: 'plant-1', placeId: 'place-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '몬테라');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, '완료'));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 1);
+    expect(find.text('식물 수정에 실패했어요'), findsOneWidget);
+    expect(find.textContaining('raw failure'), findsNothing);
+
+    final completeButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '완료'),
+    );
+    expect(completeButton.onPressed, isNotNull);
+  });
+
   testWidgets('remote loading 상태는 식물 수정 폼 대신 로딩 안내를 표시한다', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
@@ -156,6 +187,27 @@ class _PendingPlantRepository extends PlantRepository {
   }) {
     updateCalls++;
     return _completer.future;
+  }
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    return const PlantEditInfo(name: '몬테');
+  }
+}
+
+class _FailingPlantUpdateRepository extends PlantRepository {
+  _FailingPlantUpdateRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int updateCalls = 0;
+
+  @override
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    required UpdatePlantRequest request,
+  }) async {
+    updateCalls++;
+    throw StateError('raw failure');
   }
 
   @override

--- a/test/shared/forms/form_submit_controller_test.dart
+++ b/test/shared/forms/form_submit_controller_test.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('submit은 진행 중 상태를 노출하고 중복 실행을 막는다', () async {
+    final controller = FormSubmitController();
+    final completer = Completer<void>();
+    final states = <FormSubmitState>[];
+    var submitCalls = 0;
+
+    addTearDown(controller.dispose);
+    controller.addListener(() => states.add(controller.state));
+
+    final submitFuture = controller.submit(() {
+      submitCalls++;
+      return completer.future;
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.state, const FormSubmitState.submitting());
+
+    await controller.submit(() async {
+      submitCalls++;
+    });
+
+    completer.complete();
+    await submitFuture;
+
+    expect(submitCalls, 1);
+    expect(states, [
+      const FormSubmitState.submitting(),
+      const FormSubmitState.idle(),
+    ]);
+  });
+
+  test('submit 실패는 사용자 메시지 상태로 남기고 다시 제출할 수 있다', () async {
+    final controller = FormSubmitController();
+
+    addTearDown(controller.dispose);
+
+    await controller.submit(
+      () async => throw StateError('raw failure'),
+      failureMessage: '저장에 실패했어요',
+    );
+
+    expect(controller.state, const FormSubmitState.failure('저장에 실패했어요'));
+    expect(controller.state.isSubmitting, isFalse);
+
+    await controller.submit(() async {});
+
+    expect(controller.state, const FormSubmitState.idle());
+  });
+}


### PR DESCRIPTION
## 작업 내용
- 공통 `FormSubmitController`와 `FormSubmitState`를 추가해 제출 중, 실패, 재시도 가능 상태를 한 패턴으로 정리했습니다.
- 장소, 식물, 프로필 폼의 제출 중 버튼 잠금/로딩 상태를 공통 상태 값으로 연결했습니다.
- 식물 수정 실패 시 raw exception 대신 사용자용 실패 메시지를 표시하도록 테스트를 보강했습니다.
- 폼 제출 상태 공통 패턴 사용 기준을 문서에 반영했습니다.

## 검증
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #64
