### PR TITLE
Feat: Image API 연결 보강 #74

### DIFF
--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -535,11 +535,27 @@
 - 반영: `createPlaceReq`는 `address`가 required이므로 장소 생성 요청 DTO와 API mode 제출 전 검증을 조정했다.
 - 반영: User 조회/수정/검색 DTO와 datasource/repository는 `UserResponse`, `UserListJsonResponse`, `UserUpdateMultipartRequest` 기준으로 추가했다.
 - 반영: `PUT /users`는 multipart `user` JSON part와 optional `image` part를 사용하는 datasource로 구성했다.
+- 반영: `UserRepository.updateMe`는 화면의 이미지 선택 흐름이 `MultipartFile`을 확보하면 optional `image` part를 전달할 수 있도록 열어두었다.
 - 반영: `GET /users/{keyword}`는 사용자 검색 datasource/repository 후보로 추가했다.
+- 반영: `POST /place/create`와 `PUT /place/update/{code}`는 optional `image` part를 datasource/repository 경계에서 전달할 수 있도록 보강했다.
 - 반영: `PUT /place/update/{code}`는 multipart 전송 datasource/repository를 추가했다.
+- 반영: `POST /plants`와 `PUT /plants/{plantId}`는 optional `image` part를 datasource/repository 경계에서 전달할 수 있도록 보강했다.
 - 반영: Auth login DTO는 Swagger의 `newUser` 필드명을 명시적으로 보존한다.
 - 반영: Friend 요청 목록/전송/수락/거절 endpoint는 response schema가 없으므로 raw 또는 void 경계로 datasource/repository만 추가했다.
 - 반영: Image 업로드/조회/수정/삭제 endpoint는 response schema가 없으므로 raw 또는 void 경계로 datasource/repository만 추가했다.
+
+### Image 화면 연결 판단
+
+현재 화면에서 안전하게 열어둘 수 있는 범위는 도메인 API의 optional `image` multipart part까지이다. 프로필 수정, 장소 생성/수정, 식물 생성/수정은 실제 파일 선택기가 `MultipartFile`을 제공하면 repository에 전달할 수 있다.
+
+독립형 Image API(`/s3/images`)는 response schema가 없어 화면에서 반환된 image key/url을 확정적으로 읽을 수 없다. 따라서 프로필, 장소, 식물, 메모 화면에서 `/s3/images` 업로드 결과를 `imageKey`, `imgUrl`, `imageUrl`로 임의 매핑하지 않는다.
+
+현재 보류 범위:
+
+- 프로필 설정의 회원가입 이미지 업로드는 `POST /auth/register` request schema 충돌이 있어 연결하지 않는다.
+- 장소/식물 화면은 도메인 multipart `image` part 전달 경계까지만 열어두고, 실제 파일 선택기 도입은 별도 UI 작업에서 진행한다.
+- 메모 화면은 아직 Memo API가 없어 로컬 사진 상태만 유지한다.
+- `/s3/images` 다운로드 URL 조회는 성공 response의 URL 필드 또는 wrapper 구조가 확정된 뒤 화면 fallback 정책과 함께 연결한다.
 
 ## 백엔드에 다시 확인해야 할 부분
 
@@ -556,6 +572,8 @@
 - `sendFriendReq.receiverName`이 사용자 display name 배열인지, 고유 user id 배열인지 확인해야 한다.
 - `friendDecisionReq.friendId`가 요청 id인지 사용자 id인지 확인해야 한다.
 - Image API의 upload/download/update/delete 성공 response schema와 반환되는 image key/url 필드명이 필요하다. 현재 코드는 raw response까지만 받는다.
+- 화면 이미지 업로드가 `/s3/images` 선업로드 후 image key를 도메인 API에 전달하는 방식인지, 각 도메인 API의 optional `image` part를 직접 사용하는 방식인지 확인해야 한다.
+- `/s3/images`의 presigned download URL 응답이 문자열인지, `{ url }`, `{ imageUrl }`, `{ downloadUrl }` 같은 object인지, 공통 wrapper `result` 안에 들어가는지 확인해야 한다.
 - 에러 응답 body schema와 `code`, `message` 필드명이 필요하다.
 - refresh token 재발급과 로그아웃 API 제공 여부를 확인해야 한다.
 - 주소 검색, 식물 검색, 메모 API 제공 계획을 확인해야 한다.

--- a/lib/features/place/data/datasources/place_remote_data_source.dart
+++ b/lib/features/place/data/datasources/place_remote_data_source.dart
@@ -39,7 +39,10 @@ class PlaceRemoteDataSource {
     }
   }
 
