### PR TITLE
Refactor: Plant 삭제 로직 분리 #97

### DIFF
--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -9,11 +9,10 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
-import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
@@ -35,31 +34,6 @@ class PlantDetailPage extends ConsumerStatefulWidget {
 }
 
 class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
-  late final FormSubmitController _deleteController;
-
-  bool get _isDeleting => _deleteController.state.isSubmitting;
-
-  @override
-  void initState() {
-    super.initState();
-    _deleteController = FormSubmitController()
-      ..addListener(_handleDeleteStateChanged);
-  }
-
-  @override
-  void dispose() {
-    _deleteController
-      ..removeListener(_handleDeleteStateChanged)
-      ..dispose();
-    super.dispose();
-  }
-
-  void _handleDeleteStateChanged() {
-    if (mounted) {
-      setState(() {});
-    }
-  }
-
   void _showPlantMenu(BuildContext context, String? placeCode) {
     showGeneralDialog<void>(
       context: context,
@@ -102,6 +76,8 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
   }
 
   void _showDeleteDialog(BuildContext context, String? placeCode) {
+    final isDeleting = ref.read(plantDeleteControllerProvider).isSubmitting;
+
     showCommonDialog<void>(
       context: context,
       child: CommonDialogCard(
@@ -116,7 +92,7 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
           CommonDialogActionButton.confirm(
             label: '삭제',
             foregroundColor: AppColors.danger,
-            onPressed: _isDeleting
+            onPressed: isDeleting
                 ? null
                 : () => _confirmDelete(context, placeCode),
           ),
@@ -170,40 +146,28 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
   }
 
   Future<void> _deletePlant(BuildContext context, String? placeCode) async {
-    if (!ref.read(useRemoteApiProvider)) {
-      return;
-    }
-
-    final effectivePlaceCode = placeCode?.trim();
-
-    if (effectivePlaceCode == null || effectivePlaceCode.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('장소 정보를 확인할 수 없어요.')));
-      return;
-    }
-
-    await _deleteController.submit(() async {
-      await ref
-          .read(plantRepositoryProvider)
-          .deletePlant(plantId: widget.plantId, placeCode: effectivePlaceCode);
-      ref.invalidate(remotePlantListProvider);
-      ref.invalidate(remotePlantDetailProvider(widget.plantId));
-      ref.invalidate(remotePlantEditInfoProvider(widget.plantId));
-    }, failureMessage: '식물 삭제에 실패했어요');
+    final result = await ref
+        .read(plantDeleteControllerProvider.notifier)
+        .delete(plantId: widget.plantId, placeCode: placeCode);
 
     if (!mounted || !context.mounted) {
       return;
     }
 
-    if (_deleteController.state.hasError) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_deleteController.state.errorMessage!)),
-      );
+    if (result?.destination == PlantDeleteDestination.home) {
+      context.go(AppRoutePaths.home);
       return;
     }
 
