### PR TITLE
Refactor: 라우트 파라미터 검증 #89

### DIFF
--- a/lib/app/router/app_routes.dart
+++ b/lib/app/router/app_routes.dart
@@ -1,4 +1,6 @@
 import 'package:commonplant_frontend/app/router/app_route_spec.dart';
+import 'package:commonplant_frontend/app/router/route_parameter_error_page.dart';
+import 'package:commonplant_frontend/app/router/route_parameters.dart';
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/app/router/route_placeholder_page.dart';
 import 'package:commonplant_frontend/features/home/presentation/home_screen.dart';
@@ -159,39 +161,84 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
     AppRouteNames.placeCreate => const PlaceFormPage(),
     AppRouteNames.addressSearch => const AddressSearchPage(),
     AppRouteNames.placeFriendAdd => const PlaceFriendAddPage(),
-    AppRouteNames.placeEdit => PlaceFormPage(
-      placeId: state.pathParameters['placeId'],
+    AppRouteNames.placeEdit => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'placeId',
+      builder: (placeId) => PlaceFormPage(placeId: placeId),
     ),
-    AppRouteNames.friendManagement => FriendManagementPage(
-      placeId: state.pathParameters['placeId'] ?? '',
+    AppRouteNames.friendManagement => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'placeId',
+      builder: (placeId) => FriendManagementPage(placeId: placeId),
     ),
-    AppRouteNames.placeDetail => PlaceDetailPage(
-      placeId: state.pathParameters['placeId'] ?? '',
-      role: placeDetailRoleFromQuery(state.uri.queryParameters['role']),
+    AppRouteNames.placeDetail => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'placeId',
+      builder: (placeId) => PlaceDetailPage(
+        placeId: placeId,
+        role: placeDetailRoleFromQuery(state.uri.queryParameters['role']),
+      ),
     ),
     AppRouteNames.plantSearch => const PlantSearchPage(),
     AppRouteNames.plantCreateDetails => PlantFormPage(
       initialPlantName: state.uri.queryParameters['name'],
     ),
-    AppRouteNames.plantEdit => PlantFormPage(
-      plantId: state.pathParameters['plantId'],
-      placeId: state.uri.queryParameters['placeId'],
+    AppRouteNames.plantEdit => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'plantId',
+      builder: (plantId) => PlantFormPage(
+        plantId: plantId,
+        placeId: state.uri.queryParameters['placeId'],
+      ),
     ),
-    AppRouteNames.memoWrite => MemoWritePage(
-      plantId: state.pathParameters['plantId'] ?? '',
+    AppRouteNames.memoWrite => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'plantId',
+      builder: (plantId) => MemoWritePage(plantId: plantId),
     ),
-    AppRouteNames.memoList => MemoListPage(
-      plantId: state.pathParameters['plantId'] ?? '',
+    AppRouteNames.memoList => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'plantId',
+      builder: (plantId) => MemoListPage(plantId: plantId),
     ),
-    AppRouteNames.plantDetail => PlantDetailPage(
-      plantId: state.pathParameters['plantId'] ?? '',
-      placeId: state.uri.queryParameters['placeId'],
+    AppRouteNames.plantDetail => _buildWithRequiredPathParameter(
+      route: route,
+      state: state,
+      parameterName: 'plantId',
+      builder: (plantId) => PlantDetailPage(
+        plantId: plantId,
+        placeId: state.uri.queryParameters['placeId'],
+      ),
     ),
     _ => RoutePlaceholderPage(
       route: route,
       pathParameters: state.pathParameters,
     ),
   };