-  Future<void> createPlace(CreatePlaceRequest request) async {
+  Future<void> createPlace(
+    CreatePlaceRequest request, {
+    MultipartFile? image,
+  }) async {
     try {
       await _dio.post<Object?>(
         '/place/create',
@@ -48,6 +51,7 @@ class PlaceRemoteDataSource {
             jsonEncode(request.toJson()),
             contentType: DioMediaType('application', 'json'),
           ),
+          if (image != null) 'image': image,
         }),
       );
     } on DioException catch (error) {

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -3,6 +3,7 @@ import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final placeRemoteDataSourceProvider = Provider<PlaceRemoteDataSource>((ref) {
@@ -39,15 +40,20 @@ class PlaceRepository {
     return placeSummaryFromJson(object, fallbackId: code);
   }
 
-  Future<void> createPlace(CreatePlaceRequest request) {
-    return _remoteDataSource.createPlace(request);
+  Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image}) {
+    return _remoteDataSource.createPlace(request, image: image);
   }
 
   Future<void> updatePlace({
     required String code,
     required UpdatePlaceRequest request,
+    MultipartFile? image,
   }) {
-    return _remoteDataSource.updatePlace(code: code, request: request);
+    return _remoteDataSource.updatePlace(
+      code: code,
+      request: request,
+      image: image,
+    );
   }
 
   Future<void> deletePlace(String code) {

--- a/lib/features/plant/data/datasources/plant_remote_data_source.dart
+++ b/lib/features/plant/data/datasources/plant_remote_data_source.dart
@@ -22,7 +22,10 @@ class PlantRemoteDataSource {
     }
   }
 
-  Future<void> createPlant(CreatePlantRequest request) async {
+  Future<void> createPlant(
+    CreatePlantRequest request, {
+    MultipartFile? image,
+  }) async {
     try {
       await _dio.post<Object?>(
         '/plants',
@@ -31,6 +34,7 @@ class PlantRemoteDataSource {
             jsonEncode(request.toJson()),
             contentType: DioMediaType('application', 'json'),
           ),
+          if (image != null) 'image': image,
         }),
       );
     } on DioException catch (error) {
@@ -62,6 +66,7 @@ class PlantRemoteDataSource {
     required String plantId,
     required String placeCode,
     required UpdatePlantRequest request,
+    MultipartFile? image,
   }) async {
     try {
       await _dio.put<Object?>(
@@ -72,6 +77,7 @@ class PlantRemoteDataSource {
             jsonEncode(request.toJson()),
             contentType: DioMediaType('application', 'json'),
           ),
+          if (image != null) 'image': image,
         }),
       );
     } on DioException catch (error) {

--- a/lib/features/plant/data/repositories/plant_repository.dart
+++ b/lib/features/plant/data/repositories/plant_repository.dart
@@ -4,6 +4,7 @@ import 'package:commonplant_frontend/features/plant/data/datasources/plant_remot
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final plantRemoteDataSourceProvider = Provider<PlantRemoteDataSource>((ref) {
@@ -26,8 +27,8 @@ class PlantRepository {
     return [for (final item in items) plantSummaryFromJson(item)];
   }
 
-  Future<void> createPlant(CreatePlantRequest request) {
-    return _remoteDataSource.createPlant(request);
+  Future<void> createPlant(CreatePlantRequest request, {MultipartFile? image}) {
+    return _remoteDataSource.createPlant(request, image: image);
   }
 
   Future<PlantDetail> fetchPlant({required String plantId}) async {
@@ -48,11 +49,13 @@ class PlantRepository {
     required String plantId,
     required String placeCode,
     required UpdatePlantRequest request,
+    MultipartFile? image,
   }) {
     return _remoteDataSource.updatePlant(
       plantId: plantId,
       placeCode: placeCode,
       request: request,
+      image: image,
     );
   }
 

--- a/lib/features/user/data/repositories/user_repository.dart
+++ b/lib/features/user/data/repositories/user_repository.dart
@@ -3,6 +3,7 @@ import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
 import 'package:commonplant_frontend/features/user/data/dtos/user_requests.dart';
 import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final userRemoteDataSourceProvider = Provider<UserRemoteDataSource>((ref) {
@@ -32,8 +33,11 @@ class UserRepository {
     return [for (final item in items) userProfileFromJson(item)];
   }
 
-  Future<UserProfile> updateMe(UpdateUserRequest request) async {
-    final data = await _remoteDataSource.updateMe(request);
+  Future<UserProfile> updateMe(
+    UpdateUserRequest request, {
+    MultipartFile? image,
+  }) async {
+    final data = await _remoteDataSource.updateMe(request, image: image);
     final object = unwrapJsonObject(data, context: '내 정보 수정');
 
     return userProfileFromJson(object);

--- a/test/features/place/data/datasources/place_remote_data_source_test.dart
+++ b/test/features/place/data/datasources/place_remote_data_source_test.dart
@@ -27,6 +27,39 @@ void main() {
         startsWith('multipart/form-data'),
       );
     });
+
+    test('장소 생성은 optional image part를 multipart에 포함한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = PlaceRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.createPlace(
+        const CreatePlaceRequest(name: '정원', address: '서울특별시'),
+        image: MultipartFile.fromString('image-bytes', filename: 'place.png'),
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+
+      expect(adapter.latestOptions.method, 'POST');
+      expect(adapter.latestOptions.path, '/place/create');
+      expect(formData.files.map((file) => file.key), contains('image'));
+    });
+
+    test('장소 수정은 optional image part를 multipart에 포함한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = PlaceRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.updatePlace(
+        code: 'Abc123',
+        request: const UpdatePlaceRequest(name: '정원', address: '서울특별시'),
+        image: MultipartFile.fromString('image-bytes', filename: 'place.png'),
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+
+      expect(adapter.latestOptions.method, 'PUT');
+      expect(adapter.latestOptions.path, '/place/update/Abc123');
+      expect(formData.files.map((file) => file.key), contains('image'));
+    });
   });
 }
 

--- a/test/features/place/data/repositories/place_repository_test.dart
+++ b/test/features/place/data/repositories/place_repository_test.dart
@@ -1,0 +1,66 @@
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlaceRepository', () {
+    test('장소 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
+      final dataSource = _ImagePlaceRemoteDataSource();
+      final repository = PlaceRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'place.png',
+      );
+
+      await repository.createPlace(
+        const CreatePlaceRequest(name: '거실', address: '서울시 성북구'),
+        image: image,
+      );
+
+      expect(dataSource.latestCreateImage, same(image));
+    });
+
+    test('장소 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
+      final dataSource = _ImagePlaceRemoteDataSource();
+      final repository = PlaceRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'place.png',
+      );
+
+      await repository.updatePlace(
+        code: 'place-1',
+        request: const UpdatePlaceRequest(name: '거실', address: '서울시 성북구'),
+        image: image,
+      );
+
+      expect(dataSource.latestUpdateImage, same(image));
+    });
+  });
+}
+
+class _ImagePlaceRemoteDataSource extends PlaceRemoteDataSource {
+  _ImagePlaceRemoteDataSource() : super(Dio());
+
+  MultipartFile? latestCreateImage;
+  MultipartFile? latestUpdateImage;
+
+  @override
+  Future<void> createPlace(
+    CreatePlaceRequest request, {
+    MultipartFile? image,
+  }) async {
+    latestCreateImage = image;
+  }
+
+  @override
+  Future<void> updatePlace({
+    required String code,
+    required UpdatePlaceRequest request,
+    MultipartFile? image,
+  }) async {
+    latestUpdateImage = image;
+  }
+}

