### PR TITLE
Feat: Place API 화면 연결 #70

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
@@ -7,8 +9,10 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
@@ -30,11 +34,41 @@ PlaceDetailRole? placeDetailRoleFromQuery(String? value) {
   };
 }
 
-class PlaceDetailPage extends ConsumerWidget {
+class PlaceDetailPage extends ConsumerStatefulWidget {
   const PlaceDetailPage({super.key, required this.placeId, this.role});
 
   final String placeId;
   final PlaceDetailRole? role;
+
+  @override
+  ConsumerState<PlaceDetailPage> createState() => _PlaceDetailPageState();
+}
+
+class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
+  late final FormSubmitController _exitController;
+
+  bool get _isExiting => _exitController.state.isSubmitting;
+
+  @override
+  void initState() {
+    super.initState();
+    _exitController = FormSubmitController()
+      ..addListener(_handleExitStateChanged);
+  }
+
+  @override
+  void dispose() {
+    _exitController
+      ..removeListener(_handleExitStateChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _handleExitStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
 
   void _showExitDialog(BuildContext context) {
     showCommonDialog<void>(
@@ -51,7 +85,7 @@ class PlaceDetailPage extends ConsumerWidget {
           CommonDialogActionButton.confirm(
             label: '나가기',
             foregroundColor: AppColors.danger,
-            onPressed: () => Navigator.of(context).pop(),
+            onPressed: _isExiting ? null : () => _confirmExit(context),
           ),
         ],
       ),
@@ -59,14 +93,14 @@ class PlaceDetailPage extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final mockDetail = _PlaceDetailData.mock(placeId, role: role);
+  Widget build(BuildContext context) {
+    final mockDetail = _PlaceDetailData.mock(widget.placeId, role: widget.role);
 
     if (!ref.watch(useRemoteApiProvider)) {
       return _buildScaffold(context, mockDetail);
     }
 
-    final remoteDetail = ref.watch(placeDetailProvider(placeId));
+    final remoteDetail = ref.watch(placeDetailProvider(widget.placeId));
 
     return remoteDetail.when(
       data: (summary) {
@@ -93,7 +127,7 @@ class PlaceDetailPage extends ConsumerWidget {
             message: '잠시 후 다시 시도해 주세요',
             semanticsLabel: '장소 정보 오류',
             actionLabel: '다시 시도',
-            onAction: () => ref.invalidate(placeDetailProvider(placeId)),
+            onAction: () => ref.invalidate(placeDetailProvider(widget.placeId)),
           ),
         );
       },
@@ -110,6 +144,37 @@ class PlaceDetailPage extends ConsumerWidget {
     );
   }
 
+  void _confirmExit(BuildContext context) {
+    Navigator.of(context).pop();
+    unawaited(_exitPlace(context));
+  }
+
+  Future<void> _exitPlace(BuildContext context) async {
+    if (!ref.read(useRemoteApiProvider)) {
+      return;
+    }
+
+    await _exitController.submit(() async {
+      await ref.read(placeRepositoryProvider).deletePlace(widget.placeId);
+      ref.invalidate(placeDetailProvider(widget.placeId));
+      ref.invalidate(remotePlaceListProvider);
+      ref.invalidate(plantRegistrationPlaceProvider);
+    }, failureMessage: '장소 나가기에 실패했어요');
+
+    if (!mounted || !context.mounted) {
+      return;
+    }
+
+    if (_exitController.state.hasError) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_exitController.state.errorMessage!)),
+      );
+      return;
+    }
+
+    context.go(AppRoutePaths.home);
+  }
+
   Widget _buildScaffold(BuildContext context, _PlaceDetailData detail) {
     return CommonScaffold(
       title: 'My place',
@@ -119,7 +184,7 @@ class PlaceDetailPage extends ConsumerWidget {
       ),
       bodyPadding: EdgeInsets.zero,
       floatingActionButton: _PlaceDetailFab(
-        placeId: placeId,
+        placeId: widget.placeId,
         role: detail.role,
         onExit: () => _showExitDialog(context),
       ),
@@ -130,8 +195,8 @@ class PlaceDetailPage extends ConsumerWidget {
             constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
             child: Column(
               children: [
-                _PlaceDetailHeader(detail: detail, placeId: placeId),
-                _PlacePlantList(placeId: placeId, plants: detail.plants),
+                _PlaceDetailHeader(detail: detail, placeId: widget.placeId),
+                _PlacePlantList(placeId: widget.placeId, plants: detail.plants),
               ],
             ),
           ),

--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -33,10 +33,11 @@ class PlaceFormPage extends ConsumerStatefulWidget {
 
 class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   late final TextEditingController _nameController;
-  late final String _initialName;
-  late final String? _initialAddress;
   late final FormSubmitController _submitController;
+  late String _initialName;
+  String? _initialAddress;
   String? _address;
+  String? _remoteInitialPlaceId;
 
   bool get _isSubmitting => _submitController.state.isSubmitting;
 
@@ -68,6 +69,45 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.isEdit && ref.watch(useRemoteApiProvider)) {
+      final placeId = widget.placeId!;
+      final remoteDetail = ref.watch(placeDetailProvider(placeId));
+
+      return remoteDetail.when(
+        loading: () {
+          return const _PlaceFormStatusScaffold(
+            title: '장소 정보를 불러오고 있어요',
+            message: '장소 수정 정보를 준비하고 있어요',
+            isLoading: true,
+          );
+        },
+        error: (error, stackTrace) {
+          return _PlaceFormStatusScaffold(
+            title: '장소 정보를 불러오지 못했어요',
+            message: '잠시 후 다시 시도해 주세요',
+            actionLabel: '다시 시도',
+            onAction: () => ref.invalidate(placeDetailProvider(placeId)),
+          );
+        },
+        data: (summary) {
+          if (summary.name.trim().isEmpty) {
+            return const _PlaceFormStatusScaffold(
+              title: '장소 정보를 찾을 수 없어요',
+              message: '다시 장소 목록에서 선택해 주세요',
+            );
+          }
+
+          _applyRemoteSummary(summary);
+
+          return _buildForm(context);
+        },
+      );
+    }
+
+    return _buildForm(context);
+  }
+
+  Widget _buildForm(BuildContext context) {
     final currentName = _nameController.text.trim();
     final hasChanges =
         !widget.isEdit ||
@@ -102,6 +142,20 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     );
   }
 
