### PR TITLE
Refactor: Plant 상세 위젯 분리 #101

### DIFF
--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -5,18 +5,16 @@ import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_widgets.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
-import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
-import 'package:commonplant_frontend/shared/widgets/common_memo_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
@@ -186,10 +184,22 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _PlantDetailContentWidth(child: _PlantHero(detail: detail)),
-            _PlantCareSummary(detail: detail),
-            _MemoPreviewSection(plantId: widget.plantId, memos: detail.memos),
-            _PlantInfoSection(detail: detail),
+            PlantDetailContentWidth(
+              child: PlantHero(
+                placeName: detail.placeName,
+                name: detail.name,
+                species: detail.species,
+              ),
+            ),
+            PlantCareSummary(
+              name: detail.name,
+              daysTogether: detail.daysTogether,
+              dDayLabel: detail.dDayLabel,
+              startDate: detail.startDate,
+              lastWateredDate: detail.lastWateredDate,
+            ),
+            MemoPreviewSection(plantId: widget.plantId, memos: detail.memos),
+            PlantInfoSection(wateringCycleLabel: detail.wateringCycleLabel),
             const SizedBox(height: 82),
           ],
         ),
@@ -225,7 +235,7 @@ class _PlantDetailData {
   final String startDate;
   final String lastWateredDate;
   final String wateringCycleLabel;
-  final List<_PlantMemo> memos;
+  final List<PlantDetailMemoItem> memos;
 
   _PlantDetailData applyRemote(PlantDetail detail) {
     return _PlantDetailData(
@@ -254,60 +264,32 @@ class _PlantDetailData {
       lastWateredDate: '2022.11.24',
       wateringCycleLabel: '10 Day',
       memos: const [
-        _PlantMemo(
+        PlantDetailMemoItem(
           author: '커먼플랜트',
           content: '장마여서 물주는 날짜를 조금 늦춤 하지만 해는 맑구나 몬테랑 함께...',
           dateLabel: '2022.11.20',
           avatarAsset: AppImageAssets.placeDetailAvatarMe,
           thumbnailAsset: AppImageAssets.placeDetailMonstera,
         ),
-        _PlantMemo(
+        PlantDetailMemoItem(
           author: '커먼맘',
           content: '오늘은 잎이 조금 시들하구나 커먼아 해결책은?',
           dateLabel: '2022.11.20',
           avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
         ),
-        _PlantMemo(
+        PlantDetailMemoItem(
           author: '커먼맘',
           content: '오늘은 잎의 상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기...',
           dateLabel: '2022.11.20',
           avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
           thumbnailAsset: AppImageAssets.plantEditMonstera,
         ),
-        _PlantMemo(author: '커먼 파파', content: '오늘도 맑음', dateLabel: '2022.11.20'),
+        PlantDetailMemoItem(
+          author: '커먼 파파',
+          content: '오늘도 맑음',
+          dateLabel: '2022.11.20',
+        ),
       ],
-    );
-  }
-}
-
-class _PlantMemo {
-  const _PlantMemo({
-    required this.author,
-    required this.content,
-    required this.dateLabel,
-    this.avatarAsset,
-    this.thumbnailAsset,
-  });
-
-  final String author;
-  final String content;
-  final String dateLabel;
-  final String? avatarAsset;
-  final String? thumbnailAsset;
-}
-
-class _PlantDetailContentWidth extends StatelessWidget {
-  const _PlantDetailContentWidth({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
-        child: child,
-      ),
     );
   }
 }
@@ -339,491 +321,6 @@ class _PlantDetailMenuButton extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _PlantHero extends StatelessWidget {
-  const _PlantHero({required this.detail});
-
-  final _PlantDetailData detail;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        0,
-        AppSpacing.x20,
-        AppSpacing.x16,
-      ),
-      child: Column(
-        children: [
-          _PlantHeroImage(placeName: detail.placeName),
-          const SizedBox(height: AppSpacing.x8),
-          Text(
-            detail.name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            style: AppTextStyles.size24Medium.copyWith(
-              color: AppColors.textHeadline,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          Text(
-            detail.species,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            style: AppTextStyles.size16Medium.copyWith(
-              color: AppColors.textStrong,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PlantHeroImage extends StatelessWidget {
-  const _PlantHeroImage({required this.placeName});
-
-  final String placeName;
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final width = constraints.maxWidth < 335 ? constraints.maxWidth : 335.0;
-        final scale = width / 335;
-        final height = 208 * scale;
-
-        return ClipRRect(
-          borderRadius: BorderRadius.circular(AppRadius.medium),
-          child: SizedBox(
-            width: width,
-            height: height,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                const ColoredBox(color: AppColors.surfaceMuted),
-                Positioned(
-                  left: 0,
-                  top: -126 * scale,
-                  child: Image.asset(
-                    AppImageAssets.plantEditMonstera,
-                    width: 495 * scale,
-                    height: 369 * scale,
-                    fit: BoxFit.cover,
-                    semanticLabel: '몬테 식물 사진',
-                  ),
-                ),
-                Positioned(
-                  top: AppSpacing.x8 * scale,
-                  left: 0,
-                  right: 0,
-                  child: Center(child: _PlaceBadge(label: placeName)),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-class _PlaceBadge extends StatelessWidget {
-  const _PlaceBadge({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 280),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: AppColors.brandStrong,
-          borderRadius: BorderRadius.circular(AppRadius.small),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.x10,
-            AppSpacing.x4,
-            AppSpacing.x16,
-            AppSpacing.x4,
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.add_home_outlined,
-                color: AppColors.onBrand,
-                size: AppSizes.iconMedium,
-              ),
-              const SizedBox(width: AppSpacing.x4),
-              Flexible(
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyles.size14Bold.copyWith(
-                    color: AppColors.onBrand,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlantCareSummary extends StatelessWidget {
-  const _PlantCareSummary({required this.detail});
-
-  final _PlantDetailData detail;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const _SectionDivider(),
-        _PlantDetailContentWidth(
-          child: Column(
-            children: [
-              const SizedBox(height: AppSpacing.x24),
-              RichText(
-                textAlign: TextAlign.center,
-                text: TextSpan(
-                  style: AppTextStyles.size16Medium.copyWith(
-                    color: AppColors.textBody,
-                  ),
-                  children: [
-                    TextSpan(text: '${detail.name}와 함께한지 '),
-                    TextSpan(
-                      text: '${detail.daysTogether}일',
-                      style: AppTextStyles.size18Medium.copyWith(
-                        color: AppColors.textStrong,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const TextSpan(text: '이 지났어요!'),
-                  ],
-                ),
-              ),
-              const SizedBox(height: AppSpacing.x8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const CommonSvgIcon(
-                    AppIconAssets.watering,
-                    width: 32,
-                    height: 25,
-                    color: AppColors.brandAccent,
-                    semanticsLabel: '물주기',
-                  ),
-                  const SizedBox(width: AppSpacing.x8),
-                  Text(
-                    detail.dDayLabel,
-                    style: AppTextStyles.size24Medium.copyWith(
-                      fontSize: 28,
-                      height: 36 / 28,
-                      color: AppColors.textStrong,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.x12),
-              _PlantDateSummary(
-                startDate: detail.startDate,
-                lastWateredDate: detail.lastWateredDate,
-              ),
-              const SizedBox(height: AppSpacing.x24),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlantDateSummary extends StatelessWidget {
-  const _PlantDateSummary({
-    required this.startDate,
-    required this.lastWateredDate,
-  });
-
-  final String startDate;
-  final String lastWateredDate;
-
-  @override
-  Widget build(BuildContext context) {
-    final textStyle = AppTextStyles.size14Medium.copyWith(
-      color: AppColors.iconInactive,
-    );
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text('처음 함께한 날', style: textStyle),
-            Text('마지막으로 물 준 날짜', style: textStyle),
-          ],
-        ),
-        const SizedBox(width: 34),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(startDate, style: textStyle),
-            Text(lastWateredDate, style: textStyle),
-          ],
-        ),
-      ],
-    );
-  }
-}
-
-class _MemoPreviewSection extends StatelessWidget {
-  const _MemoPreviewSection({required this.plantId, required this.memos});
-
-  final String plantId;
-  final List<_PlantMemo> memos;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const _SectionDivider(),
-        _PlantDetailContentWidth(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _MemoSectionHeader(
-                onPressed: () =>
-                    context.push(AppRoutePaths.memoListLocation(plantId)),
-              ),
-              SizedBox(
-                height: AppSizes.memoCardHeight,
-                child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.x20,
-                  ),
-                  scrollDirection: Axis.horizontal,
-                  itemBuilder: (context, index) =>
-                      _PlantMemoCard(memo: memos[index]),
-                  separatorBuilder: (_, _) =>
-                      const SizedBox(width: AppSpacing.x8),
-                  itemCount: memos.length,
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.x20,
-                  AppSpacing.x16,
-                  AppSpacing.x20,
-                  AppSpacing.x24,
-                ),
-                child: CommonButton(
-                  label: '작성하기',
-                  size: CommonButtonSize.medium,
-                  onPressed: () =>
-                      context.push(AppRoutePaths.memoWriteLocation(plantId)),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _MemoSectionHeader extends StatelessWidget {
-  const _MemoSectionHeader({required this.onPressed});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        AppSpacing.x4,
-        AppSpacing.x20,
-        AppSpacing.x4,
-      ),
-      child: SizedBox(
-        height: 48,
-        child: Row(
-          children: [
-            const SizedBox(width: AppSpacing.x10),
-            Expanded(
-              child: Text(
-                'Memo',
-                style: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.iconInactive,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-            Semantics(
-              button: true,
-              label: '메모 전체보기',
-              child: ExcludeSemantics(
-                child: IconButton(
-                  onPressed: onPressed,
-                  icon: const Icon(
-                    Icons.chevron_right,
-                    color: AppColors.textStrong,
-                    size: AppSizes.iconMedium,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PlantMemoCard extends StatelessWidget {
-  const _PlantMemoCard({required this.memo});
-
-  final _PlantMemo memo;
-
-  @override
-  Widget build(BuildContext context) {
-    return CommonMemoCard(
-      author: memo.author,
-      content: memo.content,
-      dateLabel: memo.dateLabel,
-      avatar: memo.avatarAsset == null
-          ? const _EmptyAvatar()
-          : Image.asset(memo.avatarAsset!, fit: BoxFit.cover),
-      thumbnail: memo.thumbnailAsset == null
-          ? const _EmptyThumbnail()
-          : Image.asset(memo.thumbnailAsset!, fit: BoxFit.cover),
-    );
-  }
-}
-
-class _EmptyAvatar extends StatelessWidget {
-  const _EmptyAvatar();
-
-  @override
-  Widget build(BuildContext context) {
-    return const CommonSvgIcon(
-      AppIconAssets.plantEmpty,
-      fit: BoxFit.cover,
-      semanticsLabel: '기본 프로필 이미지',
-    );
-  }
-}
-
-class _EmptyThumbnail extends StatelessWidget {
-  const _EmptyThumbnail();
-
-  @override
-  Widget build(BuildContext context) {
-    return const DecoratedBox(
-      decoration: BoxDecoration(color: AppColors.white),
-      child: SizedBox.expand(),
-    );
-  }
-}
-
-class _PlantInfoSection extends StatelessWidget {
-  const _PlantInfoSection({required this.detail});
-
-  final _PlantDetailData detail;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const _SectionDivider(),
-        _PlantDetailContentWidth(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
-            child: Column(
-              children: [
-                SizedBox(
-                  width: double.infinity,
-                  height: 48,
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: AppSpacing.x10),
-                      child: Text(
-                        '식물정보',
-                        style: AppTextStyles.size18Medium.copyWith(
-                          color: AppColors.iconInactive,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFF6FBF9),
-                    borderRadius: BorderRadius.circular(AppRadius.medium),
-                  ),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: Padding(
-                      padding: const EdgeInsets.all(AppSpacing.x16),
-                      child: Row(
-                        children: [
-                          const CommonSvgIcon(
-                            AppIconAssets.watering,
-                            width: 24,
-                            height: 24,
-                            semanticsLabel: '물주기 주기',
-                          ),
-                          const SizedBox(width: AppSpacing.x8),
-                          Text(
-                            detail.wateringCycleLabel,
-                            style: AppTextStyles.size14Medium.copyWith(
-                              color: AppColors.textStrong,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _SectionDivider extends StatelessWidget {
-  const _SectionDivider();
-
-  @override
-  Widget build(BuildContext context) {
-    return const SizedBox(
-      key: ValueKey('plant-detail-section-divider'),
-      height: AppSpacing.x8,
-      width: double.infinity,
-      child: ColoredBox(color: AppColors.surfaceDisabled),
     );
   }
 }

--- a/lib/features/plant/presentation/widgets/plant_detail_widgets.dart
+++ b/lib/features/plant/presentation/widgets/plant_detail_widgets.dart
@@ -1,0 +1,552 @@
+import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_memo_card.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PlantDetailMemoItem {
+  const PlantDetailMemoItem({
+    required this.author,
+    required this.content,
+    required this.dateLabel,
+    this.avatarAsset,
+    this.thumbnailAsset,
+  });
+
+  final String author;
+  final String content;
+  final String dateLabel;
+  final String? avatarAsset;
+  final String? thumbnailAsset;
+}
+
+class PlantDetailContentWidth extends StatelessWidget {
+  const PlantDetailContentWidth({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: AppSizes.mobileWidth),
+        child: child,
+      ),
+    );
+  }
+}
+
+class PlantHero extends StatelessWidget {
+  const PlantHero({
+    super.key,
+    required this.placeName,
+    required this.name,
+    required this.species,
+  });
+
+  final String placeName;
+  final String name;
+  final String species;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        0,
+        AppSpacing.x20,
+        AppSpacing.x16,
+      ),
+      child: Column(
+        children: [
+          _PlantHeroImage(placeName: placeName),
+          const SizedBox(height: AppSpacing.x8),
+          Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: AppTextStyles.size24Medium.copyWith(
+              color: AppColors.textHeadline,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          Text(
+            species,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: AppTextStyles.size16Medium.copyWith(
+              color: AppColors.textStrong,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PlantCareSummary extends StatelessWidget {
+  const PlantCareSummary({
+    super.key,
+    required this.name,
+    required this.daysTogether,
+    required this.dDayLabel,
+    required this.startDate,
+    required this.lastWateredDate,
+  });
+
+  final String name;
+  final int daysTogether;
+  final String dDayLabel;
+  final String startDate;
+  final String lastWateredDate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionDivider(),
+        PlantDetailContentWidth(
+          child: Column(
+            children: [
+              const SizedBox(height: AppSpacing.x24),
+              RichText(
+                textAlign: TextAlign.center,
+                text: TextSpan(
+                  style: AppTextStyles.size16Medium.copyWith(
+                    color: AppColors.textBody,
+                  ),
+                  children: [
+                    TextSpan(text: '$name와 함께한지 '),
+                    TextSpan(
+                      text: '$daysTogether일',
+                      style: AppTextStyles.size18Medium.copyWith(
+                        color: AppColors.textStrong,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const TextSpan(text: '이 지났어요!'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: AppSpacing.x8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const CommonSvgIcon(
+                    AppIconAssets.watering,
+                    width: 32,
+                    height: 25,
+                    color: AppColors.brandAccent,
+                    semanticsLabel: '물주기',
+                  ),
+                  const SizedBox(width: AppSpacing.x8),
+                  Text(
+                    dDayLabel,
+                    style: AppTextStyles.size24Medium.copyWith(
+                      fontSize: 28,
+                      height: 36 / 28,
+                      color: AppColors.textStrong,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.x12),
+              _PlantDateSummary(
+                startDate: startDate,
+                lastWateredDate: lastWateredDate,
+              ),
+              const SizedBox(height: AppSpacing.x24),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class MemoPreviewSection extends StatelessWidget {
+  const MemoPreviewSection({
+    super.key,
+    required this.plantId,
+    required this.memos,
+  });
+
+  final String plantId;
+  final List<PlantDetailMemoItem> memos;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionDivider(),
+        PlantDetailContentWidth(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _MemoSectionHeader(
+                onPressed: () =>
+                    context.push(AppRoutePaths.memoListLocation(plantId)),
+              ),
+              SizedBox(
+                height: AppSizes.memoCardHeight,
+                child: ListView.separated(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.x20,
+                  ),
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder: (context, index) =>
+                      _PlantMemoCard(memo: memos[index]),
+                  separatorBuilder: (_, _) =>
+                      const SizedBox(width: AppSpacing.x8),
+                  itemCount: memos.length,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.x20,
+                  AppSpacing.x16,
+                  AppSpacing.x20,
+                  AppSpacing.x24,
+                ),
+                child: CommonButton(
+                  label: '작성하기',
+                  size: CommonButtonSize.medium,
+                  onPressed: () =>
+                      context.push(AppRoutePaths.memoWriteLocation(plantId)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class PlantInfoSection extends StatelessWidget {
+  const PlantInfoSection({super.key, required this.wateringCycleLabel});
+
+  final String wateringCycleLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionDivider(),
+        PlantDetailContentWidth(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
+            child: Column(
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  height: 48,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: AppSpacing.x10),
+                      child: Text(
+                        '식물정보',
+                        style: AppTextStyles.size18Medium.copyWith(
+                          color: AppColors.iconInactive,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF6FBF9),
+                    borderRadius: BorderRadius.circular(AppRadius.medium),
+                  ),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.x16),
+                      child: Row(
+                        children: [
+                          const CommonSvgIcon(
+                            AppIconAssets.watering,
+                            width: 24,
+                            height: 24,
+                            semanticsLabel: '물주기 주기',
+                          ),
+                          const SizedBox(width: AppSpacing.x8),
+                          Text(
+                            wateringCycleLabel,
+                            style: AppTextStyles.size14Medium.copyWith(
+                              color: AppColors.textStrong,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlantHeroImage extends StatelessWidget {
+  const _PlantHeroImage({required this.placeName});
+
+  final String placeName;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth < 335 ? constraints.maxWidth : 335.0;
+        final scale = width / 335;
+        final height = 208 * scale;
+
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(AppRadius.medium),
+          child: SizedBox(
+            width: width,
+            height: height,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                const ColoredBox(color: AppColors.surfaceMuted),
+                Positioned(
+                  left: 0,
+                  top: -126 * scale,
+                  child: Image.asset(
+                    AppImageAssets.plantEditMonstera,
+                    width: 495 * scale,
+                    height: 369 * scale,
+                    fit: BoxFit.cover,
+                    semanticLabel: '몬테 식물 사진',
+                  ),
+                ),
+                Positioned(
+                  top: AppSpacing.x8 * scale,
+                  left: 0,
+                  right: 0,
+                  child: Center(child: _PlaceBadge(label: placeName)),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PlaceBadge extends StatelessWidget {
+  const _PlaceBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 280),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.brandStrong,
+          borderRadius: BorderRadius.circular(AppRadius.small),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.x10,
+            AppSpacing.x4,
+            AppSpacing.x16,
+            AppSpacing.x4,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.add_home_outlined,
+                color: AppColors.onBrand,
+                size: AppSizes.iconMedium,
+              ),
+              const SizedBox(width: AppSpacing.x4),
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.size14Bold.copyWith(
+                    color: AppColors.onBrand,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlantDateSummary extends StatelessWidget {
+  const _PlantDateSummary({
+    required this.startDate,
+    required this.lastWateredDate,
+  });
+
+  final String startDate;
+  final String lastWateredDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = AppTextStyles.size14Medium.copyWith(
+      color: AppColors.iconInactive,
+    );
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text('처음 함께한 날', style: textStyle),
+            Text('마지막으로 물 준 날짜', style: textStyle),
+          ],
+        ),
+        const SizedBox(width: 34),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(startDate, style: textStyle),
+            Text(lastWateredDate, style: textStyle),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MemoSectionHeader extends StatelessWidget {
+  const _MemoSectionHeader({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        AppSpacing.x4,
+        AppSpacing.x20,
+        AppSpacing.x4,
+      ),
+      child: SizedBox(
+        height: 48,
+        child: Row(
+          children: [
+            const SizedBox(width: AppSpacing.x10),
+            Expanded(
+              child: Text(
+                'Memo',
+                style: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.iconInactive,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            Semantics(
+              button: true,
+              label: '메모 전체보기',
+              child: ExcludeSemantics(
+                child: IconButton(
+                  onPressed: onPressed,
+                  icon: const Icon(
+                    Icons.chevron_right,
+                    color: AppColors.textStrong,
+                    size: AppSizes.iconMedium,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlantMemoCard extends StatelessWidget {
+  const _PlantMemoCard({required this.memo});
+
+  final PlantDetailMemoItem memo;
+
+  @override
+  Widget build(BuildContext context) {
+    return CommonMemoCard(
+      author: memo.author,
+      content: memo.content,
+      dateLabel: memo.dateLabel,
+      avatar: memo.avatarAsset == null
+          ? const _EmptyAvatar()
+          : Image.asset(memo.avatarAsset!, fit: BoxFit.cover),
+      thumbnail: memo.thumbnailAsset == null
+          ? const _EmptyThumbnail()
+          : Image.asset(memo.thumbnailAsset!, fit: BoxFit.cover),
+    );
+  }
+}
+
+class _EmptyAvatar extends StatelessWidget {
+  const _EmptyAvatar();
+
+  @override
+  Widget build(BuildContext context) {
+    return const CommonSvgIcon(
+      AppIconAssets.plantEmpty,
+      fit: BoxFit.cover,
+      semanticsLabel: '기본 프로필 이미지',
+    );
+  }
+}
+
+class _EmptyThumbnail extends StatelessWidget {
+  const _EmptyThumbnail();
+
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(color: AppColors.white),
+      child: SizedBox.expand(),
+    );
+  }
+}
+
+class _SectionDivider extends StatelessWidget {
+  const _SectionDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      key: ValueKey('plant-detail-section-divider'),
+      height: AppSpacing.x8,
+      width: double.infinity,
+      child: ColoredBox(color: AppColors.surfaceDisabled),
+    );
+  }
+}

--- a/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
+++ b/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
@@ -1,0 +1,108 @@
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets('PlantHero는 장소와 식물 주요 정보를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        const PlantDetailContentWidth(
+          child: PlantHero(
+            placeName: '거실 정원',
+            name: '몬테',
+            species: 'Monstera deliciosa',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('거실 정원'), findsOneWidget);
+    expect(find.text('몬테'), findsOneWidget);
+    expect(find.text('Monstera deliciosa'), findsOneWidget);
+  });
+
+  testWidgets('PlantCareSummary와 PlantInfoSection은 관리 정보를 표시한다', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        const Column(
+          children: [
+            PlantCareSummary(
+              name: '몬테',
+              daysTogether: 3,
+              dDayLabel: 'D-2',
+              startDate: '2026.06.01',
+              lastWateredDate: '2026.06.20',
+            ),
+            PlantInfoSection(wateringCycleLabel: '10 Day'),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('D-2'), findsOneWidget);
+    expect(find.text('처음 함께한 날'), findsOneWidget);
+    expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
+    expect(find.text('2026.06.01'), findsOneWidget);
+    expect(find.text('2026.06.20'), findsOneWidget);
+    expect(find.text('식물정보'), findsOneWidget);
+    expect(find.text('10 Day'), findsOneWidget);
+  });
+
+  testWidgets('MemoPreviewSection은 메모를 표시하고 목록/작성으로 이동한다', (tester) async {
+    const memoSection = MemoPreviewSection(
+      plantId: 'plant-1',
+      memos: [
+        PlantDetailMemoItem(
+          author: '커먼맘',
+          content: '오늘은 잎 상태가 좋아요',
+          dateLabel: '2026.06.20',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_buildRouterApp(memoSection));
+
+    expect(find.text('Memo'), findsOneWidget);
+    expect(find.text('커먼맘'), findsOneWidget);
+    expect(find.text('오늘은 잎 상태가 좋아요'), findsOneWidget);
+    expect(find.text('2026.06.20'), findsOneWidget);
+    expect(find.text('작성하기'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('메모 전체보기'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('메모 목록 화면'), findsOneWidget);
+
+    await tester.pumpWidget(_buildRouterApp(memoSection));
+    await tester.tap(find.text('작성하기'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('메모 작성 화면'), findsOneWidget);
+  });
+}
+
+Widget _buildRouterApp(Widget home) {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) =>
+            Scaffold(body: SingleChildScrollView(child: home)),
+      ),
+      GoRoute(
+        path: '/plants/:plantId/memos/new',
+        builder: (context, state) => const Text('메모 작성 화면'),
+      ),
+      GoRoute(
+        path: '/plants/:plantId/memos',
+        builder: (context, state) => const Text('메모 목록 화면'),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(routerConfig: router);
+}


### PR DESCRIPTION
## Summary
- `PlantDetailPage` 내부의 hero, care summary, memo preview, info section 전용 UI를 `plant_detail_widgets.dart`로 분리했습니다.
- page는 Provider 상태, 메뉴/dialog/route 처리, mock detail 조립 중심으로 축소했습니다.
- 분리된 Plant 상세 feature widget의 렌더링과 메모 목록/작성 이동 동작을 widget test로 추가했습니다.

## Test Plan
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

Closes #101