+}
+
+Widget _buildWithRequiredPathParameter({
+  required AppRouteSpec route,
+  required GoRouterState state,
+  required String parameterName,
+  required Widget Function(String value) builder,
+}) {
+  final parameterValue = requiredPathParameter(
+    state.pathParameters,
+    parameterName,
+  );
+
+  if (parameterValue == null) {
+    return RouteParameterErrorPage(route: route, parameterName: parameterName);
+  }
+
+  return builder(parameterValue);
 }
 
 TermsNextDestination _termsNextDestination(GoRouterState state) {

--- a/lib/app/router/route_parameter_error_page.dart
+++ b/lib/app/router/route_parameter_error_page.dart
@@ -1,0 +1,36 @@
+import 'package:commonplant_frontend/app/router/app_route_spec.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
+import 'package:flutter/material.dart';
+
+class RouteParameterErrorPage extends StatelessWidget {
+  const RouteParameterErrorPage({
+    super.key,
+    required this.route,
+    required this.parameterName,
+  });
+
+  final AppRouteSpec route;
+  final String parameterName;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return CommonScaffold(
+      title: route.title,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('라우트 정보를 확인할 수 없어요', style: textTheme.titleLarge),
+          const SizedBox(height: AppSpacing.x16),
+          Text('필수 경로 값이 누락되었습니다: $parameterName', style: textTheme.bodyMedium),
+          const SizedBox(height: AppSpacing.x16),
+          Text('routeName: ${route.name}', style: textTheme.bodyMedium),
+          const SizedBox(height: AppSpacing.x8),
+          Text('path: ${route.path}', style: textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/router/route_parameters.dart
+++ b/lib/app/router/route_parameters.dart
@@ -1,0 +1,12 @@
+String? requiredPathParameter(
+  Map<String, String> pathParameters,
+  String parameterName,
+) {
+  final value = pathParameters[parameterName]?.trim();
+
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+
+  return value;
+}

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -1,6 +1,9 @@
 import 'package:commonplant_frontend/app/common_plant_app.dart';
+import 'package:commonplant_frontend/app/router/app_route_spec.dart';
 import 'package:commonplant_frontend/app/router/app_router.dart';
 import 'package:commonplant_frontend/app/router/app_routes.dart';
+import 'package:commonplant_frontend/app/router/route_parameter_error_page.dart';
+import 'package:commonplant_frontend/app/router/route_parameters.dart';
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +14,38 @@ void main() {
     expect(appRouteSpecs, hasLength(18));
     expect(appRouteSpecs.map((route) => route.name).toSet(), hasLength(18));
     expect(appRouteSpecs.map((route) => route.path).toSet(), hasLength(18));
+  });
+
+  test('필수 path parameter는 null, 빈 문자열, 공백 문자열을 허용하지 않는다', () {
+    expect(
+      requiredPathParameter(const {'placeId': 'place-1'}, 'placeId'),
+      'place-1',
+    );
+    expect(requiredPathParameter(const {}, 'placeId'), isNull);
+    expect(requiredPathParameter(const {'placeId': ''}, 'placeId'), isNull);
+    expect(requiredPathParameter(const {'placeId': '   '}, 'placeId'), isNull);
+  });
+
+  testWidgets('route parameter 오류 화면이 누락된 parameter와 route 정보를 표시한다', (
+    WidgetTester tester,
+  ) async {
+    const route = AppRouteSpec(
+      name: AppRouteNames.placeDetail,
+      path: AppRoutePaths.placeDetail,
+      title: '장소 상세',
+      figmaFrames: ['#2-3 My place 리더화면'],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: RouteParameterErrorPage(route: route, parameterName: 'placeId'),
+      ),
+    );
+
+    expect(find.text('라우트 정보를 확인할 수 없어요'), findsOneWidget);
+    expect(find.text('필수 경로 값이 누락되었습니다: placeId'), findsOneWidget);
+    expect(find.text('routeName: placeDetail'), findsOneWidget);
+    expect(find.text('path: /places/:placeId'), findsOneWidget);
   });
 
   testWidgets('Figma 기준 route-level screen이 모두 실제 화면으로 진입된다', (


### PR DESCRIPTION
## 관련 이슈
- Closes #89

## 구현 범위
- 필수 path parameter 검증 helper를 추가했습니다.
- route builder에서 `placeId`, `plantId` 누락 시 빈 문자열을 page로 전달하지 않고 오류 화면을 표시하도록 변경했습니다.
- route parameter helper와 오류 화면 테스트를 추가했습니다.

## 주요 변경사항
- `lib/app/router/route_parameters.dart` 추가
- `lib/app/router/route_parameter_error_page.dart` 추가
- `lib/app/router/app_routes.dart`의 필수 path parameter route에 검증 helper 적용
- `test/app/router/app_router_test.dart`에 path parameter 검증 테스트 추가

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .` 통과
- `fvm flutter analyze` 통과
- `fvm flutter test` 통과
- TDD RED 확인: helper/오류 화면 추가 전 `fvm flutter test test/app/router/app_router_test.dart` 실패 확인

## 리뷰 포인트
- 필수 parameter 누락 시 표시하는 오류 문구와 화면 구성이 적절한지 확인 부탁드립니다.
- 이번 PR은 path parameter 경계만 다루고, query parameter 정규화는 후속 작업으로 분리했습니다.

## 문서 반영 여부
- `docs/lib-refactoring-direction.md`의 1단계 작업 중 path parameter 안전장치에 해당합니다.

## Breaking change 여부
- 없음
