### PR TITLE
Refactor: API 매퍼 분리 #105

### DIFF
--- a/lib/features/place/data/mappers/place_mapper.dart
+++ b/lib/features/place/data/mappers/place_mapper.dart
@@ -1,0 +1,18 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+
+PlaceSummary placeSummaryFromJson(JsonMap json, {String? fallbackId}) {
+  return PlaceSummary(
+    id:
+        readOptionalString(json, const [
+          'id',
+          'placeId',
+          'code',
+          'placeCode',
+        ]) ??
+        fallbackId ??
+        readRequiredString(json, const ['nanoId'], '장소 ID'),
+    name: readRequiredString(json, const ['name', 'placeName'], '장소 이름'),
+    address: readOptionalString(json, const ['address', 'placeAddress']),
+  );
+}

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -2,6 +2,7 @@ import 'package:commonplant_frontend/core/network/api_client.dart';
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
+import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -59,20 +60,4 @@ class PlaceRepository {
   Future<void> deletePlace(String code) {
     return _remoteDataSource.deletePlace(code);
   }
-}
-
-PlaceSummary placeSummaryFromJson(JsonMap json, {String? fallbackId}) {
-  return PlaceSummary(
-    id:
-        readOptionalString(json, const [
-          'id',
-          'placeId',
-          'code',
-          'placeCode',
-        ]) ??
-        fallbackId ??
-        readRequiredString(json, const ['nanoId'], '장소 ID'),
-    name: readRequiredString(json, const ['name', 'placeName'], '장소 이름'),
-    address: readOptionalString(json, const ['address', 'placeAddress']),
-  );
 }

--- a/lib/features/plant/data/mappers/plant_mapper.dart
+++ b/lib/features/plant/data/mappers/plant_mapper.dart
@@ -1,0 +1,57 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+
+PlantSummary plantSummaryFromJson(JsonMap json) {
+  return PlantSummary(
+    id: readRequiredString(json, const ['id', 'plantId'], '식물 ID'),
+    name: readRequiredString(json, const ['nickname', 'name'], '식물 이름'),
+    placeId: readOptionalString(json, const ['placeId', 'placeCode']),
+    placeName: readOptionalString(json, const ['placeName']),
+    description: readOptionalString(json, const ['description']),
+    imageUrl: readOptionalString(json, const [
+      'representativeImageUrl',
+      'imageUrl',
+    ]),
+  );
+}
+
+PlantDetail plantDetailFromJson(
+  JsonMap json, {
+  required String fallbackId,
+  String? fallbackPlaceId,
+}) {
+  return PlantDetail(
+    id: readOptionalString(json, const ['id', 'plantId']) ?? fallbackId,
+    name: readRequiredString(json, const [
+      'nickname',
+      'name',
+      'scientificNameKo',
+      'scientificNameEn',
+    ], '식물 이름'),
+    placeId:
+        readOptionalString(json, const ['placeId', 'placeCode']) ??
+        fallbackPlaceId,
+    placeName: readOptionalString(json, const ['placeName']),
+    species: readOptionalString(json, const [
+      'scientificNameEn',
+      'scientificNameKo',
+      'species',
+    ]),
+    description: readOptionalString(json, const ['plantInfo', 'description']),
+    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
+    imageKey: readOptionalString(json, const ['imageKey']),
+    imageUrl: readOptionalString(json, const ['imageUrl']),
+    memo: readOptionalString(json, const ['memo']),
+    registeredAt: readOptionalString(json, const ['registeredAt']),
+  );
+}
+
+PlantEditInfo plantEditInfoFromJson(JsonMap json) {
+  return PlantEditInfo(
+    name: readRequiredString(json, const ['nickname', 'name'], '식물 애칭'),
+    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
+    imageKey: readOptionalString(json, const ['imageKey']),
+    imageUrl: readOptionalString(json, const ['imageUrl']),
+  );
+}

--- a/lib/features/plant/data/repositories/plant_repository.dart
+++ b/lib/features/plant/data/repositories/plant_repository.dart
@@ -2,6 +2,7 @@ import 'package:commonplant_frontend/core/network/api_client.dart';
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
+import 'package:commonplant_frontend/features/plant/data/mappers/plant_mapper.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
 import 'package:dio/dio.dart';
