### PR TITLE
Refactor: 이미지 응답 경계 정리 #107

### DIFF
--- a/lib/features/image/data/datasources/image_remote_data_source.dart
+++ b/lib/features/image/data/datasources/image_remote_data_source.dart
@@ -19,31 +19,27 @@ class ImageRemoteDataSource {
     }
   }
 
-  Future<Object?> uploadImages(List<MultipartFile> images) async {
+  Future<void> uploadImages(List<MultipartFile> images) async {
     try {
-      final response = await _dio.post<Object?>(
+      await _dio.post<Object?>(
         '/s3/images',
         data: FormData.fromMap({'images': images}),
       );
-
-      return response.data;
     } on DioException catch (error) {
       throw ApiException.fromDio(error);
     }
   }
 
-  Future<Object?> updateImage({
+  Future<void> updateImage({
     required String key,
     required MultipartFile image,
   }) async {
     try {
-      final response = await _dio.put<Object?>(
+      await _dio.put<Object?>(
         '/s3/images',
         queryParameters: {'key': key},
         data: FormData.fromMap({'image': image}),
       );
-
-      return response.data;
     } on DioException catch (error) {
       throw ApiException.fromDio(error);
     }

--- a/lib/features/image/data/repositories/image_repository.dart
+++ b/lib/features/image/data/repositories/image_repository.dart
@@ -20,11 +20,11 @@ class ImageRepository {
     return _remoteDataSource.getDownloadUrl(key);
   }
 
-  Future<Object?> uploadImages(List<MultipartFile> images) {
+  Future<void> uploadImages(List<MultipartFile> images) {
     return _remoteDataSource.uploadImages(images);
   }
 
-  Future<Object?> updateImage({
+  Future<void> updateImage({
     required String key,
     required MultipartFile image,
   }) {

--- a/test/features/image/data/repositories/image_repository_test.dart
+++ b/test/features/image/data/repositories/image_repository_test.dart
@@ -1,0 +1,63 @@
+import 'package:commonplant_frontend/features/image/data/datasources/image_remote_data_source.dart';
+import 'package:commonplant_frontend/features/image/data/repositories/image_repository.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ImageRepository', () {
+    test('이미지 업로드는 반환값 없이 datasource에 위임한다', () async {
+      final dataSource = _RecordingImageRemoteDataSource();
+      final repository = ImageRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'plant.png',
+      );
+
+      await expectLater(repository.uploadImages([image]), completes);
+
+      expect(dataSource.latestUploadedImages, [same(image)]);
+    });
+
+    test('이미지 수정은 반환값 없이 datasource에 위임한다', () async {
+      final dataSource = _RecordingImageRemoteDataSource();
+      final repository = ImageRepository(dataSource);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'plant.png',
+      );
+
+      await expectLater(
+        repository.updateImage(
+          key: 'images/user-nano-id/plant.png',
+          image: image,
+        ),
+        completes,
+      );
+
+      expect(dataSource.latestUpdatedKey, 'images/user-nano-id/plant.png');
+      expect(dataSource.latestUpdatedImage, same(image));
+    });
+  });
+}
+
+class _RecordingImageRemoteDataSource extends ImageRemoteDataSource {
+  _RecordingImageRemoteDataSource() : super(Dio());
+
+  List<MultipartFile>? latestUploadedImages;
+  String? latestUpdatedKey;
+  MultipartFile? latestUpdatedImage;
+
+  @override
+  Future<void> uploadImages(List<MultipartFile> images) async {
+    latestUploadedImages = images;
+  }
+
+  @override
+  Future<void> updateImage({
+    required String key,
+    required MultipartFile image,
+  }) async {
+    latestUpdatedKey = key;
+    latestUpdatedImage = image;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #107

## 구현 범위
- Image upload/update repository/datasource 반환 타입을 `Future<void>`로 축소했습니다.
- 성공 response schema가 미확정인 Image write API에서 raw body를 화면/상위 계층으로 노출하지 않게 했습니다.
- Friend 요청 목록과 Image download URL은 백엔드 response schema가 미확정이라 임의 DTO 없이 raw 경계를 유지했습니다.
- ImageRepository 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/api-swagger-reference.md`, `docs/backend-api-open-questions.md`의 미확정 response 정책 범위 안에서 처리해 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- schema 미확정 API를 `void`로 닫은 범위가 적절한지 확인 부탁드립니다.
- Friend 요청 목록과 Image download URL raw 유지 판단이 문서 정책과 맞는지 확인 부탁드립니다.
