### PR TITLE
Refactor: Plant 수정 폼 Provider #119

### DIFF
--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,16 +1,14 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
@@ -41,13 +39,11 @@ class PlantFormPage extends ConsumerStatefulWidget {
 }
 
 class _PlantFormPageState extends ConsumerState<PlantFormPage> {
-  static const String _defaultEditPlantName = '몬테';
-
   late final TextEditingController _nameController;
   late final String _selectedPlantName;
   String? _selectedPlaceId;
-  String _initialEditPlantName = _defaultEditPlantName;
-  bool _hasAppliedRemoteEditInfo = false;
+  String _initialEditPlantName = plantFormDefaultEditName;
+  bool _hasAppliedEditInfo = false;
 
   static const List<_PlantRegistrationPlace> _places = [
     _PlantRegistrationPlace(
@@ -77,7 +73,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     super.initState();
     _selectedPlantName = _normalizedInitialPlantName();
     _nameController = TextEditingController(
-      text: widget.isEdit ? _defaultEditPlantName : '',
+      text: widget.isEdit ? plantFormDefaultEditName : '',
     );
     _selectedPlaceId = widget.isEdit ? null : _places.first.id;
   }
@@ -114,16 +110,12 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Widget _buildEditMode() {
-    if (!ref.watch(useRemoteApiProvider)) {
-      return _buildEditScaffold();
-    }
-
     final plantId = widget.plantId!;
-    final editInfo = ref.watch(remotePlantEditInfoProvider(plantId));
+    final editInfo = ref.watch(plantFormEditInfoProvider(plantId));
 
     return editInfo.when(
       data: (info) {
-        if (_isEmptyRemoteEditInfo(info)) {
+        if (info == null) {
           return const PlantStateScaffold(
             title: '식물 수정',
             statusTitle: '식물 수정 정보를 찾을 수 없어요',
@@ -131,7 +123,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
           );
         }
 
-        _applyRemoteEditInfo(info);
+        _applyEditInfo(info);
 
         return _buildEditScaffold();
       },
@@ -140,7 +132,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
         statusTitle: '식물 수정 정보를 불러오지 못했어요',
         message: '잠시 후 다시 시도해 주세요',
         actionLabel: '다시 시도',
-        onAction: () => ref.invalidate(remotePlantEditInfoProvider(plantId)),
+        onAction: () => invalidatePlantFormEditInfo(ref, plantId),
       ),
       loading: () => const PlantStateScaffold(
         title: '식물 수정',
@@ -168,8 +160,8 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     );
   }
 
-  void _applyRemoteEditInfo(PlantEditInfo info) {
-    if (_hasAppliedRemoteEditInfo) {
+  void _applyEditInfo(PlantEditInfo info) {
+    if (_hasAppliedEditInfo) {
       return;
     }
 
@@ -178,11 +170,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     _initialEditPlantName = name;
     _nameController.text = name;
     _nameController.selection = TextSelection.collapsed(offset: name.length);
-    _hasAppliedRemoteEditInfo = true;
-  }
-
-  bool _isEmptyRemoteEditInfo(PlantEditInfo info) {
-    return info.name.trim().isEmpty;
+    _hasAppliedEditInfo = true;
   }
 
   String _normalizedInitialPlantName() {

--- a/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
@@ -1,0 +1,34 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+export 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart'
+    show PlantEditInfo;
+
+const String plantFormDefaultEditName = '몬테';
+
+final plantFormEditInfoProvider =
+    Provider.family<AsyncValue<PlantEditInfo?>, String>((ref, plantId) {
+      if (!ref.watch(useRemoteApiProvider)) {
+        return const AsyncData(PlantEditInfo(name: plantFormDefaultEditName));
+      }
+
+      return ref.watch(remotePlantFormEditInfoProvider(plantId));
+    });
+
+final remotePlantFormEditInfoProvider =
+    FutureProvider.family<PlantEditInfo?, String>((ref, plantId) async {
+      final info = await ref.watch(remotePlantEditInfoProvider(plantId).future);
+
+      if (info.name.trim().isEmpty) {
+        return null;
+      }
+
+      return info;
+    }, retry: (retryCount, error) => null);
+
+void invalidatePlantFormEditInfo(WidgetRef ref, String plantId) {
+  ref.invalidate(remotePlantEditInfoProvider(plantId));
+  ref.invalidate(remotePlantFormEditInfoProvider(plantId));
+}

--- a/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
@@ -1,0 +1,80 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('plantFormEditInfoProvider', () {
+    test('local mode는 기본 수정 정보를 즉시 반환한다', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(plantFormEditInfoProvider('plant-1'));
+
+      final info = state.requireValue;
+      expect(info?.name, '몬테');
+      expect(info?.lastWateredDate, isNull);
+    });
+
+    test('remote mode는 식물 수정 정보를 반환한다', () async {
+      final repository = _StaticPlantRepository(
+        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026.05.25'),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(
+        remotePlantFormEditInfoProvider('remote-plant').future,
+      );
+
+      final info = container
+          .read(plantFormEditInfoProvider('remote-plant'))
+          .requireValue;
+
+      expect(info?.name, '필로덴드론');
+      expect(info?.lastWateredDate, '2026.05.25');
+      expect(repository.fetchCalls, 1);
+    });
+
+    test('remote mode에서 빈 수정 정보는 null data로 표시한다', () async {
+      final repository = _StaticPlantRepository(const PlantEditInfo(name: ''));
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(
+        remotePlantFormEditInfoProvider('empty-plant').future,
+      );
+
+      expect(
+        container.read(plantFormEditInfoProvider('empty-plant')).requireValue,
+        isNull,
+      );
+    });
+  });
+}
+
+class _StaticPlantRepository extends PlantRepository {
+  _StaticPlantRepository(this.editInfo) : super(PlantRemoteDataSource(Dio()));
+
+  final PlantEditInfo editInfo;
+  int fetchCalls = 0;
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    fetchCalls++;
+    return editInfo;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #119

## 구현 범위
- Plant 수정 화면의 local 기본값/remote edit info 조회 책임을 `plantFormEditInfoProvider`로 이동했습니다.
- `PlantFormPage` 수정 모드에서 `useRemoteApiProvider` 직접 분기를 제거하고 Provider의 `AsyncValue`만 렌더링하도록 정리했습니다.
- retry는 edit Provider helper에서 기존 `remotePlantEditInfoProvider`와 edit Provider를 함께 invalidate하도록 유지했습니다.
- Plant 수정 폼 edit Provider 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 코드 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `plantFormEditInfoProvider`의 local 기본값 경계가 적절한지 확인 부탁드립니다.
- 이후 남은 page-level remote/local 분기 정리 순서를 확인 부탁드립니다.