@@ -68,58 +69,4 @@ class PlantRepository {
       placeCode: placeCode,
     );
   }
-}
-
-PlantSummary plantSummaryFromJson(JsonMap json) {
-  return PlantSummary(
-    id: readRequiredString(json, const ['id', 'plantId'], '식물 ID'),
-    name: readRequiredString(json, const ['nickname', 'name'], '식물 이름'),
-    placeId: readOptionalString(json, const ['placeId', 'placeCode']),
-    placeName: readOptionalString(json, const ['placeName']),
-    description: readOptionalString(json, const ['description']),
-    imageUrl: readOptionalString(json, const [
-      'representativeImageUrl',
-      'imageUrl',
-    ]),
-  );
-}
-
-PlantDetail plantDetailFromJson(
-  JsonMap json, {
-  required String fallbackId,
-  String? fallbackPlaceId,
-}) {
-  return PlantDetail(
-    id: readOptionalString(json, const ['id', 'plantId']) ?? fallbackId,
-    name: readRequiredString(json, const [
-      'nickname',
-      'name',
-      'scientificNameKo',
-      'scientificNameEn',
-    ], '식물 이름'),
-    placeId:
-        readOptionalString(json, const ['placeId', 'placeCode']) ??
-        fallbackPlaceId,
-    placeName: readOptionalString(json, const ['placeName']),
-    species: readOptionalString(json, const [
-      'scientificNameEn',
-      'scientificNameKo',
-      'species',
-    ]),
-    description: readOptionalString(json, const ['plantInfo', 'description']),
-    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
-    imageKey: readOptionalString(json, const ['imageKey']),
-    imageUrl: readOptionalString(json, const ['imageUrl']),
-    memo: readOptionalString(json, const ['memo']),
-    registeredAt: readOptionalString(json, const ['registeredAt']),
-  );
-}
-
-PlantEditInfo plantEditInfoFromJson(JsonMap json) {
-  return PlantEditInfo(
-    name: readRequiredString(json, const ['nickname', 'name'], '식물 애칭'),
-    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
-    imageKey: readOptionalString(json, const ['imageKey']),
-    imageUrl: readOptionalString(json, const ['imageUrl']),
-  );
 }

--- a/lib/features/user/data/mappers/user_mapper.dart
+++ b/lib/features/user/data/mappers/user_mapper.dart
@@ -1,0 +1,13 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+
+UserProfile userProfileFromJson(JsonMap json) {
+  return UserProfile(
+    id: readRequiredString(json, const ['id', 'userId', 'nanoId'], '사용자 ID'),
+    name: readRequiredString(json, const ['name'], '사용자 이름'),
+    email: readOptionalString(json, const ['email']),
+    provider: readOptionalString(json, const ['provider']),
+    imgUrl: readOptionalString(json, const ['imgUrl', 'imageUrl']),
+    introduction: readOptionalString(json, const ['introduction']),
+  );
+}

--- a/lib/features/user/data/repositories/user_repository.dart
+++ b/lib/features/user/data/repositories/user_repository.dart
@@ -2,6 +2,7 @@ import 'package:commonplant_frontend/core/network/api_client.dart';
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
 import 'package:commonplant_frontend/features/user/data/dtos/user_requests.dart';
+import 'package:commonplant_frontend/features/user/data/mappers/user_mapper.dart';
 import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,15 +47,4 @@ class UserRepository {
   Future<void> deleteMe() async {
     await _remoteDataSource.deleteMe();
   }
-}
-
-UserProfile userProfileFromJson(JsonMap json) {
-  return UserProfile(
-    id: readRequiredString(json, const ['id', 'userId', 'nanoId'], '사용자 ID'),
-    name: readRequiredString(json, const ['name'], '사용자 이름'),
-    email: readOptionalString(json, const ['email']),
-    provider: readOptionalString(json, const ['provider']),
-    imgUrl: readOptionalString(json, const ['imgUrl', 'imageUrl']),
-    introduction: readOptionalString(json, const ['introduction']),
-  );
 }