--- a/test/features/place/presentation/pages/place_form_page_test.dart
+++ b/test/features/place/presentation/pages/place_form_page_test.dart
@@ -134,7 +134,7 @@ class _PendingPlaceRepository extends PlaceRepository {
   int createCalls = 0;
 
   @override
-  Future<void> createPlace(CreatePlaceRequest request) {
+  Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image}) {
     createCalls++;
     return _completer.future;
   }
@@ -157,6 +157,7 @@ class _EditablePlaceRepository extends PlaceRepository {
   Future<void> updatePlace({
     required String code,
     required UpdatePlaceRequest request,
+    MultipartFile? image,
   }) async {
     updateCalls++;
     latestUpdateCode = code;

--- a/test/features/plant/data/datasources/plant_remote_data_source_test.dart
+++ b/test/features/plant/data/datasources/plant_remote_data_source_test.dart
@@ -41,6 +41,40 @@ void main() {
       expect(adapter.latestOptions.queryParameters, {'placeCode': 'Abc123'});
     });
 
+    test('식물 생성은 optional image part를 multipart에 포함한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.createPlant(
+        const CreatePlantRequest(placeCode: 'Abc123', nickname: '몬스테라'),
+        image: MultipartFile.fromString('image-bytes', filename: 'plant.png'),
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+
+      expect(adapter.latestOptions.method, 'POST');
+      expect(adapter.latestOptions.path, '/plants');
+      expect(formData.files.map((file) => file.key), contains('image'));
+    });
+
+    test('식물 수정은 optional image part를 multipart에 포함한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.updatePlant(
+        plantId: '1',
+        placeCode: 'Abc123',
+        request: const UpdatePlantRequest(nickname: '거실 몬스테라'),
+        image: MultipartFile.fromString('image-bytes', filename: 'plant.png'),
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+
+      expect(adapter.latestOptions.method, 'PUT');
+      expect(adapter.latestOptions.path, '/plants/1');
+      expect(formData.files.map((file) => file.key), contains('image'));
+    });
+
     test('식물 삭제는 placeCode query를 보낸다', () async {
       final adapter = _CapturingAdapter();
       final dataSource = PlantRemoteDataSource(_dioWith(adapter));

--- a/test/features/plant/data/repositories/plant_repository_test.dart
+++ b/test/features/plant/data/repositories/plant_repository_test.dart
@@ -1,5 +1,8 @@
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -86,4 +89,65 @@ void main() {
       expect(summaries.single.imageUrl, 'https://example.com/monstera.png');
     });
   });
