### PR TITLE
Refactor: 상세 임시데이터 분리 #103

### DIFF
--- a/lib/app/router/app_routes.dart
+++ b/lib/app/router/app_routes.dart
@@ -9,6 +9,7 @@ import 'package:commonplant_frontend/features/login/presentation/pages/profile_s
 import 'package:commonplant_frontend/features/memo/presentation/pages/memo_list_page.dart';
 import 'package:commonplant_frontend/features/memo/presentation/pages/memo_write_page.dart';
 import 'package:commonplant_frontend/features/onboarding/presentation/pages/onboarding_page.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/address_search_page.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/friend_management_page.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_detail_page.dart';

--- a/lib/features/place/presentation/fixtures/place_detail_fixture.dart
+++ b/lib/features/place/presentation/fixtures/place_detail_fixture.dart
@@ -1,0 +1,110 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_widgets.dart';
+
+class PlaceDetailFixtureData {
+  const PlaceDetailFixtureData({
+    required this.role,
+    required this.name,
+    required this.address,
+    required this.sunlightLabel,
+    required this.humidityLabel,
+    required this.friends,
+    required this.plants,
+  });
+
+  final PlaceDetailRole role;
+  final String name;
+  final String address;
+  final String sunlightLabel;
+  final String humidityLabel;
+  final List<PlaceDetailFriendItem> friends;
+  final List<PlaceDetailPlantItem> plants;
+
+  PlaceDetailFixtureData applySummary(PlaceSummary summary) {
+    return PlaceDetailFixtureData(
+      role: role,
+      name: summary.name,
+      address: summary.address ?? address,
+      sunlightLabel: sunlightLabel,
+      humidityLabel: humidityLabel,
+      friends: friends,
+      plants: plants,
+    );
+  }
+}
+
+PlaceDetailFixtureData placeDetailFixture(
+  String placeId, {
+  PlaceDetailRole? role,
+}) {
+  final effectiveRole = role ?? _roleFromPlaceId(placeId);
+
+  return PlaceDetailFixtureData(
+    role: effectiveRole,
+    name: '스윗 홈_거실',
+    address: '서울시 노원구 광운로 20',
+    sunlightLabel: '9.3 / 5',
+    humidityLabel: '69%',
+    friends: const [
+      PlaceDetailFriendItem(
+        id: 'me',
+        name: '나',
+        imageAsset: AppImageAssets.placeDetailAvatarMe,
+        isOwner: true,
+      ),
+      PlaceDetailFriendItem(
+        id: 'common-mom',
+        name: '커먼맘',
+        imageAsset: AppImageAssets.placeDetailAvatarCommonMom,
+      ),
+      PlaceDetailFriendItem(id: 'common-papa', name: '커먼 파파'),
+    ],
+    plants: const [
+      PlaceDetailPlantItem(
+        id: 'plant-1',
+        name: '몬테',
+        species: '몬스테라',
+        description: '일주일에 x번 물주는 거 잊지 않기',
+        dDayLabel: 'D-3',
+        dateLabel: '2022.11.20',
+        canWater: true,
+      ),
+      PlaceDetailPlantItem(
+        id: 'plant-2',
+        name: '몬테',
+        species: '몬스테라',
+        description: '일주일에 x번 물주는 거 잊지 않기',
+        dDayLabel: 'D-5',
+        dateLabel: '2022.11.20',
+      ),
+      PlaceDetailPlantItem(
+        id: 'plant-3',
+        name: '몬테',
+        species: '몬스테라',
+        description: '일주일에 x번 물주는 거 잊지 않기',
+        dDayLabel: 'D-5',
+        dateLabel: '2022.11.20',
+      ),
+      PlaceDetailPlantItem(
+        id: 'plant-4',
+        name: '몬테',
+        species: '몬스테라',
+        description: '일주일에 x번 물주는 거 잊지 않기',
+        dDayLabel: 'D-5',
+        dateLabel: '2022.11.20',
+      ),
+    ],
+  );
+}
+
+PlaceDetailRole _roleFromPlaceId(String placeId) {
+  final normalized = placeId.toLowerCase();
+
+  if (normalized.contains('member') || normalized.contains('team')) {
+    return PlaceDetailRole.member;
+  }
+
+  return PlaceDetailRole.leader;
+}