--- a/test/features/place/data/mappers/place_mapper_test.dart
+++ b/test/features/place/data/mappers/place_mapper_test.dart
@@ -1,0 +1,27 @@
+import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('placeSummaryFromJson', () {
+    test('Swagger 장소 필드를 화면용 요약 모델로 매핑한다', () {
+      final summary = placeSummaryFromJson(const <String, Object?>{
+        'placeCode': 'place-nano-id',
+        'placeName': '거실 정원',
+        'placeAddress': '서울시 성북구',
+      });
+
+      expect(summary.id, 'place-nano-id');
+      expect(summary.name, '거실 정원');
+      expect(summary.address, '서울시 성북구');
+    });
+
+    test('id 필드가 없으면 fallbackId를 사용한다', () {
+      final summary = placeSummaryFromJson(const <String, Object?>{
+        'name': '루프탑',
+      }, fallbackId: 'fallback-place');
+
+      expect(summary.id, 'fallback-place');
+      expect(summary.name, '루프탑');
+    });
+  });
+}

--- a/test/features/plant/data/mappers/plant_mapper_test.dart
+++ b/test/features/plant/data/mappers/plant_mapper_test.dart
@@ -1,0 +1,89 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/plant/data/mappers/plant_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('plantSummaryFromJson', () {
+    test('Swagger PlantSummary 필드를 화면용 요약 모델로 매핑한다', () {
+      final summary = plantSummaryFromJson({
+        'plantId': 1,
+        'nickname': '거실 몬스테라',
+        'representativeImageUrl': 'https://example.com/monstera.png',
+      });
+
+      expect(summary.id, '1');
+      expect(summary.name, '거실 몬스테라');
+      expect(summary.imageUrl, 'https://example.com/monstera.png');
+    });
+  });
+
+  group('plantDetailFromJson', () {
+    test('Swagger DetailResponse를 상세 모델로 매핑한다', () {
+      final detail = plantDetailFromJson({
+        'plantId': 1,
+        'scientificNameKo': '몬스테라',
+        'scientificNameEn': 'Monstera deliciosa',
+        'registeredAt': '2026-05-12T19:30:00',
+        'lastWateredDate': '2026-05-12',
+        'imageUrl': 'https://example.com/monstera.png',
+        'memo': '새 잎이 올라옴',
+        'placeName': '거실 정원',
+        'plantInfo': '햇빛이 잘 드는 거실에서 키우는 몬스테라입니다.',
+      }, fallbackId: '1');
+
+      expect(detail.id, '1');
+      expect(detail.name, '몬스테라');
+      expect(detail.species, 'Monstera deliciosa');
+      expect(detail.placeName, '거실 정원');
+      expect(detail.description, '햇빛이 잘 드는 거실에서 키우는 몬스테라입니다.');
+      expect(detail.lastWateredDate, '2026-05-12');
+      expect(detail.imageUrl, 'https://example.com/monstera.png');
+      expect(detail.memo, '새 잎이 올라옴');
+      expect(detail.registeredAt, '2026-05-12T19:30:00');
+    });
+  });
+
+  group('plantEditInfoFromJson', () {
+    test('Swagger EditInfoResponse를 수정 정보 모델로 매핑한다', () {
+      final editInfo = plantEditInfoFromJson(const <String, Object?>{
+        'imageKey': 'images/user-nano-id/monstera.png',
+        'imageUrl': 'https://example.com/monstera.png',
+        'nickname': '거실 몬스테라',
+        'lastWateredDate': '2026-05-12',
+      });
+
+      expect(editInfo.name, '거실 몬스테라');
+      expect(editInfo.imageKey, 'images/user-nano-id/monstera.png');
+      expect(editInfo.imageUrl, 'https://example.com/monstera.png');
+      expect(editInfo.lastWateredDate, '2026-05-12');
+    });
+  });
+
+  group('jsonListFromResponse + plantSummaryFromJson', () {
+    test('Swagger 식물 목록 wrapper에서 요약 모델 목록을 만든다', () {
+      final items = jsonListFromResponse({
+        'result': {
+          'content': {
+            'items': [
+              {
+                'plantId': 1,
+                'nickname': '거실 몬스테라',
+                'representativeImageUrl': 'https://example.com/monstera.png',
+              },
+            ],
+            'totalCount': 1,
+            'page': 0,
+            'size': 20,
+          },
+        },
+      }, context: '식물 목록 조회');
+
+      final summaries = [for (final item in items) plantSummaryFromJson(item)];
+
+      expect(summaries, hasLength(1));
+      expect(summaries.single.id, '1');
+      expect(summaries.single.name, '거실 몬스테라');
+      expect(summaries.single.imageUrl, 'https://example.com/monstera.png');
+    });
+  });
+}

