### PR TITLE
Refactor: Plant 상세 Provider 경계 #115

### DIFF
--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -2,15 +2,13 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
-import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_widgets.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
@@ -101,17 +99,12 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final mockDetail = plantDetailFixture(placeCode: widget.placeId);
+    final request = (plantId: widget.plantId, placeCode: widget.placeId);
+    final detailState = ref.watch(plantDetailViewProvider(request));
 
-    if (!ref.watch(useRemoteApiProvider)) {
-      return _buildScaffold(context, mockDetail);
-    }
-
-    final remoteDetail = ref.watch(remotePlantDetailProvider(widget.plantId));
-
-    return remoteDetail.when(
+    return detailState.when(
       data: (detail) {
-        if (_isEmptyRemoteDetail(detail)) {
+        if (detail == null) {
           return const PlantStateScaffold(
             title: 'My plant',
             statusTitle: '식물 정보를 찾을 수 없어요',
@@ -119,15 +112,14 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
           );
         }
 
-        return _buildScaffold(context, mockDetail.applyRemote(detail));
+        return _buildScaffold(context, detail);
       },
       error: (error, stackTrace) => PlantStateScaffold(
         title: 'My plant',
         statusTitle: '식물 정보를 불러오지 못했어요',
         message: '잠시 후 다시 시도해 주세요',
         actionLabel: '다시 시도',
-        onAction: () =>
-            ref.invalidate(remotePlantDetailProvider(widget.plantId)),
+        onAction: () => invalidatePlantDetailView(ref, request),
       ),
       loading: () => const PlantStateScaffold(
         title: 'My plant',
@@ -205,10 +197,6 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
         ),
       ),
     );
-  }
-
-  bool _isEmptyRemoteDetail(PlantDetail detail) {
-    return detail.name.trim().isEmpty;
   }
 }
 

--- a/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
@@ -1,0 +1,40 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+typedef PlantDetailViewRequest = ({String plantId, String? placeCode});
+
+final plantDetailViewProvider =
+    Provider.family<
+      AsyncValue<PlantDetailFixtureData?>,
+      PlantDetailViewRequest
+    >((ref, request) {
+      if (!ref.watch(useRemoteApiProvider)) {
+        return AsyncData(plantDetailFixture(placeCode: request.placeCode));
+      }
+
+      return ref.watch(remotePlantDetailViewProvider(request));
+    });
+
+final remotePlantDetailViewProvider =
+    FutureProvider.family<PlantDetailFixtureData?, PlantDetailViewRequest>((
+      ref,
+      request,
+    ) async {
+      final fixture = plantDetailFixture(placeCode: request.placeCode);
+      final detail = await ref.watch(
+        remotePlantDetailProvider(request.plantId).future,
+      );
+
+      if (detail.name.trim().isEmpty) {
+        return null;
+      }
+
+      return fixture.applyRemote(detail);
+    }, retry: (retryCount, error) => null);
+
+void invalidatePlantDetailView(WidgetRef ref, PlantDetailViewRequest request) {
+  ref.invalidate(remotePlantDetailProvider(request.plantId));
+  ref.invalidate(remotePlantDetailViewProvider(request));
+}

--- a/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
@@ -1,0 +1,94 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('plantDetailViewProvider', () {
+    test('local mode는 fixture 상세를 즉시 반환한다', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(
+        plantDetailViewProvider((plantId: 'plant-1', placeCode: 'place-1')),
+      );
+
+      final detail = state.requireValue;
+      expect(detail?.name, '몬테');
+      expect(detail?.placeCode, 'place-1');
+      expect(detail?.placeName, '스윗홈_거실');
+    });
+
+    test('remote mode는 PlantDetail을 fixture 상세에 병합한다', () async {
+      final repository = _StaticPlantRepository(
+        const PlantDetail(
+          id: 'remote-plant',
+          name: '필로덴드론',
+          placeId: 'remote-place',
+          placeName: '거실 정원',
+          species: 'Philodendron',
+          lastWateredDate: '2026.05.25',
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final request = (plantId: 'remote-plant', placeCode: 'fallback-place');
+      await container.read(remotePlantDetailViewProvider(request).future);
+
+      final detail = container
+          .read(plantDetailViewProvider(request))
+          .requireValue;
+
+      expect(detail?.name, '필로덴드론');
+      expect(detail?.placeCode, 'remote-place');
+      expect(detail?.placeName, '거실 정원');
+      expect(detail?.species, 'Philodendron');
+      expect(detail?.lastWateredDate, '2026.05.25');
+      expect(repository.fetchCalls, 1);
+    });
+
+    test('remote mode에서 빈 상세는 null data로 표시한다', () async {
+      final repository = _StaticPlantRepository(
+        const PlantDetail(id: 'empty-plant', name: ''),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final request = (plantId: 'empty-plant', placeCode: null);
+      await container.read(remotePlantDetailViewProvider(request).future);
+
+      expect(
+        container.read(plantDetailViewProvider(request)).requireValue,
+        isNull,
+      );
+    });
+  });
+}
+
+class _StaticPlantRepository extends PlantRepository {
+  _StaticPlantRepository(this.detail) : super(PlantRemoteDataSource(Dio()));
+
+  final PlantDetail detail;
+  int fetchCalls = 0;
+
+  @override
+  Future<PlantDetail> fetchPlant({required String plantId}) async {
+    fetchCalls++;
+    return detail;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #115

## 구현 범위
- Plant 상세 화면의 local fixture/remote detail 병합 책임을 `plantDetailViewProvider`로 이동했습니다.
- `PlantDetailPage`에서 `useRemoteApiProvider` 직접 분기를 제거하고 Provider의 `AsyncValue`만 렌더링하도록 정리했습니다.
- retry는 view Provider helper에서 기존 `remotePlantDetailProvider`와 view Provider를 함께 invalidate하도록 유지했습니다.
- Plant 상세 Provider 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 코드 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `plantDetailViewProvider`와 `remotePlantDetailViewProvider`의 public 경계가 적절한지 확인 부탁드립니다.
- 이후 form/detail Provider 파일 분리 범위를 어디까지 가져갈지 확인 부탁드립니다.