+  void _applyRemoteSummary(PlaceSummary summary) {
+    final placeId = widget.placeId;
+
+    if (placeId == null || _remoteInitialPlaceId == placeId) {
+      return;
+    }
+
+    _remoteInitialPlaceId = placeId;
+    _initialName = summary.name;
+    _initialAddress = summary.address;
+    _address = summary.address;
+    _nameController.text = summary.name;
+  }
+
   Future<void> _submit() async {
     if (_isSubmitting) {
       return;
@@ -120,28 +174,55 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       return;
     }
 
-    await _submitController.submit(() async {
-      if (widget.placeId case final placeId?) {
-        notifier.updatePlace(id: placeId, name: name, address: _address);
-        if (mounted) {
-          context.go(AppRoutePaths.home);
+    await _submitController.submit(
+      () async {
+        if (widget.placeId case final placeId?) {
+          if (ref.read(useRemoteApiProvider)) {
+            if (address == null || address.isEmpty) {
+              throw const _PlaceFormValidationException('장소 주소를 입력해 주세요.');
+            }
+
+            await ref
+                .read(placeRepositoryProvider)
+                .updatePlace(
+                  code: placeId,
+                  request: UpdatePlaceRequest(name: name, address: address),
+                );
+            ref.invalidate(placeDetailProvider(placeId));
+            ref.invalidate(remotePlaceListProvider);
+            ref.invalidate(plantRegistrationPlaceProvider);
+          } else {
+            notifier.updatePlace(id: placeId, name: name, address: _address);
+          }
+
+          if (mounted) {
+            context.go(AppRoutePaths.home);
+          }
+        } else {
+          if (ref.read(useRemoteApiProvider)) {
+            await ref
+                .read(placeRepositoryProvider)
+                .createPlace(CreatePlaceRequest(name: name, address: address!));
+            ref.invalidate(remotePlaceListProvider);
+          }
+
+          if (!mounted) {
+            return;
+          }
+
+          notifier.addPlace(name: name, address: _address);
+          context.push(AppRoutePaths.placeFriendAdd);
         }
-      } else {
-        if (ref.read(useRemoteApiProvider)) {
-          await ref
-              .read(placeRepositoryProvider)
-              .createPlace(CreatePlaceRequest(name: name, address: address!));
-          ref.invalidate(remotePlaceListProvider);
+      },
+      failureMessage: widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요',
+      failureMessageBuilder: (error) {
+        if (error case _PlaceFormValidationException(:final message)) {
+          return message;
         }
 
-        if (!mounted) {
-          return;
-        }
-
-        notifier.addPlace(name: name, address: _address);
-        context.push(AppRoutePaths.placeFriendAdd);
-      }
-    }, failureMessage: widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요');
+        return widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요';
+      },
+    );
 
     _showSubmitErrorIfNeeded();
   }
@@ -156,6 +237,99 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
+  }
+}
+
+class _PlaceFormValidationException implements Exception {
+  const _PlaceFormValidationException(this.message);
+
+  final String message;
+}
+
+class _PlaceFormStatusScaffold extends StatelessWidget {
+  const _PlaceFormStatusScaffold({
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+    this.isLoading = false,
+  });
+
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            CommonNavigationBar(
+              title: '장소 수정',
+              titleStyle: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.x20,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (isLoading)
+                        SizedBox.square(
+                          dimension: AppSizes.iconLarge,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 3,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              AppColors.brandStrong,
+                            ),
+                          ),
+                        ),
+                      const SizedBox(height: AppSpacing.x16),
+                      Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.size18Medium.copyWith(
+                          color: AppColors.textStrong,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.x8),
+                      Text(
+                        message,
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.size14Medium.copyWith(
+                          color: AppColors.textBody,
+                        ),
+                      ),
+                      if (actionLabel != null && onAction != null) ...[
+                        const SizedBox(height: AppSpacing.x24),
+                        SizedBox(
+                          width: AppSizes.smallButtonWidth,
+                          child: CommonButton.secondary(
+                            label: actionLabel!,
+                            size: CommonButtonSize.medium,
+                            onPressed: onAction,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
   testWidgets('리더는 FAB에서 장소 수정 액션을 확인할 수 있다', (tester) async {
@@ -122,10 +123,59 @@ void main() {
     expect(find.text('옥상 정원'), findsOneWidget);
     expect(find.text('장소 정보를 불러오지 못했어요'), findsNothing);
   });
+
+  testWidgets('remote 장소 나가기 확인은 삭제 API를 호출하고 홈으로 이동한다', (tester) async {
+    final repository = _DeletablePlaceRepository(
+      const PlaceSummary(
+        id: 'remote-place',
+        name: '옥상 정원',
+        address: '서울시 노원구 광운로 20',
+      ),
+    );
+
+    await tester.pumpWidget(_remotePlaceDetailApp(repository));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('장소 상세 메뉴'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('장소 나가기'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('나가기'));
+    await tester.pumpAndSettle();
+
+    expect(repository.deleteCalls, 1);
+    expect(repository.latestDeleteCode, 'remote-place');
+    expect(find.text('홈'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 Widget _buildPlaceDetailApp(Widget home) {
   return ProviderScope(child: MaterialApp(home: home));
+}
+
+Widget _remotePlaceDetailApp(PlaceRepository repository) {
+  final router = GoRouter(
+    initialLocation: '/places/remote-place',
+    routes: [
+      GoRoute(path: '/', builder: (context, state) => const Text('홈')),
+      GoRoute(
+        path: '/places/:placeId',
+        builder: (context, state) => PlaceDetailPage(
+          placeId: state.pathParameters['placeId'] ?? '',
+          role: PlaceDetailRole.leader,
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      placeRepositoryProvider.overrideWithValue(repository),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
 }
 
 class _PendingPlaceRepository extends PlaceRepository {
@@ -168,5 +218,24 @@ class _RetryPlaceRepository extends PlaceRepository {
       name: '옥상 정원',
       address: '서울시 노원구 광운로 20',
     );
+  }
+}
+
+class _DeletablePlaceRepository extends PlaceRepository {
+  _DeletablePlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+  int deleteCalls = 0;
+  String? latestDeleteCode;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    return summary;
+  }
+
+  @override
+  Future<void> deletePlace(String code) async {
+    deleteCalls++;
+    latestDeleteCode = code;
   }
 }

--- a/test/features/place/presentation/pages/place_form_page_test.dart
+++ b/test/features/place/presentation/pages/place_form_page_test.dart
@@ -4,11 +4,13 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_form_page.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
   testWidgets('장소 수정 화면은 기존 장소 정보와 비활성 완료 버튼을 표시한다', (
@@ -75,6 +77,54 @@ void main() {
     expect(find.text('장소 주소를 입력해 주세요.'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('remote 장소 수정 화면은 조회값으로 초기화하고 수정 API를 호출한다', (tester) async {
+    final repository = _EditablePlaceRepository(
+      const PlaceSummary(id: 'place-1', name: '루프탑', address: '서울시 성북구'),
+    );
+
+    await tester.pumpWidget(_remotePlaceEditApp(repository));
+    await tester.pumpAndSettle();
+
+    expect(find.text('루프탑'), findsOneWidget);
+    expect(find.text('서울시 성북구'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), '루프탑 정원');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, '완료'));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 1);
+    expect(repository.latestUpdateCode, 'place-1');
+    expect(repository.latestUpdateRequest?.toJson(), {
+      'name': '루프탑 정원',
+      'address': '서울시 성북구',
+    });
+    expect(find.text('홈'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _remotePlaceEditApp(PlaceRepository repository) {
+  final router = GoRouter(
+    initialLocation: '/places/place-1/edit',
+    routes: [
+      GoRoute(path: '/', builder: (context, state) => const Text('홈')),
+      GoRoute(
+        path: '/places/:placeId/edit',
+        builder: (context, state) =>
+            PlaceFormPage(placeId: state.pathParameters['placeId']),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      placeRepositoryProvider.overrideWithValue(repository),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
 }
 
 class _PendingPlaceRepository extends PlaceRepository {
@@ -87,5 +137,29 @@ class _PendingPlaceRepository extends PlaceRepository {
   Future<void> createPlace(CreatePlaceRequest request) {
     createCalls++;
     return _completer.future;
+  }
+}
+
+class _EditablePlaceRepository extends PlaceRepository {
+  _EditablePlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+  int updateCalls = 0;
+  String? latestUpdateCode;
+  UpdatePlaceRequest? latestUpdateRequest;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    return summary;
+  }
+
+  @override
+  Future<void> updatePlace({
+    required String code,
+    required UpdatePlaceRequest request,
+  }) async {
+    updateCalls++;
+    latestUpdateCode = code;
+    latestUpdateRequest = request;
   }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #70

## 구현 범위

- API mode 장소 수정 화면에서 `placeDetailProvider` 조회값으로 이름/주소를 초기화합니다.
- 장소 수정 제출 시 `PUT /place/update/{code}` repository 호출 후 Place 관련 Provider를 갱신합니다.
- API mode 장소 상세의 `장소 나가기` 확인 액션에서 `DELETE /place/delete/{code}` repository 호출 후 홈으로 이동합니다.
- Place API 성공 response schema가 아직 없으므로 create/update/delete는 기존 API 계층처럼 성공 body를 읽지 않는 `void` 경계로 유지했습니다.

## 테스트

- remote 장소 수정 화면 초기화 및 update API 호출 테스트 추가
- remote 장소 나가기 확인 후 delete API 호출 및 홈 이동 테스트 추가

## 검증

- `/Users/ywkim/fvm/bin/fvm dart format --output=none --set-exit-if-changed .` 통과
- `/Users/ywkim/fvm/bin/fvm flutter analyze` 통과
- `/Users/ywkim/fvm/bin/fvm flutter test` 통과
- `git diff --check` 통과

## 리뷰 포인트

- 현재 UI 문구는 Figma 기준 `장소 나가기`를 유지하고, API endpoint는 Swagger의 `DELETE /place/delete/{code}`를 사용했습니다.
- Place 성공 response body schema가 확정되기 전까지 mapper 확장은 보류했습니다.

## 문서 반영

- 기존 `docs/api-swagger-reference.md`의 Place response schema 확인 필요 항목을 따르며, 이번 PR에서는 문서 변경 없이 화면 연결만 반영했습니다.

## Breaking change

없음
