### PR TITLE
Refactor: 식물 Provider 책임 분리 #121

### DIFF
--- a/lib/features/plant/presentation/providers/plant_delete_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_delete_controller.dart
@@ -1,5 +1,7 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/features/plant/presentation/providers/plant_detail_remote_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_remote_provider.dart
@@ -1,0 +1,9 @@
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final remotePlantDetailProvider = FutureProvider.family<PlantDetail, String>(
+  (ref, plantId) =>
+      ref.watch(plantRepositoryProvider).fetchPlant(plantId: plantId),
+  retry: (retryCount, error) => null,
+);

--- a/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef PlantDetailViewRequest = ({String plantId, String? placeCode});

--- a/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart'
@@ -32,3 +32,11 @@ void invalidatePlantFormEditInfo(WidgetRef ref, String plantId) {
   ref.invalidate(remotePlantEditInfoProvider(plantId));
   ref.invalidate(remotePlantFormEditInfoProvider(plantId));
 }
+
+final remotePlantEditInfoProvider =
+    FutureProvider.family<PlantEditInfo, String>(
+      (ref, plantId) => ref
+          .watch(plantRepositoryProvider)
+          .fetchPlantEditInfo(plantId: plantId),
+      retry: (retryCount, error) => null,
+    );

--- a/lib/features/plant/presentation/providers/plant_list_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_list_provider.dart
@@ -1,6 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -22,20 +21,6 @@ final plantSummariesProvider = Provider<AsyncValue<List<PlantSummary>>>((ref) {
 
   return AsyncData(ref.watch(plantListProvider));
 });
-
-final remotePlantDetailProvider = FutureProvider.family<PlantDetail, String>(
-  (ref, plantId) =>
-      ref.watch(plantRepositoryProvider).fetchPlant(plantId: plantId),
-  retry: (retryCount, error) => null,
-);
-
-final remotePlantEditInfoProvider =
-    FutureProvider.family<PlantEditInfo, String>(
-      (ref, plantId) => ref
-          .watch(plantRepositoryProvider)
-          .fetchPlantEditInfo(plantId: plantId),
-      retry: (retryCount, error) => null,
-    );
 
 class PlantListNotifier extends Notifier<List<PlantSummary>> {
   int _nextId = 1;

--- a/test/features/plant/presentation/providers/plant_detail_remote_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_remote_provider_test.dart
@@ -1,0 +1,42 @@
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('remotePlantDetailProvider', () {
+    test('식물 상세 조회를 repository에 위임한다', () async {
+      final repository = _StaticPlantRepository(
+        const PlantDetail(id: 'plant-1', name: '몬스테라'),
+      );
+      final container = ProviderContainer(
+        overrides: [plantRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+
+      final detail = await container.read(
+        remotePlantDetailProvider('plant-1').future,
+      );
+
+      expect(detail.id, 'plant-1');
+      expect(detail.name, '몬스테라');
+      expect(repository.lastPlantId, 'plant-1');
+    });
+  });
+}
+
+class _StaticPlantRepository extends PlantRepository {
+  _StaticPlantRepository(this.detail) : super(PlantRemoteDataSource(Dio()));
+
+  final PlantDetail detail;
+  String? lastPlantId;
+
+  @override
+  Future<PlantDetail> fetchPlant({required String plantId}) async {
+    lastPlantId = plantId;
+    return detail;
+  }
+}

--- a/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
@@ -44,6 +44,23 @@ void main() {
       expect(repository.fetchCalls, 1);
     });
 
+    test('수정 정보 remote 조회를 repository에 위임한다', () async {
+      final repository = _StaticPlantRepository(
+        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026.05.25'),
+      );
+      final container = ProviderContainer(
+        overrides: [plantRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+
+      final info = await container.read(
+        remotePlantEditInfoProvider('remote-plant').future,
+      );
+
+      expect(info.name, '필로덴드론');
+      expect(repository.lastPlantId, 'remote-plant');
+    });
+
     test('remote mode에서 빈 수정 정보는 null data로 표시한다', () async {
       final repository = _StaticPlantRepository(const PlantEditInfo(name: ''));
       final container = ProviderContainer(
@@ -71,10 +88,12 @@ class _StaticPlantRepository extends PlantRepository {
 
   final PlantEditInfo editInfo;
   int fetchCalls = 0;
+  String? lastPlantId;
 
   @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
     fetchCalls++;
+    lastPlantId = plantId;
     return editInfo;
   }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #121

## 구현 범위
- `plant_list_provider.dart`에서 식물 상세/수정 정보 remote Provider를 분리했습니다.
- 식물 상세 조회 remote Provider를 `plant_detail_remote_provider.dart`로 이동했습니다.
- 식물 수정 정보 remote Provider를 `plant_form_edit_provider.dart` 경계로 이동했습니다.
- 삭제 Controller의 invalidate 대상 import를 새 Provider 위치에 맞춰 정리했습니다.
- 새 Provider 경계를 검증하는 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 Provider 파일 경계 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `plant_list_provider.dart`가 목록 책임만 남도록 분리된 범위가 적절한지 확인 부탁드립니다.
- 다음 작업에서 Place 목록 Provider도 같은 방식으로 분리할지 확인 부탁드립니다.
