### PR TITLE
Refactor: Place 나가기 로직 분리 #95

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -9,10 +9,9 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
-import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
@@ -45,32 +44,9 @@ class PlaceDetailPage extends ConsumerStatefulWidget {
 }
 
 class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
-  late final FormSubmitController _exitController;
-
-  bool get _isExiting => _exitController.state.isSubmitting;
-
-  @override
-  void initState() {
-    super.initState();
-    _exitController = FormSubmitController()
-      ..addListener(_handleExitStateChanged);
-  }
-
-  @override
-  void dispose() {
-    _exitController
-      ..removeListener(_handleExitStateChanged)
-      ..dispose();
-    super.dispose();
-  }
-
-  void _handleExitStateChanged() {
-    if (mounted) {
-      setState(() {});
-    }
-  }
-
   void _showExitDialog(BuildContext context) {
+    final isExiting = ref.read(placeExitControllerProvider).isSubmitting;
+
     showCommonDialog<void>(
       context: context,
       child: CommonDialogCard(
@@ -85,7 +61,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
           CommonDialogActionButton.confirm(
             label: '나가기',
             foregroundColor: AppColors.danger,
-            onPressed: _isExiting ? null : () => _confirmExit(context),
+            onPressed: isExiting ? null : () => _confirmExit(context),
           ),
         ],
       ),
@@ -150,29 +126,28 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
   }
 
   Future<void> _exitPlace(BuildContext context) async {
-    if (!ref.read(useRemoteApiProvider)) {
-      return;
-    }
-
-    await _exitController.submit(() async {
-      await ref.read(placeRepositoryProvider).deletePlace(widget.placeId);
-      ref.invalidate(placeDetailProvider(widget.placeId));
-      ref.invalidate(remotePlaceListProvider);
-      ref.invalidate(plantRegistrationPlaceProvider);
-    }, failureMessage: '장소 나가기에 실패했어요');
+    final result = await ref
+        .read(placeExitControllerProvider.notifier)
+        .exit(widget.placeId);
 
     if (!mounted || !context.mounted) {
       return;
     }
 
-    if (_exitController.state.hasError) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_exitController.state.errorMessage!)),
-      );
+    if (result?.destination == PlaceExitDestination.home) {
+      context.go(AppRoutePaths.home);
       return;
     }
 
-    context.go(AppRoutePaths.home);
+    final errorMessage = ref.read(placeExitControllerProvider).errorMessage;
+
+    if (errorMessage == null) {
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
   Widget _buildScaffold(BuildContext context, _PlaceDetailData detail) {

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -1,0 +1,54 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeExitControllerProvider =
+    NotifierProvider<PlaceExitController, FormSubmitState>(
+      PlaceExitController.new,
+    );
+
+enum PlaceExitDestination { home }
+
+class PlaceExitResult {
+  const PlaceExitResult._(this.destination);
+
+  const PlaceExitResult.home() : this._(PlaceExitDestination.home);
+
+  final PlaceExitDestination destination;
+}
+
+class PlaceExitController extends Notifier<FormSubmitState> {
+  @override
+  FormSubmitState build() {
+    return const FormSubmitState.idle();
+  }
+
+  Future<PlaceExitResult?> exit(String placeId) async {
+    if (state.isSubmitting) {
+      return null;
+    }
+
+    if (!ref.read(useRemoteApiProvider)) {
+      state = const FormSubmitState.idle();
+      return null;
+    }
+
+    state = const FormSubmitState.submitting();
+
+    try {
+      await ref.read(placeRepositoryProvider).deletePlace(placeId);
+      ref.invalidate(placeDetailProvider(placeId));
+      ref.invalidate(remotePlaceListProvider);
+      ref.invalidate(plantRegistrationPlaceProvider);
+      state = const FormSubmitState.idle();
+
+      return const PlaceExitResult.home();
+    } catch (_) {
+      state = const FormSubmitState.failure('장소 나가기에 실패했어요');
+
+      return null;
+    }
+  }
+}

--- a/test/features/place/presentation/providers/place_exit_controller_test.dart
+++ b/test/features/place/presentation/providers/place_exit_controller_test.dart
@@ -1,0 +1,104 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlaceExitController', () {
+    test('remote 장소 나가기는 repository를 호출하고 홈 이동 결과를 반환한다', () async {
+      final repository = _RecordingPlaceRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeExitControllerProvider.notifier)
+          .exit('place-1');
+
+      expect(result?.destination, PlaceExitDestination.home);
+      expect(repository.deleteCalls, 1);
+      expect(repository.latestDeleteCode, 'place-1');
+      expect(
+        container.read(placeExitControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+
+    test('remote 장소 나가기 실패는 사용자 메시지 상태를 남긴다', () async {
+      final repository = _FailingPlaceRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeExitControllerProvider.notifier)
+          .exit('place-1');
+
+      expect(result, isNull);
+      expect(repository.deleteCalls, 1);
+      expect(
+        container.read(placeExitControllerProvider),
+        const FormSubmitState.failure('장소 나가기에 실패했어요'),
+      );
+    });
+
+    test('local 장소 나가기는 원격 요청 없이 idle 상태를 유지한다', () async {
+      final repository = _RecordingPlaceRepository();
+      final container = ProviderContainer(
+        overrides: [placeRepositoryProvider.overrideWithValue(repository)],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(placeExitControllerProvider.notifier)
+          .exit('place-1');
+
+      expect(result, isNull);
+      expect(repository.deleteCalls, 0);
+      expect(
+        container.read(placeExitControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+  });
+}
+
+class _RecordingPlaceRepository extends PlaceRepository {
+  _RecordingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  int deleteCalls = 0;
+  String? latestDeleteCode;
+
+  @override
+  Future<void> deletePlace(String code) async {
+    deleteCalls++;
+    latestDeleteCode = code;
+  }
+}
+
+class _FailingPlaceRepository extends PlaceRepository {
+  _FailingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
+
+  int deleteCalls = 0;
+
+  @override
+  Future<void> deletePlace(String code) async {
+    deleteCalls++;
+    throw StateError('raw failure');
+  }
+}


### PR DESCRIPTION
## Summary
- Place 상세의 장소 나가기 삭제/상태 처리 로직을 PlaceExitController로 분리했습니다.
- PlaceDetailPage가 repository와 FormSubmitController를 직접 다루지 않도록 정리했습니다.
- remote 성공/실패, local no-op 흐름을 Controller 단위 테스트로 추가했습니다.

## Test Plan
- fvm dart format --output=none --set-exit-if-changed .
- fvm flutter analyze
- fvm flutter test
- git diff --check

Closes #95