### PR TITLE
Refactor: Place 상세 위젯 분리 #99

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -5,20 +5,16 @@ import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
-import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
-import 'package:commonplant_frontend/shared/widgets/common_plant_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
-import 'package:commonplant_frontend/shared/widgets/common_watering_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -158,9 +154,9 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
         fontWeight: FontWeight.w700,
       ),
       bodyPadding: EdgeInsets.zero,
-      floatingActionButton: _PlaceDetailFab(
+      floatingActionButton: PlaceDetailFab(
         placeId: widget.placeId,
-        role: detail.role,
+        canEditPlace: detail.role == PlaceDetailRole.leader,
         onExit: () => _showExitDialog(context),
       ),
       child: SizedBox(
@@ -170,8 +166,15 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
             constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
             child: Column(
               children: [
-                _PlaceDetailHeader(detail: detail, placeId: widget.placeId),
-                _PlacePlantList(placeId: widget.placeId, plants: detail.plants),
+                PlaceDetailHeader(
+                  placeId: widget.placeId,
+                  name: detail.name,
+                  address: detail.address,
+                  sunlightLabel: detail.sunlightLabel,
+                  humidityLabel: detail.humidityLabel,
+                  friends: detail.friends,
+                ),
+                PlacePlantList(placeId: widget.placeId, plants: detail.plants),
               ],
             ),
           ),
@@ -300,8 +303,8 @@ class _PlaceDetailData {
   final String address;
   final String sunlightLabel;
   final String humidityLabel;
-  final List<_PlaceFriend> friends;
-  final List<_PlacePlant> plants;
+  final List<PlaceDetailFriendItem> friends;
+  final List<PlaceDetailPlantItem> plants;
 
   _PlaceDetailData applySummary(PlaceSummary summary) {
     return _PlaceDetailData(
@@ -325,21 +328,21 @@ class _PlaceDetailData {
       sunlightLabel: '9.3 / 5',
       humidityLabel: '69%',
       friends: const [
-        _PlaceFriend(
+        PlaceDetailFriendItem(
           id: 'me',
           name: '나',
           imageAsset: AppImageAssets.placeDetailAvatarMe,
           isOwner: true,
         ),
-        _PlaceFriend(
+        PlaceDetailFriendItem(
           id: 'common-mom',
           name: '커먼맘',
           imageAsset: AppImageAssets.placeDetailAvatarCommonMom,
         ),
-        _PlaceFriend(id: 'common-papa', name: '커먼 파파'),
+        PlaceDetailFriendItem(id: 'common-papa', name: '커먼 파파'),
       ],
       plants: const [
-        _PlacePlant(
+        PlaceDetailPlantItem(
           id: 'plant-1',
           name: '몬테',
           species: '몬스테라',
@@ -348,7 +351,7 @@ class _PlaceDetailData {
           dateLabel: '2022.11.20',
           canWater: true,
         ),
-        _PlacePlant(
+        PlaceDetailPlantItem(
           id: 'plant-2',
           name: '몬테',
           species: '몬스테라',
@@ -356,7 +359,7 @@ class _PlaceDetailData {
           dDayLabel: 'D-5',
           dateLabel: '2022.11.20',
         ),
-        _PlacePlant(
+        PlaceDetailPlantItem(
           id: 'plant-3',
           name: '몬테',
           species: '몬스테라',
@@ -364,7 +367,7 @@ class _PlaceDetailData {
           dDayLabel: 'D-5',
           dateLabel: '2022.11.20',
         ),
-        _PlacePlant(
+        PlaceDetailPlantItem(
           id: 'plant-4',
           name: '몬테',
           species: '몬스테라',
@@ -384,449 +387,5 @@ class _PlaceDetailData {
     }
 
     return PlaceDetailRole.leader;
-  }
-}
-
-class _PlaceFriend {
-  const _PlaceFriend({
-    required this.id,
-    required this.name,
-    this.imageAsset,
-    this.isOwner = false,
-  });
-
-  final String id;
-  final String name;
-  final String? imageAsset;
-  final bool isOwner;
-
-  PlaceFriendProfile toProfile() {
-    return PlaceFriendProfile(id: id, name: name, imageAsset: imageAsset);
-  }
-}
-
-class _PlacePlant {
-  const _PlacePlant({
-    required this.id,
-    required this.name,
-    required this.species,
-    required this.description,
-    required this.dDayLabel,
-    required this.dateLabel,
-    this.canWater = false,
-  });
-
-  final String id;
-  final String name;
-  final String species;
-  final String description;
-  final String dDayLabel;
-  final String dateLabel;
-  final bool canWater;
-}
-
-class _PlaceDetailHeader extends StatelessWidget {
-  const _PlaceDetailHeader({required this.detail, required this.placeId});
-
-  final _PlaceDetailData detail;
-  final String placeId;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: AppColors.surfaceBase,
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.textStrong.withValues(alpha: 0.1),
-            blurRadius: 8,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.x20,
-          AppSpacing.x16,
-          AppSpacing.x20,
-          AppSpacing.x16,
-        ),
-        child: Column(
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: _PlaceTitleBlock(
-                    name: detail.name,
-                    address: detail.address,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.x12),
-                _PlaceMetricStrip(
-                  sunlightLabel: detail.sunlightLabel,
-                  humidityLabel: detail.humidityLabel,
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.x24),
-            _PlaceFriendStrip(friends: detail.friends, placeId: placeId),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PlaceTitleBlock extends StatelessWidget {
-  const _PlaceTitleBlock({required this.name, required this.address});
-
-  final String name;
-  final String address;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          name,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTextStyles.size24Medium.copyWith(
-            color: AppColors.textHeadline,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.x4),
-        Text(
-          address,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTextStyles.size16Medium.copyWith(
-            color: AppColors.textStrong,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlaceMetricStrip extends StatelessWidget {
-  const _PlaceMetricStrip({
-    required this.sunlightLabel,
-    required this.humidityLabel,
-  });
-
-  final String sunlightLabel;
-  final String humidityLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _PlaceMetric(
-          icon: AppIconAssets.tagSunlight,
-          label: sunlightLabel,
-          semanticsLabel: '햇빛',
-        ),
-        const SizedBox(width: AppSpacing.x16),
-        _PlaceMetric(
-          icon: AppIconAssets.tagHumidity,
-          label: humidityLabel,
-          semanticsLabel: '습도',
-        ),
-      ],
-    );
-  }
-}
-
-class _PlaceMetric extends StatelessWidget {
-  const _PlaceMetric({
-    required this.icon,
-    required this.label,
-    required this.semanticsLabel,
-  });
-
-  final String icon;
-  final String label;
-  final String semanticsLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        CommonSvgIcon(
-          icon,
-          width: AppSizes.iconMedium,
-          height: AppSizes.iconMedium,
-          semanticsLabel: semanticsLabel,
-        ),
-        const SizedBox(height: AppSpacing.x8),
-        Text(
-          label,
-          style: AppTextStyles.size14Medium.copyWith(
-            color: AppColors.textHeadline,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlaceFriendStrip extends StatelessWidget {
-  const _PlaceFriendStrip({required this.friends, required this.placeId});
-
-  final List<_PlaceFriend> friends;
-  final String placeId;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        for (final friend in friends)
-          _PlaceFriendMark(friend: friend, profile: friend.toProfile()),
-        _FriendManagementShortcut(
-          onPressed: () =>
-              context.push(AppRoutePaths.friendManagementLocation(placeId)),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlaceFriendMark extends StatelessWidget {
-  const _PlaceFriendMark({required this.friend, required this.profile});
-
-  final _PlaceFriend friend;
-  final PlaceFriendProfile profile;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 56,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            width: 46,
-            height: 40,
-            child: Stack(
-              clipBehavior: Clip.none,
-              alignment: Alignment.center,
-              children: [
-                if (friend.isOwner)
-                  Positioned(
-                    left: 1,
-                    top: 2,
-                    child: Transform.rotate(
-                      angle: -0.8,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          color: AppColors.brandSoft,
-                          borderRadius: BorderRadius.circular(AppRadius.xSmall),
-                        ),
-                        child: const SizedBox(width: 18, height: 10),
-                      ),
-                    ),
-                  ),
-                PlaceFriendAvatar(friend: profile, dimension: 36),
-              ],
-            ),
-          ),
-          Text(
-            friend.name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            style: AppTextStyles.size12Medium.copyWith(
-              color: AppColors.iconInactive,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _FriendManagementShortcut extends StatelessWidget {
-  const _FriendManagementShortcut({required this.onPressed});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: '친구 관리',
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onPressed,
-        child: SizedBox(
-          width: 56,
-          height: 56,
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: DecoratedBox(
-              decoration: const BoxDecoration(
-                color: AppColors.surfaceDisabled,
-                shape: BoxShape.circle,
-              ),
-              child: SizedBox.square(
-                dimension: 36,
-                child: Icon(
-                  Icons.chevron_right,
-                  color: AppColors.iconInactive,
-                  size: AppSizes.iconMedium,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlacePlantList extends StatelessWidget {
-  const _PlacePlantList({required this.placeId, required this.plants});
-
-  final String placeId;
-  final List<_PlacePlant> plants;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        AppSpacing.x24,
-        AppSpacing.x20,
-        120,
-      ),
-      child: Column(
-        children: [
-          for (final plant in plants) ...[
-            CommonPlacePlantCard(
-              width: double.infinity,
-              name: plant.name,
-              species: plant.species,
-              description: plant.description,
-              imageProvider: const AssetImage(
-                AppImageAssets.placeDetailMonstera,
-              ),
-              action: CommonWateringButton(
-                onPressed: plant.canWater ? () {} : null,
-              ),
-              trailing: _PlantDueInfo(
-                dDayLabel: plant.dDayLabel,
-                dateLabel: plant.dateLabel,
-                isPrimary: plant.canWater,
-              ),
-              onTap: () => context.push(
-                AppRoutePaths.plantDetailLocation(plant.id, placeId: placeId),
-              ),
-            ),
-            if (plant != plants.last) const SizedBox(height: AppSpacing.x16),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _PlantDueInfo extends StatelessWidget {
-  const _PlantDueInfo({
-    required this.dDayLabel,
-    required this.dateLabel,
-    required this.isPrimary,
-  });
-
-  final String dDayLabel;
-  final String dateLabel;
-  final bool isPrimary;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        Text(
-          dDayLabel,
-          style: AppTextStyles.size16Bold.copyWith(
-            color: isPrimary ? AppColors.brandPrimary : AppColors.iconInactive,
-          ),
-        ),
-        Text(
-          dateLabel,
-          style: AppTextStyles.size12Medium.copyWith(color: AppColors.textBody),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlaceDetailFab extends StatelessWidget {
-  const _PlaceDetailFab({
-    required this.placeId,
-    required this.role,
-    required this.onExit,
-  });
-
-  final String placeId;
-  final PlaceDetailRole role;
-  final VoidCallback onExit;
-
-  @override
-  Widget build(BuildContext context) {
-    return CommonFabDial(
-      actions: [
-        CommonFabDialAction(
-          label: '식물 추가하기',
-          icon: const CommonSvgIcon(
-            AppIconAssets.addPlant,
-            width: AppSizes.iconMedium,
-            height: AppSizes.iconMedium,
-            color: AppColors.textStrong,
-            semanticsLabel: '식물 추가',
-          ),
-          onPressed: () => context.push(AppRoutePaths.plantSearch),
-        ),
-        if (role == PlaceDetailRole.leader)
-          CommonFabDialAction(
-            label: '장소 수정하기',
-            icon: const CommonSvgIcon(
-              AppIconAssets.edit,
-              width: AppSizes.iconMedium,
-              height: AppSizes.iconMedium,
-              color: AppColors.textStrong,
-              semanticsLabel: '장소 수정',
-            ),
-            onPressed: () =>
-                context.push(AppRoutePaths.placeEditLocation(placeId)),
-          ),
-        CommonFabDialAction(
-          label: '장소 나가기',
-          icon: const CommonSvgIcon(
-            AppIconAssets.exit,
-            width: AppSizes.iconMedium,
-            height: AppSizes.iconMedium,
-            color: AppColors.textStrong,
-            semanticsLabel: '장소 나가기',
-          ),
-          onPressed: onExit,
-        ),
-      ],
-      child: const CommonSvgIcon(
-        AppIconAssets.shape,
-        width: 5,
-        height: 25,
-        semanticsLabel: '장소 상세 메뉴',
-      ),
-    );
   }
 }

--- a/lib/features/place/presentation/widgets/place_detail_widgets.dart
+++ b/lib/features/place/presentation/widgets/place_detail_widgets.dart
@@ -1,0 +1,473 @@
+import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selection_widgets.dart';
+import 'package:commonplant_frontend/shared/widgets/common_fab.dart';
+import 'package:commonplant_frontend/shared/widgets/common_plant_card.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:commonplant_frontend/shared/widgets/common_watering_button.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PlaceDetailFriendItem {
+  const PlaceDetailFriendItem({
+    required this.id,
+    required this.name,
+    this.imageAsset,
+    this.isOwner = false,
+  });
+
+  final String id;
+  final String name;
+  final String? imageAsset;
+  final bool isOwner;
+
+  PlaceFriendProfile toProfile() {
+    return PlaceFriendProfile(id: id, name: name, imageAsset: imageAsset);
+  }
+}
+
+class PlaceDetailPlantItem {
+  const PlaceDetailPlantItem({
+    required this.id,
+    required this.name,
+    required this.species,
+    required this.description,
+    required this.dDayLabel,
+    required this.dateLabel,
+    this.canWater = false,
+  });
+
+  final String id;
+  final String name;
+  final String species;
+  final String description;
+  final String dDayLabel;
+  final String dateLabel;
+  final bool canWater;
+}
+
+class PlaceDetailHeader extends StatelessWidget {
+  const PlaceDetailHeader({
+    super.key,
+    required this.placeId,
+    required this.name,
+    required this.address,
+    required this.sunlightLabel,
+    required this.humidityLabel,
+    required this.friends,
+  });
+
+  final String placeId;
+  final String name;
+  final String address;
+  final String sunlightLabel;
+  final String humidityLabel;
+  final List<PlaceDetailFriendItem> friends;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.surfaceBase,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.textStrong.withValues(alpha: 0.1),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x20,
+          AppSpacing.x16,
+          AppSpacing.x20,
+          AppSpacing.x16,
+        ),
+        child: Column(
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: _PlaceTitleBlock(name: name, address: address),
+                ),
+                const SizedBox(width: AppSpacing.x12),
+                _PlaceMetricStrip(
+                  sunlightLabel: sunlightLabel,
+                  humidityLabel: humidityLabel,
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.x24),
+            _PlaceFriendStrip(friends: friends, placeId: placeId),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class PlacePlantList extends StatelessWidget {
+  const PlacePlantList({
+    super.key,
+    required this.placeId,
+    required this.plants,
+  });
+
+  final String placeId;
+  final List<PlaceDetailPlantItem> plants;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        AppSpacing.x24,
+        AppSpacing.x20,
+        120,
+      ),
+      child: Column(
+        children: [
+          for (final plant in plants) ...[
+            CommonPlacePlantCard(
+              width: double.infinity,
+              name: plant.name,
+              species: plant.species,
+              description: plant.description,
+              imageProvider: const AssetImage(
+                AppImageAssets.placeDetailMonstera,
+              ),
+              action: CommonWateringButton(
+                onPressed: plant.canWater ? () {} : null,
+              ),
+              trailing: _PlantDueInfo(
+                dDayLabel: plant.dDayLabel,
+                dateLabel: plant.dateLabel,
+                isPrimary: plant.canWater,
+              ),
+              onTap: () => context.push(
+                AppRoutePaths.plantDetailLocation(plant.id, placeId: placeId),
+              ),
+            ),
+            if (plant != plants.last) const SizedBox(height: AppSpacing.x16),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class PlaceDetailFab extends StatelessWidget {
+  const PlaceDetailFab({
+    super.key,
+    required this.placeId,
+    required this.canEditPlace,
+    required this.onExit,
+  });
+
+  final String placeId;
+  final bool canEditPlace;
+  final VoidCallback onExit;
+
+  @override
+  Widget build(BuildContext context) {
+    return CommonFabDial(
+      actions: [
+        CommonFabDialAction(
+          label: '식물 추가하기',
+          icon: const CommonSvgIcon(
+            AppIconAssets.addPlant,
+            width: AppSizes.iconMedium,
+            height: AppSizes.iconMedium,
+            color: AppColors.textStrong,
+            semanticsLabel: '식물 추가',
+          ),
+          onPressed: () => context.push(AppRoutePaths.plantSearch),
+        ),
+        if (canEditPlace)
+          CommonFabDialAction(
+            label: '장소 수정하기',
+            icon: const CommonSvgIcon(
+              AppIconAssets.edit,
+              width: AppSizes.iconMedium,
+              height: AppSizes.iconMedium,
+              color: AppColors.textStrong,
+              semanticsLabel: '장소 수정',
+            ),
+            onPressed: () =>
+                context.push(AppRoutePaths.placeEditLocation(placeId)),
+          ),
+        CommonFabDialAction(
+          label: '장소 나가기',
+          icon: const CommonSvgIcon(
+            AppIconAssets.exit,
+            width: AppSizes.iconMedium,
+            height: AppSizes.iconMedium,
+            color: AppColors.textStrong,
+            semanticsLabel: '장소 나가기',
+          ),
+          onPressed: onExit,
+        ),
+      ],
+      child: const CommonSvgIcon(
+        AppIconAssets.shape,
+        width: 5,
+        height: 25,
+        semanticsLabel: '장소 상세 메뉴',
+      ),
+    );
+  }
+}
+
+class _PlaceTitleBlock extends StatelessWidget {
+  const _PlaceTitleBlock({required this.name, required this.address});
+
+  final String name;
+  final String address;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size24Medium.copyWith(
+            color: AppColors.textHeadline,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x4),
+        Text(
+          address,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size16Medium.copyWith(
+            color: AppColors.textStrong,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaceMetricStrip extends StatelessWidget {
+  const _PlaceMetricStrip({
+    required this.sunlightLabel,
+    required this.humidityLabel,
+  });
+
+  final String sunlightLabel;
+  final String humidityLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _PlaceMetric(
+          icon: AppIconAssets.tagSunlight,
+          label: sunlightLabel,
+          semanticsLabel: '햇빛',
+        ),
+        const SizedBox(width: AppSpacing.x16),
+        _PlaceMetric(
+          icon: AppIconAssets.tagHumidity,
+          label: humidityLabel,
+          semanticsLabel: '습도',
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaceMetric extends StatelessWidget {
+  const _PlaceMetric({
+    required this.icon,
+    required this.label,
+    required this.semanticsLabel,
+  });
+
+  final String icon;
+  final String label;
+  final String semanticsLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        CommonSvgIcon(
+          icon,
+          width: AppSizes.iconMedium,
+          height: AppSizes.iconMedium,
+          semanticsLabel: semanticsLabel,
+        ),
+        const SizedBox(height: AppSpacing.x8),
+        Text(
+          label,
+          style: AppTextStyles.size14Medium.copyWith(
+            color: AppColors.textHeadline,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaceFriendStrip extends StatelessWidget {
+  const _PlaceFriendStrip({required this.friends, required this.placeId});
+
+  final List<PlaceDetailFriendItem> friends;
+  final String placeId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        for (final friend in friends)
+          _PlaceFriendMark(friend: friend, profile: friend.toProfile()),
+        _FriendManagementShortcut(
+          onPressed: () =>
+              context.push(AppRoutePaths.friendManagementLocation(placeId)),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaceFriendMark extends StatelessWidget {
+  const _PlaceFriendMark({required this.friend, required this.profile});
+
+  final PlaceDetailFriendItem friend;
+  final PlaceFriendProfile profile;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 56,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 46,
+            height: 40,
+            child: Stack(
+              clipBehavior: Clip.none,
+              alignment: Alignment.center,
+              children: [
+                if (friend.isOwner)
+                  Positioned(
+                    left: 1,
+                    top: 2,
+                    child: Transform.rotate(
+                      angle: -0.8,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: AppColors.brandSoft,
+                          borderRadius: BorderRadius.circular(AppRadius.xSmall),
+                        ),
+                        child: const SizedBox(width: 18, height: 10),
+                      ),
+                    ),
+                  ),
+                PlaceFriendAvatar(friend: profile, dimension: 36),
+              ],
+            ),
+          ),
+          Text(
+            friend.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: AppTextStyles.size12Medium.copyWith(
+              color: AppColors.iconInactive,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FriendManagementShortcut extends StatelessWidget {
+  const _FriendManagementShortcut({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: '친구 관리',
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onPressed,
+        child: SizedBox(
+          width: 56,
+          height: 56,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                color: AppColors.surfaceDisabled,
+                shape: BoxShape.circle,
+              ),
+              child: SizedBox.square(
+                dimension: 36,
+                child: Icon(
+                  Icons.chevron_right,
+                  color: AppColors.iconInactive,
+                  size: AppSizes.iconMedium,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlantDueInfo extends StatelessWidget {
+  const _PlantDueInfo({
+    required this.dDayLabel,
+    required this.dateLabel,
+    required this.isPrimary,
+  });
+
+  final String dDayLabel;
+  final String dateLabel;
+  final bool isPrimary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Text(
+          dDayLabel,
+          style: AppTextStyles.size16Bold.copyWith(
+            color: isPrimary ? AppColors.brandPrimary : AppColors.iconInactive,
+          ),
+        ),
+        Text(
+          dateLabel,
+          style: AppTextStyles.size12Medium.copyWith(color: AppColors.textBody),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/place/presentation/widgets/place_detail_widgets_test.dart
+++ b/test/features/place/presentation/widgets/place_detail_widgets_test.dart
@@ -1,0 +1,112 @@
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets('PlaceDetailHeader는 장소 정보와 친구 관리 이동을 제공한다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        PlaceDetailHeader(
+          placeId: 'place-1',
+          name: '옥상 정원',
+          address: '서울시 노원구 광운로 20',
+          sunlightLabel: '9.3 / 5',
+          humidityLabel: '69%',
+          friends: const [
+            PlaceDetailFriendItem(id: 'me', name: '나', isOwner: true),
+            PlaceDetailFriendItem(id: 'mate', name: '커먼맘'),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('옥상 정원'), findsOneWidget);
+    expect(find.text('서울시 노원구 광운로 20'), findsOneWidget);
+    expect(find.text('9.3 / 5'), findsOneWidget);
+    expect(find.text('69%'), findsOneWidget);
+    expect(find.text('나'), findsOneWidget);
+    expect(find.text('커먼맘'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('친구 관리'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('친구 관리 화면'), findsOneWidget);
+  });
+
+  testWidgets('PlacePlantList는 식물 정보를 표시하고 식물 상세로 이동한다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        const PlacePlantList(
+          placeId: 'place-1',
+          plants: [
+            PlaceDetailPlantItem(
+              id: 'plant-1',
+              name: '몬테',
+              species: '몬스테라',
+              description: '일주일에 x번 물주는 거 잊지 않기',
+              dDayLabel: 'D-3',
+              dateLabel: '2022.11.20',
+              canWater: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('몬테'), findsOneWidget);
+    expect(find.text('몬스테라'), findsOneWidget);
+    expect(find.text('D-3'), findsOneWidget);
+    expect(find.text('2022.11.20'), findsOneWidget);
+
+    await tester.tap(find.text('몬테'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('식물 상세 화면'), findsOneWidget);
+  });
+
+  testWidgets('PlaceDetailFab는 권한에 따라 장소 수정 액션을 표시한다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        PlaceDetailFab(placeId: 'place-1', canEditPlace: false, onExit: () {}),
+      ),
+    );
+
+    await tester.tap(find.bySemanticsLabel('장소 상세 메뉴'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('식물 추가하기'), findsOneWidget);
+    expect(find.text('장소 수정하기'), findsNothing);
+    expect(find.text('장소 나가기'), findsOneWidget);
+  });
+}
+
+Widget _buildRouterApp(Widget home) {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(body: home),
+      ),
+      GoRoute(
+        path: '/places/:placeId/friends',
+        builder: (context, state) => const Text('친구 관리 화면'),
+      ),
+      GoRoute(
+        path: '/plants/:plantId',
+        builder: (context, state) => const Text('식물 상세 화면'),
+      ),
+      GoRoute(
+        path: '/plants/new/search',
+        builder: (context, state) => const Text('식물 검색 화면'),
+      ),
+      GoRoute(
+        path: '/places/:placeId/edit',
+        builder: (context, state) => const Text('장소 수정 화면'),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(routerConfig: router);
+}


### PR DESCRIPTION
## Summary
- `PlaceDetailPage` 내부의 header, metric, friend strip, plant list, FAB 전용 UI를 `place_detail_widgets.dart`로 분리했습니다.
- page는 Provider 상태, dialog/route 처리, mock detail 조립 중심으로 축소했습니다.
- 분리된 Place 상세 feature widget의 렌더링과 주요 이동 동작을 widget test로 추가했습니다.

## Test Plan
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

Closes #99