--- a/test/features/plant/data/repositories/plant_repository_test.dart
+++ b/test/features/plant/data/repositories/plant_repository_test.dart
@@ -1,4 +1,3 @@
-import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
@@ -6,90 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('plantSummaryFromJson', () {
-    test('Swagger PlantSummary 필드를 화면용 요약 모델로 매핑한다', () {
-      final summary = plantSummaryFromJson({
-        'plantId': 1,
-        'nickname': '거실 몬스테라',
-        'representativeImageUrl': 'https://example.com/monstera.png',
-      });
-
-      expect(summary.id, '1');
-      expect(summary.name, '거실 몬스테라');
-      expect(summary.imageUrl, 'https://example.com/monstera.png');
-    });
-  });
-
-  group('plantDetailFromJson', () {
-    test('Swagger DetailResponse를 상세 모델로 매핑한다', () {
-      final detail = plantDetailFromJson({
-        'plantId': 1,
-        'scientificNameKo': '몬스테라',
-        'scientificNameEn': 'Monstera deliciosa',
-        'registeredAt': '2026-05-12T19:30:00',
-        'lastWateredDate': '2026-05-12',
-        'imageUrl': 'https://example.com/monstera.png',
-        'memo': '새 잎이 올라옴',
-        'placeName': '거실 정원',
-        'plantInfo': '햇빛이 잘 드는 거실에서 키우는 몬스테라입니다.',
-      }, fallbackId: '1');
-
-      expect(detail.id, '1');
-      expect(detail.name, '몬스테라');
-      expect(detail.species, 'Monstera deliciosa');
-      expect(detail.placeName, '거실 정원');
-      expect(detail.description, '햇빛이 잘 드는 거실에서 키우는 몬스테라입니다.');
-      expect(detail.lastWateredDate, '2026-05-12');
-      expect(detail.imageUrl, 'https://example.com/monstera.png');
-      expect(detail.memo, '새 잎이 올라옴');
-      expect(detail.registeredAt, '2026-05-12T19:30:00');
-    });
-  });
-
-  group('plantEditInfoFromJson', () {
-    test('Swagger EditInfoResponse를 수정 정보 모델로 매핑한다', () {
-      final editInfo = plantEditInfoFromJson(const <String, Object?>{
-        'imageKey': 'images/user-nano-id/monstera.png',
-        'imageUrl': 'https://example.com/monstera.png',
-        'nickname': '거실 몬스테라',
-        'lastWateredDate': '2026-05-12',
-      });
-
-      expect(editInfo.name, '거실 몬스테라');
-      expect(editInfo.imageKey, 'images/user-nano-id/monstera.png');
-      expect(editInfo.imageUrl, 'https://example.com/monstera.png');
-      expect(editInfo.lastWateredDate, '2026-05-12');
-    });
-  });
-
-  group('jsonListFromResponse + plantSummaryFromJson', () {
-    test('Swagger 식물 목록 wrapper에서 요약 모델 목록을 만든다', () {
-      final items = jsonListFromResponse({
-        'result': {
-          'content': {
-            'items': [
-              {
-                'plantId': 1,
-                'nickname': '거실 몬스테라',
-                'representativeImageUrl': 'https://example.com/monstera.png',
-              },
-            ],
-            'totalCount': 1,
-            'page': 0,
-            'size': 20,
-          },
-        },
-      }, context: '식물 목록 조회');
-
-      final summaries = [for (final item in items) plantSummaryFromJson(item)];
-
-      expect(summaries, hasLength(1));
-      expect(summaries.single.id, '1');
-      expect(summaries.single.name, '거실 몬스테라');
-      expect(summaries.single.imageUrl, 'https://example.com/monstera.png');
-    });
-  });
-
   group('PlantRepository', () {
     test('식물 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlantRemoteDataSource();

--- a/test/features/user/data/mappers/user_mapper_test.dart
+++ b/test/features/user/data/mappers/user_mapper_test.dart
@@ -1,0 +1,47 @@
+import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/user/data/mappers/user_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('userProfileFromJson', () {
+    test('Swagger UserResponse를 사용자 프로필 모델로 매핑한다', () {
+      final profile = userProfileFromJson({
+        'name': '커먼',
+        'id': 'user-nano-id',
+        'email': 'common@example.com',
+        'provider': 'GOOGLE',
+        'imgUrl': 'https://example.com/profile.png',
+        'introduction': '몬스테라를 키우는 식집사입니다.',
+      });
+
+      expect(profile.id, 'user-nano-id');
+      expect(profile.name, '커먼');
+      expect(profile.email, 'common@example.com');
+      expect(profile.provider, 'GOOGLE');
+      expect(profile.imgUrl, 'https://example.com/profile.png');
+      expect(profile.introduction, '몬스테라를 키우는 식집사입니다.');
+    });
+  });
+
+  group('jsonListFromResponse + userProfileFromJson', () {
+    test('Swagger UserListJsonResponse에서 사용자 목록을 만든다', () {
+      final items = jsonListFromResponse({
+        'result': [
+          {
+            'name': '커먼',
+            'id': 'user-nano-id',
+            'email': 'common@example.com',
+            'provider': 'KAKAO',
+          },
+        ],
+      }, context: '사용자 검색');
+
+      final profiles = [for (final item in items) userProfileFromJson(item)];
+
+      expect(profiles, hasLength(1));
+      expect(profiles.single.id, 'user-nano-id');
+      expect(profiles.single.name, '커먼');
+      expect(profiles.single.provider, 'KAKAO');
+    });
+  });
+}

--- a/test/features/user/data/repositories/user_repository_test.dart
+++ b/test/features/user/data/repositories/user_repository_test.dart
@@ -1,4 +1,3 @@
-import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
 import 'package:commonplant_frontend/features/user/data/dtos/user_requests.dart';
 import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
@@ -6,48 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('userProfileFromJson', () {
-    test('Swagger UserResponse를 사용자 프로필 모델로 매핑한다', () {
-      final profile = userProfileFromJson({
-        'name': '커먼',
-        'id': 'user-nano-id',
-        'email': 'common@example.com',
-        'provider': 'GOOGLE',
-        'imgUrl': 'https://example.com/profile.png',
-        'introduction': '몬스테라를 키우는 식집사입니다.',
-      });
-
-      expect(profile.id, 'user-nano-id');
-      expect(profile.name, '커먼');
-      expect(profile.email, 'common@example.com');
-      expect(profile.provider, 'GOOGLE');
-      expect(profile.imgUrl, 'https://example.com/profile.png');
-      expect(profile.introduction, '몬스테라를 키우는 식집사입니다.');
-    });
-  });
-
-  group('jsonListFromResponse + userProfileFromJson', () {
-    test('Swagger UserListJsonResponse에서 사용자 목록을 만든다', () {
-      final items = jsonListFromResponse({
-        'result': [
-          {
-            'name': '커먼',
-            'id': 'user-nano-id',
-            'email': 'common@example.com',
-            'provider': 'KAKAO',
-          },
-        ],
-      }, context: '사용자 검색');
-
-      final profiles = [for (final item in items) userProfileFromJson(item)];
-
-      expect(profiles, hasLength(1));
-      expect(profiles.single.id, 'user-nano-id');
-      expect(profiles.single.name, '커먼');
-      expect(profiles.single.provider, 'KAKAO');
-    });
-  });
-
   group('UserRepository', () {
     test('내 정보 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImageUpdateUserRemoteDataSource();


### PR DESCRIPTION
## 관련 이슈
- Closes #105

## 구현 범위
- Place/Plant/User API JSON mapper를 feature별 `data/mappers`로 분리했습니다.
- repository 파일은 datasource 호출, response unwrap/list parsing, mapper 조합만 담당하도록 축소했습니다.
- mapper unit test를 `test/features/*/data/mappers`로 분리했습니다.
- 기존 repository test는 repository 동작 검증만 남겼습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md` 6단계 범위 수행으로 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `data/mappers` 파일 경계가 현재 DTO/codegen 미도입 상태에 적절한지 확인 부탁드립니다.
- repository test와 mapper test 분리 수준이 충분한지 확인 부탁드립니다.
