### PR TITLE
Refactor: Place 폼 컨트롤러 분리 #91

### DIFF
--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -5,10 +5,8 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_image_add_button.dart';
@@ -33,13 +31,10 @@ class PlaceFormPage extends ConsumerStatefulWidget {
 
 class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   late final TextEditingController _nameController;
-  late final FormSubmitController _submitController;
   late String _initialName;
   String? _initialAddress;
   String? _address;
   String? _remoteInitialPlaceId;
-
-  bool get _isSubmitting => _submitController.state.isSubmitting;
 
   @override
   void initState() {
@@ -47,24 +42,13 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     _initialName = widget.isEdit ? _placeEditInitialName : '';
     _initialAddress = null;
     _nameController = TextEditingController(text: _initialName);
-    _submitController = FormSubmitController()
-      ..addListener(_handleSubmitStateChanged);
     _address = _initialAddress;
   }
 
   @override
   void dispose() {
-    _submitController
-      ..removeListener(_handleSubmitStateChanged)
-      ..dispose();
     _nameController.dispose();
     super.dispose();
-  }
-
-  void _handleSubmitStateChanged() {
-    if (mounted) {
-      setState(() {});
-    }
   }
 
   @override
@@ -108,19 +92,21 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   }
 
   Widget _buildForm(BuildContext context) {
+    final submitState = ref.watch(placeFormControllerProvider);
+    final isSubmitting = submitState.isSubmitting;
     final currentName = _nameController.text.trim();
     final hasChanges =
         !widget.isEdit ||
         currentName != _initialName ||
         _address != _initialAddress;
-    final canSubmit = currentName.isNotEmpty && hasChanges && !_isSubmitting;
+    final canSubmit = currentName.isNotEmpty && hasChanges && !isSubmitting;
 
     if (!widget.isEdit) {
       return _PlaceCreateScaffold(
         nameController: _nameController,
         address: _address,
         canSubmit: canSubmit,
-        isSubmitting: _isSubmitting,
+        isSubmitting: isSubmitting,
         onNameChanged: (_) => setState(() {}),
         onImageTap: () {},
         onAddressTap: () => context.push(AppRoutePaths.addressSearch),
@@ -133,7 +119,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       nameController: _nameController,
       address: _address,
       canSubmit: canSubmit,
-      isSubmitting: _isSubmitting,
+      isSubmitting: isSubmitting,
       onNameChanged: (_) => setState(() {}),
       onImageTap: () {},
       onAddressTap: () => context.push(AppRoutePaths.addressSearch),
@@ -157,78 +143,40 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   }
 
   Future<void> _submit() async {
-    if (_isSubmitting) {
+    if (ref.read(placeFormControllerProvider).isSubmitting) {
       return;
     }
 
     final name = _nameController.text.trim();
-    final notifier = ref.read(placeListProvider.notifier);
     final address = _address?.trim();
+    final input = switch (widget.placeId) {
+      final placeId? => PlaceFormSubmitInput.update(
+        placeId: placeId,
+        name: name,
+        address: address,
+      ),
+      null => PlaceFormSubmitInput.create(name: name, address: address),
+    };
+    final result = await ref
+        .read(placeFormControllerProvider.notifier)
+        .submit(input);
 
-    if (!widget.isEdit &&
-        ref.read(useRemoteApiProvider) &&
-        (address == null || address.isEmpty)) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('장소 주소를 입력해 주세요.')));
+    if (!mounted) {
       return;
     }
 
-    await _submitController.submit(
-      () async {
-        if (widget.placeId case final placeId?) {
-          if (ref.read(useRemoteApiProvider)) {
-            if (address == null || address.isEmpty) {
-              throw const _PlaceFormValidationException('장소 주소를 입력해 주세요.');
-            }
-
-            await ref
-                .read(placeRepositoryProvider)
-                .updatePlace(
-                  code: placeId,
-                  request: UpdatePlaceRequest(name: name, address: address),
-                );
-            ref.invalidate(placeDetailProvider(placeId));
-            ref.invalidate(remotePlaceListProvider);
-            ref.invalidate(plantRegistrationPlaceProvider);
-          } else {
-            notifier.updatePlace(id: placeId, name: name, address: _address);
-          }
-
-          if (mounted) {
-            context.go(AppRoutePaths.home);
-          }
-        } else {
-          if (ref.read(useRemoteApiProvider)) {
-            await ref
-                .read(placeRepositoryProvider)
-                .createPlace(CreatePlaceRequest(name: name, address: address!));
-            ref.invalidate(remotePlaceListProvider);
-          }
-
-          if (!mounted) {
-            return;
-          }
-
-          notifier.addPlace(name: name, address: _address);
-          context.push(AppRoutePaths.placeFriendAdd);
-        }
-      },
-      failureMessage: widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요',
-      failureMessageBuilder: (error) {
-        if (error case _PlaceFormValidationException(:final message)) {
-          return message;
-        }
-
-        return widget.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요';
-      },
-    );
-
-    _showSubmitErrorIfNeeded();
+    switch (result?.destination) {
+      case PlaceFormSubmitDestination.home:
+        context.go(AppRoutePaths.home);
+      case PlaceFormSubmitDestination.friendAdd:
+        context.push(AppRoutePaths.placeFriendAdd);
+      case null:
+        _showSubmitErrorIfNeeded();
+    }
   }
 
   void _showSubmitErrorIfNeeded() {
-    final errorMessage = _submitController.state.errorMessage;
+    final errorMessage = ref.read(placeFormControllerProvider).errorMessage;
 
     if (!mounted || errorMessage == null) {
       return;
@@ -238,12 +186,6 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       context,
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
-}
-
-class _PlaceFormValidationException implements Exception {
-  const _PlaceFormValidationException(this.message);
-
-  final String message;
 }
 
 class _PlaceFormStatusScaffold extends StatelessWidget {

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -1,0 +1,149 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const String placeFormAddressRequiredMessage = '장소 주소를 입력해 주세요.';
+
+final placeFormControllerProvider =
+    NotifierProvider<PlaceFormController, FormSubmitState>(
+      PlaceFormController.new,
+    );
+
+enum PlaceFormSubmitDestination { home, friendAdd }
+
+class PlaceFormSubmitResult {
+  const PlaceFormSubmitResult._(this.destination);
+
+  const PlaceFormSubmitResult.home() : this._(PlaceFormSubmitDestination.home);
+
+  const PlaceFormSubmitResult.friendAdd()
+    : this._(PlaceFormSubmitDestination.friendAdd);
+
+  final PlaceFormSubmitDestination destination;
+}
+
+class PlaceFormSubmitInput {
+  const PlaceFormSubmitInput.create({required this.name, this.address})
+    : placeId = null;
+
+  const PlaceFormSubmitInput.update({
+    required this.placeId,
+    required this.name,
+    this.address,
+  });
+
+  final String? placeId;
+  final String name;
+  final String? address;
+
+  bool get isEdit => placeId != null;
+}
+
+class PlaceFormController extends Notifier<FormSubmitState> {
+  @override
+  FormSubmitState build() {
+    return const FormSubmitState.idle();
+  }
+
+  Future<PlaceFormSubmitResult?> submit(PlaceFormSubmitInput input) async {
+    if (state.isSubmitting) {
+      return null;
+    }
+
+    state = const FormSubmitState.submitting();
+
+    try {
+      final result = input.isEdit ? await _update(input) : await _create(input);
+      state = const FormSubmitState.idle();
+
+      return result;
+    } on _PlaceFormValidationException catch (error) {
+      state = FormSubmitState.failure(error.message);
+
+      return null;
+    } catch (_) {
+      state = FormSubmitState.failure(
+        input.isEdit ? '장소 수정에 실패했어요' : '장소 생성에 실패했어요',
+      );
+
+      return null;
+    }
+  }
+
+  Future<PlaceFormSubmitResult> _create(PlaceFormSubmitInput input) async {
+    final name = input.name.trim();
+    final address = _normalizeAddress(input.address);
+
+    if (ref.read(useRemoteApiProvider)) {
+      final requiredAddress = _requiredAddress(address);
+
+      await ref
+          .read(placeRepositoryProvider)
+          .createPlace(
+            CreatePlaceRequest(name: name, address: requiredAddress),
+          );
+      ref.invalidate(remotePlaceListProvider);
+    } else {
+      ref
+          .read(placeListProvider.notifier)
+          .addPlace(name: name, address: address);
+    }
+
+    return const PlaceFormSubmitResult.friendAdd();
+  }
+
+  Future<PlaceFormSubmitResult> _update(PlaceFormSubmitInput input) async {
+    final placeId = input.placeId!;
+    final name = input.name.trim();
+    final address = _normalizeAddress(input.address);
+
+    if (ref.read(useRemoteApiProvider)) {
+      final requiredAddress = _requiredAddress(address);
+
+      await ref
+          .read(placeRepositoryProvider)
+          .updatePlace(
+            code: placeId,
+            request: UpdatePlaceRequest(name: name, address: requiredAddress),
+          );
+      ref.invalidate(placeDetailProvider(placeId));
+      ref.invalidate(remotePlaceListProvider);
+      ref.invalidate(plantRegistrationPlaceProvider);
+    } else {
+      ref
+          .read(placeListProvider.notifier)
+          .updatePlace(id: placeId, name: name, address: address);
+    }
+
+    return const PlaceFormSubmitResult.home();
+  }
+
+  String? _normalizeAddress(String? address) {
+    final trimmed = address?.trim();
+
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+
+    return trimmed;
+  }
+
+  String _requiredAddress(String? address) {
+    if (address == null || address.isEmpty) {
+      throw const _PlaceFormValidationException(
+        placeFormAddressRequiredMessage,
+      );
+    }
+
+    return address;
+  }
+}
+
+class _PlaceFormValidationException implements Exception {
+  const _PlaceFormValidationException(this.message);
+
+  final String message;
+}

--- a/test/features/place/presentation/providers/place_form_controller_test.dart
+++ b/test/features/place/presentation/providers/place_form_controller_test.dart
@@ -1,0 +1,151 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlaceFormController', () {
+    test('local 장소 생성은 목록에 추가하고 친구 추가 이동 결과를 반환한다', () async {
+      final container = ProviderContainer();
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeFormControllerProvider.notifier)
+          .submit(
+            const PlaceFormSubmitInput.create(
+              name: '  거실  ',
+              address: '  서울시 성북구  ',
+            ),
+          );
+      final places = container.read(placeListProvider);
+
+      expect(result?.destination, PlaceFormSubmitDestination.friendAdd);
+      expect(
+        container.read(placeFormControllerProvider),
+        const FormSubmitState.idle(),
+      );
+      expect(places, hasLength(1));
+      expect(places.single.name, '거실');
+      expect(places.single.address, '서울시 성북구');
+    });
+
+    test('local 장소 수정은 목록 값을 갱신하고 홈 이동 결과를 반환한다', () async {
+      final container = ProviderContainer();
+
+      addTearDown(container.dispose);
+
+      final place = container
+          .read(placeListProvider.notifier)
+          .addPlace(name: '거실', address: '서울시 성북구');
+
+      final result = await container
+          .read(placeFormControllerProvider.notifier)
+          .submit(
+            PlaceFormSubmitInput.update(
+              placeId: place.id,
+              name: '루프탑',
+              address: '서울시 강남구',
+            ),
+          );
+      final places = container.read(placeListProvider);
+
+      expect(result?.destination, PlaceFormSubmitDestination.home);
+      expect(places.single.name, '루프탑');
+      expect(places.single.address, '서울시 강남구');
+    });
+
+    test('remote 장소 생성은 주소가 없으면 요청하지 않고 검증 메시지를 남긴다', () async {
+      final repository = _RecordingPlaceRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeFormControllerProvider.notifier)
+          .submit(const PlaceFormSubmitInput.create(name: '거실'));
+
+      expect(result, isNull);
+      expect(repository.createCalls, 0);
+      expect(
+        container.read(placeFormControllerProvider),
+        const FormSubmitState.failure('장소 주소를 입력해 주세요.'),
+      );
+    });
+
+    test('remote 장소 수정은 repository를 호출하고 홈 이동 결과를 반환한다', () async {
+      final repository = _RecordingPlaceRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeFormControllerProvider.notifier)
+          .submit(
+            const PlaceFormSubmitInput.update(
+              placeId: 'place-1',
+              name: '루프탑',
+              address: '서울시 성북구',
+            ),
+          );
+
+      expect(result?.destination, PlaceFormSubmitDestination.home);
+      expect(repository.updateCalls, 1);
+      expect(repository.latestUpdateCode, 'place-1');
+      expect(repository.latestUpdateRequest?.toJson(), {
+        'name': '루프탑',
+        'address': '서울시 성북구',
+      });
+      expect(
+        container.read(placeFormControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+  });
+}
+
+class _RecordingPlaceRepository extends PlaceRepository {
+  _RecordingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  int createCalls = 0;
+  int updateCalls = 0;
+  String? latestUpdateCode;
+  CreatePlaceRequest? latestCreateRequest;
+  UpdatePlaceRequest? latestUpdateRequest;
+
+  @override
+  Future<void> createPlace(
+    CreatePlaceRequest request, {
+    MultipartFile? image,
+  }) async {
+    createCalls++;
+    latestCreateRequest = request;
+  }
+
+  @override
+  Future<void> updatePlace({
+    required String code,
+    required UpdatePlaceRequest request,
+    MultipartFile? image,
+  }) async {
+    updateCalls++;
+    latestUpdateCode = code;
+    latestUpdateRequest = request;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #91

## 구현 범위
- `PlaceFormPage`의 생성/수정 submit 로직을 `placeFormControllerProvider`로 분리했습니다.
- page의 `place_requests.dart`, `place_repository.dart`, `FormSubmitController` 직접 의존을 제거했습니다.
- local 생성/수정, remote 주소 검증, remote 수정 API 호출을 controller 단위 테스트로 추가했습니다.

## 주요 변경사항
- `PlaceFormController`가 submit 상태, remote/local 분기, repository 호출, Provider invalidate를 담당합니다.
- `PlaceFormPage`는 controller 상태를 watch하고 성공 결과에 따라 route 이동 또는 snackbar 표시만 수행합니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md`의 방향에 맞춘 구현이라 별도 문서 변경은 없습니다.

## Breaking change 여부
- 없음
