### PR TITLE
Refactor: Plant 폼 컨트롤러 분리 #93

### DIFF
--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -8,12 +8,10 @@ import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
-import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
@@ -47,12 +45,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
   late final TextEditingController _nameController;
   late final String _selectedPlantName;
-  late final FormSubmitController _submitController;
   String? _selectedPlaceId;
   String _initialEditPlantName = _defaultEditPlantName;
   bool _hasAppliedRemoteEditInfo = false;
-
-  bool get _isSubmitting => _submitController.state.isSubmitting;
 
   static const List<_PlantRegistrationPlace> _places = [
     _PlantRegistrationPlace(
@@ -84,24 +79,13 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     _nameController = TextEditingController(
       text: widget.isEdit ? _defaultEditPlantName : '',
     );
-    _submitController = FormSubmitController()
-      ..addListener(_handleSubmitStateChanged);
     _selectedPlaceId = widget.isEdit ? null : _places.first.id;
   }
 
   @override
   void dispose() {
-    _submitController
-      ..removeListener(_handleSubmitStateChanged)
-      ..dispose();
     _nameController.dispose();
     super.dispose();
-  }
-
-  void _handleSubmitStateChanged() {
-    if (mounted) {
-      setState(() {});
-    }
   }
 
   @override
@@ -114,6 +98,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     final registrationPlaces = _registrationPlacesFromSummaries(
       remotePlaces.value ?? const [],
     );
+    final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
     final places = registrationPlaces.isEmpty ? _places : registrationPlaces;
     final selectedPlaceId = _effectiveSelectedPlaceId(places);
 
@@ -121,7 +106,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       places: places,
       selectedPlaceId: selectedPlaceId,
       wateringDate: '2023. 01. 30',
-      isSubmitting: _isSubmitting,
+      isSubmitting: isSubmitting,
       onPlaceSelected: (place) => setState(() => _selectedPlaceId = place.id),
       onCancel: _cancelCreate,
       onSubmit: () => _submitCreate(),
@@ -167,16 +152,17 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Widget _buildEditScaffold() {
+    final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
     final trimmedName = _nameController.text.trim();
     final canSubmit =
         trimmedName.isNotEmpty &&
         trimmedName != _initialEditPlantName &&
-        !_isSubmitting;
+        !isSubmitting;
 
     return _PlantEditScaffold(
       nameController: _nameController,
       canSubmit: canSubmit,
-      isSubmitting: _isSubmitting,
+      isSubmitting: isSubmitting,
       onChanged: (_) => setState(() {}),
       onSubmit: () => _submitEdit(),
     );
@@ -252,7 +238,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Future<void> _submitCreate() async {
-    if (_isSubmitting) {
+    if (ref.read(plantFormControllerProvider).isSubmitting) {
       return;
     }
 
@@ -262,76 +248,64 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       return;
     }
 
-    await _submitController.submit(() async {
-      if (ref.read(useRemoteApiProvider)) {
-        await ref
-            .read(plantRepositoryProvider)
-            .createPlant(
-              CreatePlantRequest(
-                placeCode: selectedPlace.id,
-                nickname: _selectedPlantName,
-                scientificNameKo: _selectedPlantName,
-              ),
-            );
-        ref.invalidate(remotePlantListProvider);
-      }
-
-      if (!mounted) {
-        return;
-      }
-
-      ref
-          .read(plantListProvider.notifier)
-          .addPlant(
-            name: _selectedPlantName,
+    final result = await ref
+        .read(plantFormControllerProvider.notifier)
+        .submit(
+          PlantFormSubmitInput.create(
+            plantName: _selectedPlantName,
             placeId: selectedPlace.id,
             placeName: selectedPlace.name,
-          );
+          ),
+        );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (result?.destination == PlantFormSubmitDestination.home) {
       context.go(AppRoutePaths.home);
-    }, failureMessage: '식물 등록에 실패했어요');
+      return;
+    }
 
     _showSubmitErrorIfNeeded();
   }
 
   Future<void> _submitEdit() async {
-    if (_isSubmitting) {
+    if (ref.read(plantFormControllerProvider).isSubmitting) {
       return;
     }
 
     final name = _nameController.text.trim();
+    final result = await ref
+        .read(plantFormControllerProvider.notifier)
+        .submit(
+          PlantFormSubmitInput.update(
+            plantId: widget.plantId!,
+            plantName: name,
+            placeId: widget.placeId,
+          ),
+        );
 
-    await _submitController.submit(() async {
-      if (ref.read(useRemoteApiProvider) && widget.placeId != null) {
-        await ref
-            .read(plantRepositoryProvider)
-            .updatePlant(
-              plantId: widget.plantId!,
-              placeCode: widget.placeId!,
-              request: UpdatePlantRequest(nickname: name),
-            );
-        ref.invalidate(remotePlantListProvider);
-      }
+    if (!mounted) {
+      return;
+    }
 
-      if (!mounted) {
-        return;
-      }
-
-      ref
-          .read(plantListProvider.notifier)
-          .updatePlant(id: widget.plantId!, name: name);
+    if (result?.destination == PlantFormSubmitDestination.plantDetail &&
+        result?.plantId != null) {
       context.go(
         AppRoutePaths.plantDetailLocation(
-          widget.plantId!,
-          placeId: widget.placeId,
+          result!.plantId!,
+          placeId: result.placeId,
         ),
       );
-    }, failureMessage: '식물 수정에 실패했어요');
+      return;
+    }
 
     _showSubmitErrorIfNeeded();
   }
 
   void _showSubmitErrorIfNeeded() {
-    final errorMessage = _submitController.state.errorMessage;
+    final errorMessage = ref.read(plantFormControllerProvider).errorMessage;
 
     if (!mounted || errorMessage == null) {
       return;

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -1,0 +1,137 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantFormControllerProvider =
+    NotifierProvider<PlantFormController, FormSubmitState>(
+      PlantFormController.new,
+    );
+
+enum PlantFormSubmitDestination { home, plantDetail }
+
+class PlantFormSubmitResult {
+  const PlantFormSubmitResult._({
+    required this.destination,
+    this.plantId,
+    this.placeId,
+  });
+
+  const PlantFormSubmitResult.home()
+    : this._(destination: PlantFormSubmitDestination.home);
+
+  const PlantFormSubmitResult.plantDetail({
+    required String plantId,
+    String? placeId,
+  }) : this._(
+         destination: PlantFormSubmitDestination.plantDetail,
+         plantId: plantId,
+         placeId: placeId,
+       );
+
+  final PlantFormSubmitDestination destination;
+  final String? plantId;
+  final String? placeId;
+}
+
+class PlantFormSubmitInput {
+  const PlantFormSubmitInput.create({
+    required this.plantName,
+    required this.placeId,
+    required this.placeName,
+  }) : plantId = null;
+
+  const PlantFormSubmitInput.update({
+    required this.plantId,
+    required this.plantName,
+    this.placeId,
+  }) : placeName = null;
+
+  final String? plantId;
+  final String plantName;
+  final String? placeId;
+  final String? placeName;
+
+  bool get isEdit => plantId != null;
+}
+
+class PlantFormController extends Notifier<FormSubmitState> {
+  @override
+  FormSubmitState build() {
+    return const FormSubmitState.idle();
+  }
+
+  Future<PlantFormSubmitResult?> submit(PlantFormSubmitInput input) async {
+    if (state.isSubmitting) {
+      return null;
+    }
+
+    state = const FormSubmitState.submitting();
+
+    try {
+      final result = input.isEdit ? await _update(input) : await _create(input);
+      state = const FormSubmitState.idle();
+
+      return result;
+    } catch (_) {
+      state = FormSubmitState.failure(
+        input.isEdit ? '식물 수정에 실패했어요' : '식물 등록에 실패했어요',
+      );
+
+      return null;
+    }
+  }
+
+  Future<PlantFormSubmitResult> _create(PlantFormSubmitInput input) async {
+    final plantName = input.plantName.trim();
+    final placeId = input.placeId!;
+    final placeName = input.placeName!;
+
+    if (ref.read(useRemoteApiProvider)) {
+      await ref
+          .read(plantRepositoryProvider)
+          .createPlant(
+            CreatePlantRequest(
+              placeCode: placeId,
+              nickname: plantName,
+              scientificNameKo: plantName,
+            ),
+          );
+      ref.invalidate(remotePlantListProvider);
+    }
+
+    ref
+        .read(plantListProvider.notifier)
+        .addPlant(name: plantName, placeId: placeId, placeName: placeName);
+
+    return const PlantFormSubmitResult.home();
+  }
+
+  Future<PlantFormSubmitResult> _update(PlantFormSubmitInput input) async {
+    final plantId = input.plantId!;
+    final plantName = input.plantName.trim();
+    final placeId = input.placeId;
+
+    if (ref.read(useRemoteApiProvider) && placeId != null) {
+      await ref
+          .read(plantRepositoryProvider)
+          .updatePlant(
+            plantId: plantId,
+            placeCode: placeId,
+            request: UpdatePlantRequest(nickname: plantName),
+          );
+      ref.invalidate(remotePlantListProvider);
+    }
+
+    ref
+        .read(plantListProvider.notifier)
+        .updatePlant(id: plantId, name: plantName);
+
+    return PlantFormSubmitResult.plantDetail(
+      plantId: plantId,
+      placeId: placeId,
+    );
+  }
+}

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -1,0 +1,164 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlantFormController', () {
+    test('local 식물 생성은 목록에 추가하고 홈 이동 결과를 반환한다', () async {
+      final container = ProviderContainer();
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantFormControllerProvider.notifier)
+          .submit(
+            const PlantFormSubmitInput.create(
+              plantName: '  몬스테라  ',
+              placeId: 'place-1',
+              placeName: '거실',
+            ),
+          );
+      final plants = container.read(plantListProvider);
+
+      expect(result?.destination, PlantFormSubmitDestination.home);
+      expect(
+        container.read(plantFormControllerProvider),
+        const FormSubmitState.idle(),
+      );
+      expect(plants, hasLength(1));
+      expect(plants.single.name, '몬스테라');
+      expect(plants.single.placeId, 'place-1');
+      expect(plants.single.placeName, '거실');
+    });
+
+    test('remote 식물 생성은 repository를 호출하고 local 목록도 갱신한다', () async {
+      final repository = _RecordingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantFormControllerProvider.notifier)
+          .submit(
+            const PlantFormSubmitInput.create(
+              plantName: '몬스테라',
+              placeId: 'place-1',
+              placeName: '거실',
+            ),
+          );
+      final plants = container.read(plantListProvider);
+
+      expect(result?.destination, PlantFormSubmitDestination.home);
+      expect(repository.createCalls, 1);
+      expect(repository.latestCreateRequest?.toJson(), {
+        'placeCode': 'place-1',
+        'nickname': '몬스테라',
+        'scientificNameKo': '몬스테라',
+      });
+      expect(plants.single.name, '몬스테라');
+    });
+
+    test('local 식물 수정은 목록 값을 갱신하고 상세 이동 결과를 반환한다', () async {
+      final container = ProviderContainer();
+
+      addTearDown(container.dispose);
+
+      final plant = container
+          .read(plantListProvider.notifier)
+          .addPlant(name: '몬테', placeId: 'place-1', placeName: '거실');
+
+      final result = await container
+          .read(plantFormControllerProvider.notifier)
+          .submit(
+            PlantFormSubmitInput.update(
+              plantId: plant.id,
+              plantName: '몬테라',
+              placeId: 'place-1',
+            ),
+          );
+      final plants = container.read(plantListProvider);
+
+      expect(result?.destination, PlantFormSubmitDestination.plantDetail);
+      expect(result?.plantId, plant.id);
+      expect(result?.placeId, 'place-1');
+      expect(plants.single.name, '몬테라');
+    });
+
+    test('remote 식물 수정은 repository를 호출하고 상세 이동 결과를 반환한다', () async {
+      final repository = _RecordingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantFormControllerProvider.notifier)
+          .submit(
+            const PlantFormSubmitInput.update(
+              plantId: 'plant-1',
+              plantName: '몬테라',
+              placeId: 'place-1',
+            ),
+          );
+
+      expect(result?.destination, PlantFormSubmitDestination.plantDetail);
+      expect(repository.updateCalls, 1);
+      expect(repository.latestUpdatePlantId, 'plant-1');
+      expect(repository.latestUpdatePlaceCode, 'place-1');
+      expect(repository.latestUpdateRequest?.toJson(), {'nickname': '몬테라'});
+      expect(
+        container.read(plantFormControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+  });
+}
+
+class _RecordingPlantRepository extends PlantRepository {
+  _RecordingPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int createCalls = 0;
+  int updateCalls = 0;
+  String? latestUpdatePlantId;
+  String? latestUpdatePlaceCode;
+  CreatePlantRequest? latestCreateRequest;
+  UpdatePlantRequest? latestUpdateRequest;
+
+  @override
+  Future<void> createPlant(
+    CreatePlantRequest request, {
+    MultipartFile? image,
+  }) async {
+    createCalls++;
+    latestCreateRequest = request;
+  }
+
+  @override
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    required UpdatePlantRequest request,
+    MultipartFile? image,
+  }) async {
+    updateCalls++;
+    latestUpdatePlantId = plantId;
+    latestUpdatePlaceCode = placeCode;
+    latestUpdateRequest = request;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #93

## 구현 범위
- `PlantFormPage`의 생성/수정 submit 로직을 `plantFormControllerProvider`로 분리했습니다.
- page의 `plant_requests.dart`, `plant_repository.dart`, `FormSubmitController` 직접 의존을 제거했습니다.
- local 생성/수정, remote 생성/수정 요청을 controller 단위 테스트로 추가했습니다.

## 주요 변경사항
- `PlantFormController`가 submit 상태, remote/local 분기, repository 호출, Provider invalidate를 담당합니다.
- `PlantFormPage`는 controller 상태를 watch하고 성공 결과에 따라 홈 또는 식물 상세로 이동합니다.
- 기존 동작처럼 remote 생성 성공 후 local 목록도 함께 갱신하도록 유지했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md`의 방향에 맞춘 구현이라 별도 문서 변경은 없습니다.

## Breaking change 여부
- 없음
