### PR TITLE
Refactor: Place 수정 폼 Provider #117

### DIFF
--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -1,12 +1,11 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_place_image_add_button.dart';
@@ -15,8 +14,6 @@ import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-
-const String _placeEditInitialName = '스윗 홈_ 거실';
 
 class PlaceFormPage extends ConsumerStatefulWidget {
   const PlaceFormPage({super.key, this.placeId});
@@ -34,12 +31,12 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
   late String _initialName;
   String? _initialAddress;
   String? _address;
-  String? _remoteInitialPlaceId;
+  String? _appliedEditPlaceId;
 
   @override
   void initState() {
     super.initState();
-    _initialName = widget.isEdit ? _placeEditInitialName : '';
+    _initialName = widget.isEdit ? placeFormDefaultEditName : '';
     _initialAddress = null;
     _nameController = TextEditingController(text: _initialName);
     _address = _initialAddress;
@@ -53,11 +50,11 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.isEdit && ref.watch(useRemoteApiProvider)) {
+    if (widget.isEdit) {
       final placeId = widget.placeId!;
-      final remoteDetail = ref.watch(placeDetailProvider(placeId));
+      final editInfo = ref.watch(placeFormEditInfoProvider(placeId));
 
-      return remoteDetail.when(
+      return editInfo.when(
         loading: () {
           return const _PlaceFormStatusScaffold(
             title: '장소 정보를 불러오고 있어요',
@@ -70,18 +67,18 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
             title: '장소 정보를 불러오지 못했어요',
             message: '잠시 후 다시 시도해 주세요',
             actionLabel: '다시 시도',
-            onAction: () => ref.invalidate(placeDetailProvider(placeId)),
+            onAction: () => invalidatePlaceFormEditInfo(ref, placeId),
           );
         },
-        data: (summary) {
-          if (summary.name.trim().isEmpty) {
+        data: (info) {
+          if (info == null) {
             return const _PlaceFormStatusScaffold(
               title: '장소 정보를 찾을 수 없어요',
               message: '다시 장소 목록에서 선택해 주세요',
             );
           }
 
-          _applyRemoteSummary(summary);
+          _applyEditInfo(info);
 
           return _buildForm(context);
         },
@@ -128,18 +125,18 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     );
   }
 
-  void _applyRemoteSummary(PlaceSummary summary) {
+  void _applyEditInfo(PlaceFormEditInfo info) {
     final placeId = widget.placeId;
 
-    if (placeId == null || _remoteInitialPlaceId == placeId) {
+    if (placeId == null || _appliedEditPlaceId == placeId) {
       return;
     }
 
-    _remoteInitialPlaceId = placeId;
-    _initialName = summary.name;
-    _initialAddress = summary.address;
-    _address = summary.address;
-    _nameController.text = summary.name;
+    _appliedEditPlaceId = placeId;
+    _initialName = info.name;
+    _initialAddress = info.address;
+    _address = info.address;
+    _nameController.text = info.name;
   }
 
   Future<void> _submit() async {

--- a/lib/features/place/presentation/providers/place_form_edit_provider.dart
+++ b/lib/features/place/presentation/providers/place_form_edit_provider.dart
@@ -1,0 +1,48 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const String placeFormDefaultEditName = '스윗 홈_ 거실';
+
+class PlaceFormEditInfo {
+  const PlaceFormEditInfo({required this.id, required this.name, this.address});
+
+  factory PlaceFormEditInfo.fromSummary(PlaceSummary summary) {
+    return PlaceFormEditInfo(
+      id: summary.id,
+      name: summary.name,
+      address: summary.address,
+    );
+  }
+
+  final String id;
+  final String name;
+  final String? address;
+}
+
+final placeFormEditInfoProvider =
+    Provider.family<AsyncValue<PlaceFormEditInfo?>, String>((ref, placeId) {
+      if (!ref.watch(useRemoteApiProvider)) {
+        return AsyncData(
+          PlaceFormEditInfo(id: placeId, name: placeFormDefaultEditName),
+        );
+      }
+
+      return ref.watch(remotePlaceFormEditInfoProvider(placeId));
+    });
+
+final remotePlaceFormEditInfoProvider =
+    FutureProvider.family<PlaceFormEditInfo?, String>((ref, placeId) async {
+      final summary = await ref.watch(placeDetailProvider(placeId).future);
+
+      if (summary.name.trim().isEmpty) {
+        return null;
+      }
+
+      return PlaceFormEditInfo.fromSummary(summary);
+    }, retry: (retryCount, error) => null);
+
+void invalidatePlaceFormEditInfo(WidgetRef ref, String placeId) {
+  ref.invalidate(placeDetailProvider(placeId));
+  ref.invalidate(remotePlaceFormEditInfoProvider(placeId));
+}

--- a/test/features/place/presentation/providers/place_form_edit_provider_test.dart
+++ b/test/features/place/presentation/providers/place_form_edit_provider_test.dart
@@ -1,0 +1,85 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('placeFormEditInfoProvider', () {
+    test('local mode는 기본 수정 정보를 즉시 반환한다', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(placeFormEditInfoProvider('place-1'));
+
+      final info = state.requireValue;
+      expect(info?.id, 'place-1');
+      expect(info?.name, '스윗 홈_ 거실');
+      expect(info?.address, isNull);
+    });
+
+    test('remote mode는 장소 상세 summary를 수정 정보로 변환한다', () async {
+      final repository = _StaticPlaceRepository(
+        const PlaceSummary(id: 'remote-place', name: '루프탑', address: '서울시 성북구'),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(
+        remotePlaceFormEditInfoProvider('remote-place').future,
+      );
+
+      final info = container
+          .read(placeFormEditInfoProvider('remote-place'))
+          .requireValue;
+
+      expect(info?.id, 'remote-place');
+      expect(info?.name, '루프탑');
+      expect(info?.address, '서울시 성북구');
+      expect(repository.fetchCalls, 1);
+    });
+
+    test('remote mode에서 빈 summary는 null data로 표시한다', () async {
+      final repository = _StaticPlaceRepository(
+        const PlaceSummary(id: 'empty-place', name: ''),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(
+        remotePlaceFormEditInfoProvider('empty-place').future,
+      );
+
+      expect(
+        container.read(placeFormEditInfoProvider('empty-place')).requireValue,
+        isNull,
+      );
+    });
+  });
+}
+
+class _StaticPlaceRepository extends PlaceRepository {
+  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+  int fetchCalls = 0;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    fetchCalls++;
+    return summary;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #117

## 구현 범위
- Place 수정 화면의 local 기본값/remote summary 조회 책임을 `placeFormEditInfoProvider`로 이동했습니다.
- `PlaceFormPage` 수정 모드에서 `useRemoteApiProvider` 직접 분기를 제거하고 Provider의 `AsyncValue`만 렌더링하도록 정리했습니다.
- retry는 edit Provider helper에서 기존 `placeDetailProvider`와 edit Provider를 함께 invalidate하도록 유지했습니다.
- Place 수정 폼 edit Provider 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 코드 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `placeFormEditInfoProvider`의 local 기본값 경계가 적절한지 확인 부탁드립니다.
- 같은 패턴을 Plant 수정 폼에도 이어갈지 확인 부탁드립니다.