-    context.go(AppRoutePaths.home);
+    final errorMessage = ref.read(plantDeleteControllerProvider).errorMessage;
+
+    if (errorMessage == null) {
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
   Widget _buildScaffold(BuildContext context, _PlantDetailData detail) {

--- a/lib/features/plant/presentation/providers/plant_delete_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_delete_controller.dart
@@ -1,0 +1,66 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantDeleteControllerProvider =
+    NotifierProvider<PlantDeleteController, FormSubmitState>(
+      PlantDeleteController.new,
+    );
+
+enum PlantDeleteDestination { home }
+
+class PlantDeleteResult {
+  const PlantDeleteResult._(this.destination);
+
+  const PlantDeleteResult.home() : this._(PlantDeleteDestination.home);
+
+  final PlantDeleteDestination destination;
+}
+
+class PlantDeleteController extends Notifier<FormSubmitState> {
+  @override
+  FormSubmitState build() {
+    return const FormSubmitState.idle();
+  }
+
+  Future<PlantDeleteResult?> delete({
+    required String plantId,
+    required String? placeCode,
+  }) async {
+    if (state.isSubmitting) {
+      return null;
+    }
+
+    if (!ref.read(useRemoteApiProvider)) {
+      state = const FormSubmitState.idle();
+      return null;
+    }
+
+    final effectivePlaceCode = placeCode?.trim();
+
+    if (effectivePlaceCode == null || effectivePlaceCode.isEmpty) {
+      state = const FormSubmitState.failure('장소 정보를 확인할 수 없어요.');
+      return null;
+    }
+
+    state = const FormSubmitState.submitting();
+
+    try {
+      await ref
+          .read(plantRepositoryProvider)
+          .deletePlant(plantId: plantId, placeCode: effectivePlaceCode);
+      ref.invalidate(remotePlantListProvider);
+      ref.invalidate(remotePlantDetailProvider(plantId));
+      ref.invalidate(remotePlantEditInfoProvider(plantId));
+      state = const FormSubmitState.idle();
+
+      return const PlantDeleteResult.home();
+    } catch (_) {
+      state = const FormSubmitState.failure('식물 삭제에 실패했어요');
+
+      return null;
+    }
+  }
+}

--- a/test/features/plant/presentation/providers/plant_delete_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_delete_controller_test.dart
@@ -1,0 +1,139 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlantDeleteController', () {
+    test('remote 식물 삭제는 repository를 호출하고 홈 이동 결과를 반환한다', () async {
+      final repository = _RecordingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantDeleteControllerProvider.notifier)
+          .delete(plantId: 'plant-1', placeCode: 'place-1');
+
+      expect(result?.destination, PlantDeleteDestination.home);
+      expect(repository.deleteCalls, 1);
+      expect(repository.latestDeletedPlantId, 'plant-1');
+      expect(repository.latestDeletedPlaceCode, 'place-1');
+      expect(
+        container.read(plantDeleteControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+
+    test('remote 식물 삭제 실패는 사용자 메시지 상태를 남긴다', () async {
+      final repository = _FailingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantDeleteControllerProvider.notifier)
+          .delete(plantId: 'plant-1', placeCode: 'place-1');
+
+      expect(result, isNull);
+      expect(repository.deleteCalls, 1);
+      expect(
+        container.read(plantDeleteControllerProvider),
+        const FormSubmitState.failure('식물 삭제에 실패했어요'),
+      );
+    });
+
+    test('placeCode가 없으면 원격 요청 없이 사용자 메시지 상태를 남긴다', () async {
+      final repository = _RecordingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantDeleteControllerProvider.notifier)
+          .delete(plantId: 'plant-1', placeCode: ' ');
+
+      expect(result, isNull);
+      expect(repository.deleteCalls, 0);
+      expect(
+        container.read(plantDeleteControllerProvider),
+        const FormSubmitState.failure('장소 정보를 확인할 수 없어요.'),
+      );
+    });
+
+    test('local 식물 삭제는 원격 요청 없이 idle 상태를 유지한다', () async {
+      final repository = _RecordingPlantRepository();
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(false),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(plantDeleteControllerProvider.notifier)
+          .delete(plantId: 'plant-1', placeCode: 'place-1');
+
+      expect(result, isNull);
+      expect(repository.deleteCalls, 0);
+      expect(
+        container.read(plantDeleteControllerProvider),
+        const FormSubmitState.idle(),
+      );
+    });
+  });
+}
+
+class _RecordingPlantRepository extends PlantRepository {
+  _RecordingPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int deleteCalls = 0;
+  String? latestDeletedPlantId;
+  String? latestDeletedPlaceCode;
+
+  @override
+  Future<void> deletePlant({
+    required String plantId,
+    required String placeCode,
+  }) async {
+    deleteCalls++;
+    latestDeletedPlantId = plantId;
+    latestDeletedPlaceCode = placeCode;
+  }
+}
+
+class _FailingPlantRepository extends PlantRepository {
+  _FailingPlantRepository() : super(PlantRemoteDataSource(Dio()));
+
+  int deleteCalls = 0;
+
+  @override
+  Future<void> deletePlant({
+    required String plantId,
+    required String placeCode,
+  }) async {
+    deleteCalls++;
+    throw StateError('raw failure');
+  }
+}


### PR DESCRIPTION
## Summary
- Plant 상세의 식물 삭제 API 호출과 submit 상태를 `PlantDeleteController`로 분리했습니다.
- `PlantDetailPage`가 repository와 `FormSubmitController`를 직접 다루지 않도록 정리했습니다.
- remote 성공/실패, placeCode 누락, local no-op 흐름을 Controller 단위 테스트로 추가했습니다.

## Test Plan
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

Closes #97