--- a/lib/features/place/presentation/models/place_detail_role.dart
+++ b/lib/features/place/presentation/models/place_detail_role.dart
@@ -1,0 +1,9 @@
+enum PlaceDetailRole { leader, member }
+
+PlaceDetailRole? placeDetailRoleFromQuery(String? value) {
+  return switch (value) {
+    'leader' => PlaceDetailRole.leader,
+    'member' || 'team' => PlaceDetailRole.member,
+    _ => null,
+  };
+}

--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -2,12 +2,13 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_widgets.dart';
@@ -18,16 +19,6 @@ import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-
-enum PlaceDetailRole { leader, member }
-
-PlaceDetailRole? placeDetailRoleFromQuery(String? value) {
-  return switch (value) {
-    'leader' => PlaceDetailRole.leader,
-    'member' || 'team' => PlaceDetailRole.member,
-    _ => null,
-  };
-}
 
 class PlaceDetailPage extends ConsumerStatefulWidget {
   const PlaceDetailPage({super.key, required this.placeId, this.role});
@@ -66,7 +57,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final mockDetail = _PlaceDetailData.mock(widget.placeId, role: widget.role);
+    final mockDetail = placeDetailFixture(widget.placeId, role: widget.role);
 
     if (!ref.watch(useRemoteApiProvider)) {
       return _buildScaffold(context, mockDetail);
@@ -146,7 +137,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
-  Widget _buildScaffold(BuildContext context, _PlaceDetailData detail) {
+  Widget _buildScaffold(BuildContext context, PlaceDetailFixtureData detail) {
     return CommonScaffold(
       title: 'My place',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -284,108 +275,5 @@ class _PlaceDetailStatusView extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-class _PlaceDetailData {
-  const _PlaceDetailData({
-    required this.role,
-    required this.name,
-    required this.address,
-    required this.sunlightLabel,
-    required this.humidityLabel,
-    required this.friends,
-    required this.plants,
-  });
-
-  final PlaceDetailRole role;
-  final String name;
-  final String address;
-  final String sunlightLabel;
-  final String humidityLabel;
-  final List<PlaceDetailFriendItem> friends;
-  final List<PlaceDetailPlantItem> plants;
-
-  _PlaceDetailData applySummary(PlaceSummary summary) {
-    return _PlaceDetailData(
-      role: role,
-      name: summary.name,
-      address: summary.address ?? address,
-      sunlightLabel: sunlightLabel,
-      humidityLabel: humidityLabel,
-      friends: friends,
-      plants: plants,
-    );
-  }
-
-  static _PlaceDetailData mock(String placeId, {PlaceDetailRole? role}) {
-    final effectiveRole = role ?? _roleFromPlaceId(placeId);
-
-    return _PlaceDetailData(
-      role: effectiveRole,
-      name: '스윗 홈_거실',
-      address: '서울시 노원구 광운로 20',
-      sunlightLabel: '9.3 / 5',
-      humidityLabel: '69%',
-      friends: const [
-        PlaceDetailFriendItem(
-          id: 'me',
-          name: '나',
-          imageAsset: AppImageAssets.placeDetailAvatarMe,
-          isOwner: true,
-        ),
-        PlaceDetailFriendItem(
-          id: 'common-mom',
-          name: '커먼맘',
-          imageAsset: AppImageAssets.placeDetailAvatarCommonMom,
-        ),
-        PlaceDetailFriendItem(id: 'common-papa', name: '커먼 파파'),
-      ],
-      plants: const [
-        PlaceDetailPlantItem(
-          id: 'plant-1',
-          name: '몬테',
-          species: '몬스테라',
-          description: '일주일에 x번 물주는 거 잊지 않기',
-          dDayLabel: 'D-3',
-          dateLabel: '2022.11.20',
-          canWater: true,
-        ),
-        PlaceDetailPlantItem(
-          id: 'plant-2',
-          name: '몬테',
-          species: '몬스테라',
-          description: '일주일에 x번 물주는 거 잊지 않기',
-          dDayLabel: 'D-5',
-          dateLabel: '2022.11.20',
-        ),
-        PlaceDetailPlantItem(
-          id: 'plant-3',
-          name: '몬테',
-          species: '몬스테라',
-          description: '일주일에 x번 물주는 거 잊지 않기',
-          dDayLabel: 'D-5',
-          dateLabel: '2022.11.20',
-        ),
-        PlaceDetailPlantItem(
-          id: 'plant-4',
-          name: '몬테',
-          species: '몬스테라',
-          description: '일주일에 x번 물주는 거 잊지 않기',
-          dDayLabel: 'D-5',
-          dateLabel: '2022.11.20',
-        ),
-      ],
-    );
-  }
-
-  static PlaceDetailRole _roleFromPlaceId(String placeId) {
-    final normalized = placeId.toLowerCase();
-
-    if (normalized.contains('member') || normalized.contains('team')) {
-      return PlaceDetailRole.member;
-    }
-
-    return PlaceDetailRole.leader;
   }
 }

--- a/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
+++ b/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
@@ -1,0 +1,85 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_widgets.dart';
+
+class PlantDetailFixtureData {
+  const PlantDetailFixtureData({
+    required this.placeCode,
+    required this.placeName,
+    required this.name,
+    required this.species,
+    required this.daysTogether,
+    required this.dDayLabel,
+    required this.startDate,
+    required this.lastWateredDate,
+    required this.wateringCycleLabel,
+    required this.memos,
+  });
+
+  final String? placeCode;
+  final String placeName;
+  final String name;
+  final String species;
+  final int daysTogether;
+  final String dDayLabel;
+  final String startDate;
+  final String lastWateredDate;
+  final String wateringCycleLabel;
+  final List<PlantDetailMemoItem> memos;
+
+  PlantDetailFixtureData applyRemote(PlantDetail detail) {
+    return PlantDetailFixtureData(
+      placeCode: detail.placeId ?? placeCode,
+      placeName: detail.placeName ?? placeName,
+      name: detail.name,
+      species: detail.species ?? species,
+      daysTogether: daysTogether,
+      dDayLabel: dDayLabel,
+      startDate: startDate,
+      lastWateredDate: detail.lastWateredDate ?? lastWateredDate,
+      wateringCycleLabel: wateringCycleLabel,
+      memos: memos,
+    );
+  }
+}
+
+PlantDetailFixtureData plantDetailFixture({String? placeCode}) {
+  return PlantDetailFixtureData(
+    placeCode: placeCode,
+    placeName: '스윗홈_거실',
+    name: '몬테',
+    species: 'Monstera deliciosa',
+    daysTogether: 1,
+    dDayLabel: 'D-3',
+    startDate: '2022.11.24',
+    lastWateredDate: '2022.11.24',
+    wateringCycleLabel: '10 Day',
+    memos: const [
+      PlantDetailMemoItem(
+        author: '커먼플랜트',
+        content: '장마여서 물주는 날짜를 조금 늦춤 하지만 해는 맑구나 몬테랑 함께...',
+        dateLabel: '2022.11.20',
+        avatarAsset: AppImageAssets.placeDetailAvatarMe,
+        thumbnailAsset: AppImageAssets.placeDetailMonstera,
+      ),
+      PlantDetailMemoItem(
+        author: '커먼맘',
+        content: '오늘은 잎이 조금 시들하구나 커먼아 해결책은?',
+        dateLabel: '2022.11.20',
+        avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
+      ),
+      PlantDetailMemoItem(
+        author: '커먼맘',
+        content: '오늘은 잎의 상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기...',
+        dateLabel: '2022.11.20',
+        avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
+        thumbnailAsset: AppImageAssets.plantEditMonstera,
+      ),
+      PlantDetailMemoItem(
+        author: '커먼 파파',
+        content: '오늘도 맑음',
+        dateLabel: '2022.11.20',
+      ),
+    ],
+  );
+}

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_widgets.dart';
@@ -101,7 +101,7 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final mockDetail = _PlantDetailData.mock(placeCode: widget.placeId);
+    final mockDetail = plantDetailFixture(placeCode: widget.placeId);
 
     if (!ref.watch(useRemoteApiProvider)) {
       return _buildScaffold(context, mockDetail);
@@ -168,7 +168,7 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
-  Widget _buildScaffold(BuildContext context, _PlantDetailData detail) {
+  Widget _buildScaffold(BuildContext context, PlantDetailFixtureData detail) {
     return CommonScaffold(
       title: 'My plant',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -209,88 +209,6 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
 
   bool _isEmptyRemoteDetail(PlantDetail detail) {
     return detail.name.trim().isEmpty;
-  }
-}
-
-class _PlantDetailData {
-  const _PlantDetailData({
-    required this.placeCode,
-    required this.placeName,
-    required this.name,
-    required this.species,
-    required this.daysTogether,
-    required this.dDayLabel,
-    required this.startDate,
-    required this.lastWateredDate,
-    required this.wateringCycleLabel,
-    required this.memos,
-  });
-
-  final String? placeCode;
-  final String placeName;
-  final String name;
-  final String species;
-  final int daysTogether;
-  final String dDayLabel;
-  final String startDate;
-  final String lastWateredDate;
-  final String wateringCycleLabel;
-  final List<PlantDetailMemoItem> memos;
-
-  _PlantDetailData applyRemote(PlantDetail detail) {
-    return _PlantDetailData(
-      placeCode: detail.placeId ?? placeCode,
-      placeName: detail.placeName ?? placeName,
-      name: detail.name,
-      species: detail.species ?? species,
-      daysTogether: daysTogether,
-      dDayLabel: dDayLabel,
-      startDate: startDate,
-      lastWateredDate: detail.lastWateredDate ?? lastWateredDate,
-      wateringCycleLabel: wateringCycleLabel,
-      memos: memos,
-    );
-  }
-
-  static _PlantDetailData mock({String? placeCode}) {
-    return _PlantDetailData(
-      placeCode: placeCode,
-      placeName: '스윗홈_거실',
-      name: '몬테',
-      species: 'Monstera deliciosa',
-      daysTogether: 1,
-      dDayLabel: 'D-3',
-      startDate: '2022.11.24',
-      lastWateredDate: '2022.11.24',
-      wateringCycleLabel: '10 Day',
-      memos: const [
-        PlantDetailMemoItem(
-          author: '커먼플랜트',
-          content: '장마여서 물주는 날짜를 조금 늦춤 하지만 해는 맑구나 몬테랑 함께...',
-          dateLabel: '2022.11.20',
-          avatarAsset: AppImageAssets.placeDetailAvatarMe,
-          thumbnailAsset: AppImageAssets.placeDetailMonstera,
-        ),
-        PlantDetailMemoItem(
-          author: '커먼맘',
-          content: '오늘은 잎이 조금 시들하구나 커먼아 해결책은?',
-          dateLabel: '2022.11.20',
-          avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
-        ),
-        PlantDetailMemoItem(
-          author: '커먼맘',
-          content: '오늘은 잎의 상태가 매우 좋다 커먼아 앱에서 알려준 물주기의 주기...',
-          dateLabel: '2022.11.20',
-          avatarAsset: AppImageAssets.placeDetailAvatarCommonMom,
-          thumbnailAsset: AppImageAssets.plantEditMonstera,
-        ),
-        PlantDetailMemoItem(
-          author: '커먼 파파',
-          content: '오늘도 맑음',
-          dateLabel: '2022.11.20',
-        ),
-      ],
-    );
   }
 }
 

--- a/test/features/place/presentation/fixtures/place_detail_fixture_test.dart
+++ b/test/features/place/presentation/fixtures/place_detail_fixture_test.dart
@@ -1,0 +1,45 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('placeDetailFixture', () {
+    test('placeId와 명시 role로 local 상세 데이터를 만든다', () {
+      final leaderDetail = placeDetailFixture(
+        'place-1',
+        role: PlaceDetailRole.leader,
+      );
+      final memberDetail = placeDetailFixture('team-place');
+
+      expect(leaderDetail.role, PlaceDetailRole.leader);
+      expect(leaderDetail.name, '스윗 홈_거실');
+      expect(leaderDetail.address, '서울시 노원구 광운로 20');
+      expect(leaderDetail.friends.map((friend) => friend.name), [
+        '나',
+        '커먼맘',
+        '커먼 파파',
+      ]);
+      expect(leaderDetail.plants, hasLength(4));
+      expect(leaderDetail.plants.first.canWater, isTrue);
+      expect(memberDetail.role, PlaceDetailRole.member);
+    });
+
+    test('remote summary를 적용해도 fixture 보조 정보는 유지한다', () {
+      final detail = placeDetailFixture('place-1').applySummary(
+        const PlaceSummary(
+          id: 'remote-place',
+          name: '옥상 정원',
+          address: '서울시 성북구',
+        ),
+      );
+
+      expect(detail.name, '옥상 정원');
+      expect(detail.address, '서울시 성북구');
+      expect(detail.sunlightLabel, '9.3 / 5');
+      expect(detail.humidityLabel, '69%');
+      expect(detail.friends, hasLength(3));
+      expect(detail.plants, hasLength(4));
+    });
+  });
+}

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -4,6 +4,7 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_detail_page.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';

--- a/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
+++ b/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
@@ -1,0 +1,40 @@
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('plantDetailFixture', () {
+    test('local 식물 상세 fallback 데이터를 만든다', () {
+      final detail = plantDetailFixture(placeCode: 'place-1');
+
+      expect(detail.placeCode, 'place-1');
+      expect(detail.placeName, '스윗홈_거실');
+      expect(detail.name, '몬테');
+      expect(detail.species, 'Monstera deliciosa');
+      expect(detail.dDayLabel, 'D-3');
+      expect(detail.wateringCycleLabel, '10 Day');
+      expect(detail.memos, hasLength(4));
+      expect(detail.memos.first.author, '커먼플랜트');
+    });
+
+    test('remote detail을 적용할 때 없는 값은 fallback을 유지한다', () {
+      final detail = plantDetailFixture(placeCode: 'fallback-place')
+          .applyRemote(
+            const PlantDetail(
+              id: 'plant-remote',
+              name: '필로덴드론',
+              placeName: '거실 정원',
+              lastWateredDate: '2026.05.25',
+            ),
+          );
+
+      expect(detail.placeCode, 'fallback-place');
+      expect(detail.placeName, '거실 정원');
+      expect(detail.name, '필로덴드론');
+      expect(detail.species, 'Monstera deliciosa');
+      expect(detail.lastWateredDate, '2026.05.25');
+      expect(detail.dDayLabel, 'D-3');
+      expect(detail.memos, hasLength(4));
+    });
+  });
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #103

## 구현 범위
- Place/Plant 상세 화면의 local mock 데이터를 `presentation/fixtures`로 분리했습니다.
- Place 상세 role/query helper를 `presentation/models/place_detail_role.dart`로 분리했습니다.
- 상세 page는 fixture 적용, Provider 상태, route/dialog 처리만 담당하도록 축소했습니다.
- fixture 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md` 5단계 범위 수행으로 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- fixture가 local/mock fallback 전용 위치로 적절한지 확인 부탁드립니다.
- Place role 모델 분리 위치가 라우팅/page/fixture 공용 참조에 적절한지 확인 부탁드립니다.
