### PR TITLE
Docs: PR 담당자 규칙 갱신 #87

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@
 ## GitHub Project 정리 기준
 
 - 이슈 제목은 `[Epic]`, `[Feature]`, `[Task]`, `[Bug]` 중 하나로 시작하고, GitHub Issue Type도 같은 의미로 입력한다.
-- 신규 일반 이슈와 PR은 `ywkim95`, `allmanLee`를 assignees로 지정한다.
+- 신규 일반 이슈와 PR은 `allmanLee`, `ywkim95`, `bbielo`를 assignees로 지정한다.
 - 신규 일반 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정한다.
 - Project 10의 category는 도메인 기준으로 `User`, `Place`, `Plant`, `Memo`, `Info`, `Story`, `Calendar` 중 알맞게 지정한다.
 - 작업 중인 이슈는 Project 10 status를 `In Progress`, PR 생성 후 이슈와 PR은 `In Review`, 병합 또는 완료 후에는 `Done`으로 맞춘다.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -54,7 +54,7 @@ git switch -c feature/place-list
 - 제목 타입과 같은 의미의 GitHub Issue Type을 입력합니다.
 - 본문에는 작업 개요, 목표, 완료 조건, 검증 기준을 포함합니다.
 - 관련 도메인이나 작업 유형에 맞는 라벨을 지정합니다.
-- 신규 일반 이슈는 `ywkim95`, `allmanLee`를 assignees로 지정합니다.
+- 신규 일반 이슈는 `allmanLee`, `ywkim95`, `bbielo`를 assignees로 지정합니다.
 - 신규 일반 이슈는 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정합니다.
 - 상위 범위가 있으면 parent issue를 연결합니다.
 - 기존 이슈가 같은 범위를 이미 다루고 있으면 새 이슈를 만들지 않고 기존 이슈를 사용합니다.
@@ -224,7 +224,7 @@ CLI 권한이 부족하면 GitHub UI의 PR 우측 `Projects` 영역에서 위 Pr
 | --- | --- |
 | Title | 이슈는 `[Epic]`, `[Feature]`, `[Task]`, `[Bug]` prefix를 사용합니다. |
 | Issue Type | 제목 prefix와 같은 의미로 `Epic`, `Feature`, `Task`, `Bug` 중 선택합니다. |
-| Assignees | 신규 일반 이슈와 PR은 `ywkim95`, `allmanLee`를 지정합니다. |
+| Assignees | 신규 일반 이슈와 PR은 `allmanLee`, `ywkim95`, `bbielo`를 지정합니다. |
 | Milestone | 신규 일반 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)`을 지정합니다. |
 | Status | 작업 시작은 `In Progress`, PR 생성 후는 `In Review`, 완료 후는 `Done`입니다. |
 | Category | 도메인 기준으로 `User`, `Place`, `Plant`, `Memo`, `Info`, `Story`, `Calendar` 중 선택합니다. |
@@ -240,7 +240,7 @@ CLI 권한이 부족하면 GitHub UI의 PR 우측 `Projects` 영역에서 위 Pr
 - [ ] 일반 작업 PR의 base가 `develop`인가?
 - [ ] 배포 PR의 base가 `main`이고 head가 `release/*`인가?
 - [ ] PR이 CommonPlant GitHub Project 10에 연결되었는가?
-- [ ] 이슈와 PR의 assignees가 `ywkim95`, `allmanLee`로 지정되었는가?
+- [ ] 이슈와 PR의 assignees가 `allmanLee`, `ywkim95`, `bbielo`로 지정되었는가?
 - [ ] 이슈와 PR의 milestone이 지정되었는가?
 - [ ] Project 10의 category와 status가 최신 상태인가?
 - [ ] 이슈 제목 prefix와 GitHub Issue Type이 일치하는가?

--- a/docs/remaining-work-plan.md
+++ b/docs/remaining-work-plan.md
@@ -9,7 +9,7 @@
 - 모든 작업 브랜치는 최신 `develop`에서 생성한다.
 - 한 브랜치는 아래 표의 한 행만 다룬다.
 - 이슈 제목은 `[Task]`, `[Feature]`, `[Bug]` 중 하나로 시작한다.
-- 신규 이슈와 PR은 `ywkim95`, `allmanLee`를 assignee로 지정한다.
+- 신규 이슈와 PR은 `allmanLee`, `ywkim95`, `bbielo`를 assignee로 지정한다.
 - 신규 이슈와 PR은 `v1.0.0 - MVP (핵심 기능 개발)` milestone을 지정한다.
 - Project 10 status는 작업 시작 시 `In Progress`, PR 생성 후 `In Review`, 병합 후 `Done`으로 맞춘다.
 - GitHub 이슈, PR, 코멘트 본문은 실제 줄바꿈 보존을 위해 `--body-file -` 또는 heredoc 입력을 사용한다.


### PR DESCRIPTION
## 관련 이슈
- Closes #87

## 구현 범위
- 신규 일반 이슈와 PR assignee 기준에 `bbielo`를 추가했습니다.
- 사용자 요청에 맞춰 담당자 표기 순서를 `allmanLee`, `ywkim95`, `bbielo`로 통일했습니다.

## 주요 변경사항
- `AGENTS.md` GitHub Project 정리 기준 갱신
- `docs/git-workflow.md` 이슈/PR assignee 기준 및 PR 체크리스트 갱신
- `docs/remaining-work-plan.md` 진행 규칙 갱신

## 테스트
- `git diff --check` 통과

## 문서 반영 여부
- 협업/브랜치/PR 관련 문서에 반영 완료

## Breaking change 여부
- 없음