+
+  group('PlantRepository', () {
+    test('식물 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
+      final dataSource = _ImagePlantRemoteDataSource();
+      final repository = PlantRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'plant.png',
+      );
+
+      await repository.createPlant(
+        const CreatePlantRequest(placeCode: 'place-1', nickname: '몬스테라'),
+        image: image,
+      );
+
+      expect(dataSource.latestCreateImage, same(image));
+    });
+
+    test('식물 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
+      final dataSource = _ImagePlantRemoteDataSource();
+      final repository = PlantRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'plant.png',
+      );
+
+      await repository.updatePlant(
+        plantId: 'plant-1',
+        placeCode: 'place-1',
+        request: const UpdatePlantRequest(nickname: '몬스테라'),
+        image: image,
+      );
+
+      expect(dataSource.latestUpdateImage, same(image));
+    });
+  });
+}
+
+class _ImagePlantRemoteDataSource extends PlantRemoteDataSource {
+  _ImagePlantRemoteDataSource() : super(Dio());
+
+  MultipartFile? latestCreateImage;
+  MultipartFile? latestUpdateImage;
+
+  @override
+  Future<void> createPlant(
+    CreatePlantRequest request, {
+    MultipartFile? image,
+  }) async {
+    latestCreateImage = image;
+  }
+
+  @override
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    required UpdatePlantRequest request,
+    MultipartFile? image,
+  }) async {
+    latestUpdateImage = image;
+  }
 }

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -184,6 +184,7 @@ class _PendingPlantRepository extends PlantRepository {
     required String plantId,
     required String placeCode,
     required UpdatePlantRequest request,
+    MultipartFile? image,
   }) {
     updateCalls++;
     return _completer.future;
@@ -205,6 +206,7 @@ class _FailingPlantUpdateRepository extends PlantRepository {
     required String plantId,
     required String placeCode,
     required UpdatePlantRequest request,
+    MultipartFile? image,
   }) async {
     updateCalls++;
     throw StateError('raw failure');

--- a/test/features/user/data/repositories/user_repository_test.dart
+++ b/test/features/user/data/repositories/user_repository_test.dart
@@ -1,5 +1,8 @@
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
+import 'package:commonplant_frontend/features/user/data/dtos/user_requests.dart';
 import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -44,4 +47,40 @@ void main() {
       expect(profiles.single.provider, 'KAKAO');
     });
   });
+
+  group('UserRepository', () {
+    test('내 정보 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
+      final dataSource = _ImageUpdateUserRemoteDataSource();
+      final repository = UserRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'profile.png',
+      );
+
+      await repository.updateMe(
+        const UpdateUserRequest(name: '커먼'),
+        image: image,
+      );
+
+      expect(dataSource.latestImage, same(image));
+    });
+  });
+}
+
+class _ImageUpdateUserRemoteDataSource extends UserRemoteDataSource {
+  _ImageUpdateUserRemoteDataSource() : super(Dio());
+
+  MultipartFile? latestImage;
+
+  @override
+  Future<Object?> updateMe(
+    UpdateUserRequest request, {
+    MultipartFile? image,
+  }) async {
+    latestImage = image;
+
+    return {
+      'result': {'id': 'user-1', 'name': request.name},
+    };
+  }
 }


### PR DESCRIPTION
## 요약
- User/Place/Plant API 계층에서 Swagger로 확정된 optional `image` multipart part를 repository 경계까지 전달할 수 있도록 열었습니다.
- Place/Plant datasource가 생성/수정 요청에 optional image part를 포함하도록 보강했습니다.
- 독립형 Image API(`/s3/images`)는 응답 schema가 없어 화면 key/url 매핑을 임의 구현하지 않고 문서에 보류 범위와 백엔드 확인 항목을 정리했습니다.

## 테스트
- `/Users/ywkim/fvm/bin/fvm dart format --output=none --set-exit-if-changed .`
- `/Users/ywkim/fvm/bin/fvm flutter analyze`
- `/Users/ywkim/fvm/bin/fvm flutter test`
- `git diff --check`

## 확인 필요
- `/s3/images` upload/download/update/delete 성공 response schema와 image key/url 필드명 확인이 필요합니다.
- 화면 이미지 업로드가 `/s3/images` 선업로드 방식인지, 각 도메인 API의 optional `image` part 직접 전송 방식인지 백엔드와 합의가 필요합니다.

Closes #74
