### PR TITLE
Refactor: Place 상세 Provider 경계 #113

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -2,15 +2,14 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
-import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_view_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_widgets.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
@@ -57,17 +56,12 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final mockDetail = placeDetailFixture(widget.placeId, role: widget.role);
+    final request = (placeId: widget.placeId, role: widget.role);
+    final detailState = ref.watch(placeDetailViewProvider(request));
 
-    if (!ref.watch(useRemoteApiProvider)) {
-      return _buildScaffold(context, mockDetail);
-    }
-
-    final remoteDetail = ref.watch(placeDetailProvider(widget.placeId));
-
-    return remoteDetail.when(
-      data: (summary) {
-        if (_isEmptyRemoteSummary(summary)) {
+    return detailState.when(
+      data: (detail) {
+        if (detail == null) {
           return _buildStatusScaffold(
             context,
             const _PlaceDetailStatusView(
@@ -79,7 +73,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
           );
         }
 
-        return _buildScaffold(context, mockDetail.applySummary(summary));
+        return _buildScaffold(context, detail);
       },
       error: (error, stackTrace) {
         return _buildStatusScaffold(
@@ -90,7 +84,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
             message: '잠시 후 다시 시도해 주세요',
             semanticsLabel: '장소 정보 오류',
             actionLabel: '다시 시도',
-            onAction: () => ref.invalidate(placeDetailProvider(widget.placeId)),
+            onAction: () => invalidatePlaceDetailView(ref, request),
           ),
         );
       },
@@ -192,10 +186,6 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
         ),
       ),
     );
-  }
-
-  bool _isEmptyRemoteSummary(PlaceSummary summary) {
-    return summary.name.trim().isEmpty;
   }
 }
 

--- a/lib/features/place/presentation/providers/place_detail_view_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_view_provider.dart
@@ -1,0 +1,43 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+typedef PlaceDetailViewRequest = ({String placeId, PlaceDetailRole? role});
+
+final placeDetailViewProvider =
+    Provider.family<
+      AsyncValue<PlaceDetailFixtureData?>,
+      PlaceDetailViewRequest
+    >((ref, request) {
+      if (!ref.watch(useRemoteApiProvider)) {
+        return AsyncData(
+          placeDetailFixture(request.placeId, role: request.role),
+        );
+      }
+
+      return ref.watch(remotePlaceDetailViewProvider(request));
+    });
+
+final remotePlaceDetailViewProvider =
+    FutureProvider.family<PlaceDetailFixtureData?, PlaceDetailViewRequest>((
+      ref,
+      request,
+    ) async {
+      final fixture = placeDetailFixture(request.placeId, role: request.role);
+      final summary = await ref.watch(
+        placeDetailProvider(request.placeId).future,
+      );
+
+      if (summary.name.trim().isEmpty) {
+        return null;
+      }
+
+      return fixture.applySummary(summary);
+    }, retry: (retryCount, error) => null);
+
+void invalidatePlaceDetailView(WidgetRef ref, PlaceDetailViewRequest request) {
+  ref.invalidate(placeDetailProvider(request.placeId));
+  ref.invalidate(remotePlaceDetailViewProvider(request));
+}

--- a/test/features/place/presentation/providers/place_detail_view_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_view_provider_test.dart
@@ -1,0 +1,92 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_view_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('placeDetailViewProvider', () {
+    test('local mode는 fixture 상세를 즉시 반환한다', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(
+        placeDetailViewProvider((
+          placeId: 'place-1',
+          role: PlaceDetailRole.member,
+        )),
+      );
+
+      final detail = state.requireValue;
+      expect(detail?.name, '스윗 홈_거실');
+      expect(detail?.role, PlaceDetailRole.member);
+    });
+
+    test('remote mode는 summary를 fixture 상세에 병합한다', () async {
+      final repository = _StaticPlaceRepository(
+        const PlaceSummary(
+          id: 'remote-place',
+          name: '옥상 정원',
+          address: '서울시 노원구 광운로 20',
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final request = (placeId: 'remote-place', role: PlaceDetailRole.leader);
+      await container.read(remotePlaceDetailViewProvider(request).future);
+
+      final detail = container
+          .read(placeDetailViewProvider(request))
+          .requireValue;
+
+      expect(detail?.name, '옥상 정원');
+      expect(detail?.address, '서울시 노원구 광운로 20');
+      expect(detail?.role, PlaceDetailRole.leader);
+      expect(repository.fetchCalls, 1);
+    });
+
+    test('remote mode에서 빈 summary는 null data로 표시한다', () async {
+      final repository = _StaticPlaceRepository(
+        const PlaceSummary(id: 'empty-place', name: ''),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final request = (placeId: 'empty-place', role: null);
+      await container.read(remotePlaceDetailViewProvider(request).future);
+
+      expect(
+        container.read(placeDetailViewProvider(request)).requireValue,
+        isNull,
+      );
+    });
+  });
+}
+
+class _StaticPlaceRepository extends PlaceRepository {
+  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+  int fetchCalls = 0;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    fetchCalls++;
+    return summary;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #113

## 구현 범위
- Place 상세 화면의 local fixture/remote summary 병합 책임을 `placeDetailViewProvider`로 이동했습니다.
- `PlaceDetailPage`에서 `useRemoteApiProvider` 직접 분기를 제거하고 Provider의 `AsyncValue`만 렌더링하도록 정리했습니다.
- remote retry는 view Provider helper에서 기존 상세 summary Provider와 view Provider를 함께 invalidate하도록 유지했습니다.
- Place 상세 Provider 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 코드 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `placeDetailViewProvider`와 `remotePlaceDetailViewProvider`의 public 경계가 적절한지 확인 부탁드립니다.
- Plant 상세에도 같은 패턴으로 확장할지 확인 부탁드립니다.
