### PR TITLE
Feat: User 검색 화면 연결 #66

### DIFF
--- a/lib/features/place/presentation/pages/place_friend_add_page.dart
+++ b/lib/features/place/presentation/pages/place_friend_add_page.dart
@@ -1,27 +1,33 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/user_search_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 const double _friendAddTrailingWidth = 81;
 
-class PlaceFriendAddPage extends StatefulWidget {
+class PlaceFriendAddPage extends ConsumerStatefulWidget {
   const PlaceFriendAddPage({super.key});
 
   @override
-  State<PlaceFriendAddPage> createState() => _PlaceFriendAddPageState();
+  ConsumerState<PlaceFriendAddPage> createState() => _PlaceFriendAddPageState();
 }
 
-class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
+class _PlaceFriendAddPageState extends ConsumerState<PlaceFriendAddPage> {
   final TextEditingController _searchController = TextEditingController();
   final Set<String> _selectedIds = <String>{};
+  final Map<String, PlaceFriendProfile> _remoteSelectedFriends =
+      <String, PlaceFriendProfile>{};
 
   static const List<PlaceFriendProfile> _friends = [
     PlaceFriendProfile(
@@ -57,8 +63,21 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
     setState(() {
       if (_selectedIds.contains(id)) {
         _selectedIds.remove(id);
+        _remoteSelectedFriends.remove(id);
       } else {
         _selectedIds.add(id);
+      }
+    });
+  }
+
+  void _toggleRemote(PlaceFriendProfile friend) {
+    setState(() {
+      if (_selectedIds.contains(friend.id)) {
+        _selectedIds.remove(friend.id);
+        _remoteSelectedFriends.remove(friend.id);
+      } else {
+        _selectedIds.add(friend.id);
+        _remoteSelectedFriends[friend.id] = friend;
       }
     });
   }
@@ -81,12 +100,13 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
   @override
   Widget build(BuildContext context) {
     final query = _searchController.text.trim();
-    final results = query.isEmpty
+    final useRemoteApi = ref.watch(useRemoteApiProvider);
+    final localResults = query.isEmpty
         ? const <PlaceFriendProfile>[]
         : _friends.where((friend) => friend.name.contains(query)).toList();
-    final selectedFriends = _friends
-        .where((friend) => _selectedIds.contains(friend.id))
-        .toList();
+    final selectedFriends = useRemoteApi
+        ? _remoteSelectedFriends.values.toList()
+        : _friends.where((friend) => _selectedIds.contains(friend.id)).toList();
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -116,11 +136,17 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
                 onChanged: (_) => setState(() {}),
               ),
               Expanded(
-                child: PlaceFriendCandidateList(
-                  friends: results,
-                  selectedIds: _selectedIds,
-                  onToggle: _toggle,
-                ),
+                child: useRemoteApi
+                    ? _RemoteFriendCandidateList(
+                        query: query,
+                        selectedIds: _selectedIds,
+                        onToggle: _toggleRemote,
+                      )
+                    : PlaceFriendCandidateList(
+                        friends: localResults,
+                        selectedIds: _selectedIds,
+                        onToggle: _toggle,
+                      ),
               ),
               PlaceFriendBottomActions(
                 onCancel: _cancel,
@@ -128,6 +154,129 @@ class _PlaceFriendAddPageState extends State<PlaceFriendAddPage> {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RemoteFriendCandidateList extends ConsumerWidget {
+  const _RemoteFriendCandidateList({
+    required this.query,
+    required this.selectedIds,
+    required this.onToggle,
+  });
+
+  final String query;
+  final Set<String> selectedIds;
+  final ValueChanged<PlaceFriendProfile> onToggle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (query.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final users = ref.watch(userSearchProvider(query));
+
+    return users.when(
+      data: (items) {
+        final friends = _friendsFromUsers(items);
+
+        if (friends.isEmpty) {
+          return const _FriendSearchStatusView(
+            title: '검색 결과가 없어요',
+            message: '다른 닉네임으로 검색해 주세요',
+          );
+        }
+
+        return PlaceFriendCandidateList(
+          friends: friends,
+          selectedIds: selectedIds,
+          onToggle: (id) {
+            final friend = friends.firstWhere((friend) => friend.id == id);
+            onToggle(friend);
+          },
+        );
+      },
+      error: (error, stackTrace) => _FriendSearchStatusView(
+        title: '사용자 검색에 실패했어요',
+        message: '잠시 후 다시 시도해 주세요',
+        actionLabel: '다시 시도',
+        onAction: () => ref.invalidate(userSearchProvider(query)),
+      ),
+      loading: () => const _FriendSearchStatusView(
+        title: '사용자를 검색하고 있어요',
+        message: '닉네임 검색 결과를 준비하고 있어요',
+        isLoading: true,
+      ),
+    );
+  }
+
+  List<PlaceFriendProfile> _friendsFromUsers(List<UserProfile> users) {
+    return [
+      for (final user in users)
+        PlaceFriendProfile(id: user.id, name: user.name),
+    ];
+  }
+}
+
+class _FriendSearchStatusView extends StatelessWidget {
+  const _FriendSearchStatusView({
+    required this.title,
+    required this.message,
+    this.isLoading = false,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final String title;
+  final String message;
+  final bool isLoading;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isLoading) ...[
+              const SizedBox.square(
+                dimension: AppSizes.iconLarge,
+                child: CircularProgressIndicator(strokeWidth: 3),
+              ),
+              const SizedBox(height: AppSpacing.x16),
+            ],
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size16Medium.copyWith(
+                color: AppColors.textStrong,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: AppTextStyles.size14Medium.copyWith(
+                color: AppColors.textBody,
+              ),
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: AppSpacing.x16),
+              SizedBox(
+                width: AppSizes.smallButtonWidth,
+                child: TextButton(
+                  onPressed: onAction,
+                  child: Text(actionLabel!),
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/lib/features/user/presentation/providers/user_search_provider.dart
+++ b/lib/features/user/presentation/providers/user_search_provider.dart
@@ -1,0 +1,16 @@
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final userSearchProvider = FutureProvider.family<List<UserProfile>, String>((
+  ref,
+  keyword,
+) {
+  final normalizedKeyword = keyword.trim();
+
+  if (normalizedKeyword.isEmpty) {
+    return const <UserProfile>[];
+  }
+
+  return ref.watch(userRepositoryProvider).searchUsers(normalizedKeyword);
+}, retry: (retryCount, error) => null);

--- a/test/features/place/presentation/pages/place_friend_add_page_test.dart
+++ b/test/features/place/presentation/pages/place_friend_add_page_test.dart
@@ -1,10 +1,18 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_friend_add_page.dart';
+import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('친구 추가 기본 화면은 검색 전 결과 없이 액션을 표시한다', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlaceFriendAddPage()));
+    await tester.pumpWidget(_friendAddApp());
 
     expect(find.text('친구 추가'), findsOneWidget);
     expect(find.text('건너뛰기'), findsOneWidget);
@@ -16,7 +24,7 @@ void main() {
   });
 
   testWidgets('친구 닉네임 검색 후 결과를 선택할 수 있다', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlaceFriendAddPage()));
+    await tester.pumpWidget(_friendAddApp());
 
     await tester.enterText(find.byType(TextField), '커먼');
     await tester.pumpAndSettle();
@@ -42,7 +50,7 @@ void main() {
   });
 
   testWidgets('선택된 친구 마크 삭제 버튼으로 선택을 해제한다', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlaceFriendAddPage()));
+    await tester.pumpWidget(_friendAddApp());
 
     await tester.enterText(find.byType(TextField), '커먼');
     await tester.pumpAndSettle();
@@ -69,4 +77,119 @@ void main() {
     expect(find.byIcon(Icons.radio_button_unchecked), findsNWidgets(5));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('remote 검색 중에는 로딩 안내를 표시한다', (WidgetTester tester) async {
+    await tester.pumpWidget(_friendAddRemoteApp(_PendingUserRepository()));
+
+    await tester.enterText(find.byType(TextField), '커먼');
+    await tester.pump();
+
+    expect(find.text('사용자를 검색하고 있어요'), findsOneWidget);
+    expect(find.text('커먼맘'), findsNothing);
+  });
+
+  testWidgets('remote 검색 결과가 없으면 empty 안내를 표시한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _friendAddRemoteApp(_StaticUserRepository(const [])),
+    );
+
+    await tester.enterText(find.byType(TextField), '없는친구');
+    await tester.pumpAndSettle();
+
+    expect(find.text('검색 결과가 없어요'), findsOneWidget);
+    expect(find.text('다른 닉네임으로 검색해 주세요'), findsOneWidget);
+  });
+
+  testWidgets('remote 검색 실패는 재시도 후 결과를 표시한다', (WidgetTester tester) async {
+    final repository = _RetryUserRepository();
+
+    await tester.pumpWidget(_friendAddRemoteApp(repository));
+
+    await tester.enterText(find.byType(TextField), '커먼');
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('사용자 검색에 실패했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.tap(find.text('다시 시도'));
+    await tester.pumpAndSettle();
+
+    expect(repository.searchCalls, 2);
+    expect(find.text('커먼맘'), findsOneWidget);
+    expect(find.text('사용자 검색에 실패했어요'), findsNothing);
+  });
+
+  testWidgets('remote 검색 결과를 선택할 수 있다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _friendAddRemoteApp(
+        _StaticUserRepository(const [UserProfile(id: 'user-1', name: '커먼맘')]),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), '커먼');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('커먼맘'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('selected-friend-user-1')),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}
+
+Widget _friendAddApp() {
+  return const ProviderScope(child: MaterialApp(home: PlaceFriendAddPage()));
+}
+
+Widget _friendAddRemoteApp(UserRepository repository) {
+  return ProviderScope(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      userRepositoryProvider.overrideWithValue(repository),
+    ],
+    child: const MaterialApp(home: PlaceFriendAddPage()),
+  );
+}
+
+class _PendingUserRepository extends UserRepository {
+  _PendingUserRepository() : super(UserRemoteDataSource(Dio()));
+
+  final Completer<List<UserProfile>> _completer =
+      Completer<List<UserProfile>>();
+
+  @override
+  Future<List<UserProfile>> searchUsers(String keyword) {
+    return _completer.future;
+  }
+}
+
+class _StaticUserRepository extends UserRepository {
+  _StaticUserRepository(this.users) : super(UserRemoteDataSource(Dio()));
+
+  final List<UserProfile> users;
+
+  @override
+  Future<List<UserProfile>> searchUsers(String keyword) async {
+    return users;
+  }
+}
+
+class _RetryUserRepository extends UserRepository {
+  _RetryUserRepository() : super(UserRemoteDataSource(Dio()));
+
+  int searchCalls = 0;
+
+  @override
+  Future<List<UserProfile>> searchUsers(String keyword) async {
+    searchCalls++;
+
+    if (searchCalls == 1) {
+      throw StateError('network');
+    }
+
+    return const [UserProfile(id: 'user-1', name: '커먼맘')];
+  }
 }

--- a/test/features/user/presentation/providers/user_search_provider_test.dart
+++ b/test/features/user/presentation/providers/user_search_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/user_search_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('빈 검색어는 repository를 호출하지 않고 빈 목록을 반환한다', () async {
+    final repository = _UserSearchRepository();
+    final container = ProviderContainer(
+      overrides: [userRepositoryProvider.overrideWithValue(repository)],
+    );
+    addTearDown(container.dispose);
+
+    final users = await container.read(userSearchProvider('  ').future);
+
+    expect(users, isEmpty);
+    expect(repository.searchCalls, 0);
+  });
+
+  test('검색어가 있으면 UserRepository.searchUsers 결과를 반환한다', () async {
+    final repository = _UserSearchRepository(
+      users: const [
+        UserProfile(id: 'user-1', name: '커먼맘'),
+        UserProfile(id: 'user-2', name: '커먼 파파'),
+      ],
+    );
+    final container = ProviderContainer(
+      overrides: [userRepositoryProvider.overrideWithValue(repository)],
+    );
+    addTearDown(container.dispose);
+
+    final users = await container.read(userSearchProvider(' 커먼 ').future);
+
+    expect(repository.searchCalls, 1);
+    expect(repository.lastKeyword, '커먼');
+    expect(users.map((user) => user.name), ['커먼맘', '커먼 파파']);
+  });
+}
+
+class _UserSearchRepository extends UserRepository {
+  _UserSearchRepository({this.users = const []})
+    : super(UserRemoteDataSource(Dio()));
+
+  final List<UserProfile> users;
+  int searchCalls = 0;
+  String? lastKeyword;
+
+  @override
+  Future<List<UserProfile>> searchUsers(String keyword) async {
+    searchCalls++;
+    lastKeyword = keyword;
+
+    return users;
+  }
+}


### PR DESCRIPTION
## 작업 내용
- `userSearchProvider`를 추가해 User 검색 API를 화면에서 override/test 가능한 형태로 연결했습니다.
- API mode에서 친구 추가 화면의 닉네임 검색이 `UserRepository.searchUsers` 결과를 사용하도록 분기했습니다.
- remote 검색의 loading, empty, error, retry, success 선택 흐름을 추가했습니다.
- 기존 local mock 검색 UX는 API mode가 아닐 때 그대로 유지했습니다.

## 검증
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #66
