### PR TITLE
Docs: 인증 redirect 설계 #111

### DIFF
--- a/docs/routing-guide.md
+++ b/docs/routing-guide.md
@@ -108,13 +108,42 @@ lib/app/router/
 
 인증 기능이 들어오면 아래 방향으로 확장합니다.
 
-1. 인증 상태 Provider를 `app_routerProvider`에서 watch합니다.
-2. 로그인 전 접근 가능한 route와 로그인 후 route를 `/login`, `/` 기준으로 분리합니다.
-3. 인증 토큰은 `flutter_secure_storage` 기반 저장소를 통해 관리합니다.
-4. access token 만료, refresh 실패, 로그아웃은 라우터 redirect에서 `/login`으로 이동시킵니다.
+1. 인증 상태 Provider를 `appRouterProvider`에서 watch합니다.
+2. 로그인 전 접근 가능한 route, 회원가입 진행 route, 로그인 후 route를 route policy로 분리합니다.
+3. 인증 토큰은 `flutter_secure_storage` 기반 저장소를 통해 관리하되, 라우터는 token storage에 직접 접근하지 않고 인증 Provider의 상태만 봅니다.
+4. access token 만료, refresh 실패, 로그아웃은 인증 Provider 상태를 `unauthenticated`로 바꾸고, 라우터 redirect에서 `/login`으로 이동시킵니다.
 5. 로그인 성공 후에는 사용자가 원래 접근하려던 위치로 복귀할 수 있도록 redirect target을 보존합니다.
 
 인증 판단을 개별 화면의 `initState`나 `build`에서 처리하지 않습니다.
+
+### Auth redirect Provider 설계
+
+현재 `appRouterProvider`는 `createAppRouter()`만 반환하며 인증 상태를 watch하지 않습니다. 인증 redirect 구현 PR에서는 아래 파일 경계를 목표로 둡니다.
+
+| 파일 | 역할 |
+| --- | --- |
+| `features/login/presentation/providers/auth_state_provider.dart` | 앱 전역 인증 상태를 `checking`, `unauthenticated`, `signupRequired`, `authenticated`처럼 표현합니다. |
+| `app/router/route_access_policy.dart` | route name별 접근 정책을 공개, 회원가입 진행, 인증 필요로 분류합니다. |
+| `app/router/redirect_notifier.dart` | 인증 Provider 변경을 `GoRouter.refreshListenable`로 연결합니다. |
+| `app/router/app_router.dart` | 인증 상태와 현재 location을 기준으로 redirect target을 계산합니다. |
+
+라우터 redirect는 아래 순서를 따릅니다.
+
+1. 인증 상태가 `checking`이면 현재 위치를 유지합니다.
+2. 공개 route는 인증 여부와 관계없이 진입을 허용합니다.
+3. `signupRequired` 상태에서는 `profileSetup`, `terms` route만 허용하고 그 외 route는 `/profile/setup`으로 보냅니다.
+4. `unauthenticated` 상태에서 공개 route가 아닌 route에 접근하면 `/login`으로 보내며, 원래 location은 redirect target으로 보존합니다.
+5. `authenticated` 상태에서 공개 route나 회원가입 진행 route에 접근하면 보존된 redirect target 또는 `/`로 보냅니다.
+
+초기 route policy는 아래처럼 둡니다.
+
+| 정책 | Route name |
+| --- | --- |
+| 공개 route | `onboarding`, `login` |
+| 회원가입 진행 route | `profileSetup`, `terms` |
+| 인증 필요 route | `home`, `placeInvitations`, `placeCreate`, `addressSearch`, `placeFriendAdd`, `placeEdit`, `placeDetail`, `friendManagement`, `plantSearch`, `plantCreateDetails`, `plantEdit`, `plantDetail`, `memoWrite`, `memoList` |
+
+`TOKEN-01`, `TOKEN-02`가 답변되기 전까지 refresh token 재발급과 서버 로그아웃 invalidation은 redirect 구현 범위에 넣지 않습니다. 그 전에는 토큰이 없거나 명시적으로 clear된 경우만 `unauthenticated`로 전환합니다.
 
 ## 화면 이동 기준
 

--- a/docs/state-management-guide.md
+++ b/docs/state-management-guide.md
@@ -125,6 +125,31 @@ lib/features/login/
 - 라우터는 인증 Provider의 결과만 보고 redirect하며, storage에 직접 접근하지 않습니다.
 - refresh 실패 또는 로그아웃 시 인증 상태를 unauthenticated로 전환합니다.
 
+### Auth state Provider 설계
+
+인증 상태는 token 문자열 자체보다 앱이 판단해야 하는 route 상태를 중심으로 표현합니다.
+
+| 상태 | 의미 | 라우터 처리 |
+| --- | --- | --- |
+| `checking` | 앱 시작 시 secure storage 또는 세션 복원 확인 중 | 현재 location 유지 |
+| `unauthenticated` | 유효한 로그인 세션이 없음 | 인증 필요 route를 `/login`으로 redirect |
+| `signupRequired` | 로그인은 성공했지만 신규 유저 프로필 설정이 필요함 | `profileSetup`, `terms` 외 route를 `/profile/setup`으로 redirect |
+| `authenticated` | 홈과 도메인 화면에 접근 가능한 세션 | 공개/회원가입 route 진입 시 `/` 또는 보존된 target으로 redirect |
+
+Provider 책임은 아래처럼 나눕니다.
+
+| 대상 | 책임 |
+| --- | --- |
+| `AuthTokenStore` | access token, refresh token의 저장/읽기/삭제만 담당합니다. UI나 라우터 상태를 알지 않습니다. |
+| `AuthInterceptor` | 요청 직전 access token을 `Authorization: Bearer ...` header에 첨부합니다. redirect를 직접 수행하지 않습니다. |
+| `authStateProvider` | token store와 로그인/회원가입 결과를 바탕으로 앱 인증 상태를 노출합니다. |
+| 로그인/회원가입 Controller | repository 호출, token 저장, `signupRequired` 또는 `authenticated` 전환을 담당합니다. |
+| 로그아웃 Controller | 로컬 token clear 후 `unauthenticated`로 전환합니다. 서버 로그아웃 API는 `TOKEN-02` 답변 후 추가합니다. |
+
+`authStateProvider`는 테스트에서 override할 수 있어야 하며, router test는 `unauthenticated`, `signupRequired`, `authenticated` 상태별 redirect를 직접 검증합니다.
+
+`TOKEN-01` refresh API가 확정되기 전까지 access token 만료 자동 복구는 구현하지 않습니다. 401 응답을 받은 뒤 token을 갱신하는 interceptor 재시도 정책은 백엔드 endpoint와 error code가 확정된 뒤 별도 이슈에서 다룹니다.
+
 ## Provider 네이밍
 
 | 대상 | 예시 |


### PR DESCRIPTION
## 관련 이슈
- Closes #111

## 구현 범위
- `docs/routing-guide.md`에 Auth redirect Provider 목표 구조와 route access policy를 추가했습니다.
- `docs/state-management-guide.md`에 auth state Provider 상태 모델과 token store/interceptor 책임 경계를 보강했습니다.
- `TOKEN-01`, `TOKEN-02` 미확정 범위는 구현 보류 기준으로 명시했습니다.

## 테스트
- `git diff --check`

## 문서 반영 여부
- 문서 작업 PR입니다.

## 리뷰 포인트
- 공개 route, 회원가입 진행 route, 인증 필요 route의 초기 분류가 적절한지 확인 부탁드립니다.
- refresh/logout API 미확정 상태에서 구현 보류 범위를 충분히 좁혔는지 확인 부탁드립니다.
