### PR TITLE
Docs: shared 위젯 소유권 감사 #109

### DIFF
--- a/docs/shared-widget-guide.md
+++ b/docs/shared-widget-guide.md
@@ -32,6 +32,14 @@ CommonScaffold(
 
 상단 네비게이션 바가 필요 없는 샘플 또는 특수 화면은 `showNavigationBar: false`를 사용할 수 있습니다.
 
+### CommonSectionHeader
+
+섹션 제목과 우측 액션을 나란히 배치하는 작은 헤더입니다.
+
+- 제목 텍스트는 `20/500`
+- 우측 액션은 `action` 슬롯으로 주입
+- 특정 도메인 상태나 Provider를 직접 알지 않음
+
 ## 버튼
 
 ### CommonButton
@@ -57,6 +65,8 @@ CommonButton(
 ### CommonPlusIconButton
 
 36x36 영역의 플러스 아이콘 버튼입니다. 아이콘은 24x24로 중앙 정렬됩니다.
+
+내부 플러스 도형은 `CommonPlusMark`가 담당합니다. `CommonPlusMark`는 단독 사용보다 `CommonPlusIconButton`, `CommonAddTile` 같은 공용 컨트롤 내부 primitive로 우선 사용합니다.
 
 ### CommonWateringButton
 
@@ -270,12 +280,36 @@ const CommonSvgIcon(
 
 새 아이콘을 추가할 때는 `assets/icons`에 파일을 넣고 `AppIconAssets`에 상수를 추가합니다.
 
+## 소유권 감사 결과
+
+2026-06-25 기준 `lib/shared/widgets`와 `lib/features/common/presentation/widgets`를 확인한 결과입니다. 이 표는 즉시 파일을 이동하기 위한 목록이 아니라, 이후 화면 분해나 공용 위젯 추가 PR에서 소유권을 판단하는 기준입니다.
+
+| 분류 | 대상 | 판단 |
+| --- | --- | --- |
+| 공용 control로 유지 | `CommonButton`, `CommonScaffold`, `CommonNavigationBar`, `CommonSvgIcon`, `CommonTextField`, `CommonSearchTextField`, `CommonAddressOrPlaceField`, `CommonDialogCard`, `CommonDialogActionButton`, `CommonEditDeletePopup`, `CommonFab`, `CommonFabDial`, `CommonPlusIconButton` | 여러 feature에서 같은 의미와 상호작용으로 쓰이고 도메인 정책을 알지 않으므로 `shared/widgets`에 둡니다. |
+| 공용 primitive로 유지 | `CommonPlusMark`, `CommonSectionHeader` | 도메인 의존성은 없지만 직접 사용처가 적습니다. 공용 위젯 내부 primitive 또는 반복 섹션 헤더로만 확장하고, 화면별 조합 로직은 넣지 않습니다. |
+| 공용 image input 후보 | `CommonCircleImageBox`, `CommonPhotoAddButton`, `CommonPlaceImageAddButton` | 이미지 선택 UI라는 공통성이 있습니다. 다만 `CommonPlaceImageAddButton`처럼 특정 도메인 이름이 들어간 위젯은 다른 feature로 확장하기 전에 generic variant 추가 또는 feature 내부 이동을 먼저 검토합니다. |
+| 공용 display 후보 | `CommonPlaceCard`, `CommonPlantCard`, `CommonPlacePlantCard`, `CommonMemoCard`, `CommonWateringButton` | Home, Place, Plant, Memo 사이에서 같은 카드 표현을 공유할 가능성이 있어 당장은 유지합니다. API 상태, route 이동, 권한 정책이 들어가기 시작하면 feature 내부 widget으로 내리거나 domain-agnostic display model을 주입하는 방식으로 정리합니다. |
+| feature 내부 이동 후보 | `CommonAddTile`, `CommonPlaceGuideBanner` | 장소/식물 Figma 조합이나 안내 배너 성격이 강하고 현재 직접 사용처가 적습니다. 다음 화면 분해 PR에서 실제 사용 화면이 하나로 좁혀지면 해당 feature의 `presentation/widgets`로 이동하거나 제거를 검토합니다. |
+| Phase 0 임시 위젯 | `Phase0Section`, `Phase0Surface`, `Phase0Chip`, `Phase0EmptyState`, `Phase0UserAvatar`, `Phase0InfoRow` | `features/common`의 Phase 0 보조 위젯입니다. 새 화면에서 확대 사용하지 않고, 실제 반복 사용처가 생기면 `shared/widgets` 승격 또는 feature 내부 이동을 별도 PR로 결정합니다. |
+
+### 이동 판단 기준
+
+- 두 개 이상의 feature에서 같은 형태와 같은 상호작용으로 쓰이면 `shared/widgets` 유지 또는 승격을 검토합니다.
+- 도메인 이름이 들어간 위젯은 여러 feature에서 같은 의미로 재사용되는 display 컴포넌트일 때만 `shared/widgets`에 둡니다.
+- route 이동, Provider watch, API 상태, 권한 정책을 알게 되는 순간 feature 내부 `presentation/widgets` 또는 `presentation/providers`로 내립니다.
+- Figma 특정 section, banner, form 조합처럼 한 화면의 배치 의도가 강한 위젯은 공용화하지 않습니다.
+- `shared/widgets`에서 feature 내부로 이동하는 PR은 동작 변경 없이 import와 테스트만 함께 정리합니다.
+- 공용 위젯이 300줄을 넘거나 variant가 늘어나면 primitive, style, variant 파일 분리를 검토합니다.
+
 ## 새 공용 위젯 추가 체크리스트
 
 - [ ] `lib/shared/widgets/common_*.dart` 이름으로 추가했는가?
 - [ ] style 값이 `core/theme` 토큰을 사용하고 있는가?
 - [ ] 필요한 asset이 `AppIconAssets`에 등록되어 있는가?
 - [ ] 상태 변화가 콜백으로 외부 주입 가능한가?
+- [ ] 두 개 이상의 feature에서 같은 의미로 재사용되는가?
+- [ ] 도메인 정책, route, Provider, API 모델을 직접 알지 않는가?
 - [ ] 샘플 화면에서 확인 가능한가?
 - [ ] `fvm flutter analyze`를 통과하는가?
 - [ ] 필요한 경우 widget test를 갱신했는가?


### PR DESCRIPTION
## 관련 이슈
- Closes #109

## 구현 범위
- `docs/shared-widget-guide.md`에 shared widget 소유권 감사 결과를 추가했습니다.
- 공용 control, primitive, image input 후보, display 후보, feature 내부 이동 후보, Phase 0 임시 위젯을 분류했습니다.
- 이후 화면 분해나 공용 위젯 추가 PR에서 사용할 이동 판단 기준과 체크리스트를 보강했습니다.

## 테스트
- `git diff --check`

## 문서 반영 여부
- 문서 작업 PR입니다.

## 리뷰 포인트
- `CommonPlaceCard`, `CommonPlantCard`, `CommonMemoCard`를 당장 이동하지 않고 display 후보로 유지하는 판단이 적절한지 확인 부탁드립니다.
- `CommonAddTile`, `CommonPlaceGuideBanner`, `Phase0*` 위젯의 후속 정리 기준이 충분한지 확인 부탁드립니다.
