### PR TITLE
Refactor: Place Provider 책임 분리 #123

### DIFF
--- a/lib/features/place/presentation/providers/place_detail_remote_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_remote_provider.dart
@@ -1,0 +1,8 @@
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeDetailProvider = FutureProvider.family<PlaceSummary, String>(
+  (ref, code) => ref.watch(placeRepositoryProvider).fetchPlace(code),
+  retry: (retryCount, error) => null,
+);

--- a/lib/features/place/presentation/providers/place_detail_view_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_view_provider.dart
@@ -1,7 +1,7 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef PlaceDetailViewRequest = ({String placeId, PlaceDetailRole? role});

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -1,6 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -1,7 +1,9 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/place/presentation/providers/place_form_edit_provider.dart
+++ b/lib/features/place/presentation/providers/place_form_edit_provider.dart
@@ -1,5 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const String placeFormDefaultEditName = '스윗 홈_ 거실';

--- a/lib/features/place/presentation/providers/place_list_provider.dart
+++ b/lib/features/place/presentation/providers/place_list_provider.dart
@@ -22,21 +22,6 @@ final placeSummariesProvider = Provider<AsyncValue<List<PlaceSummary>>>((ref) {
   return AsyncData(ref.watch(placeListProvider));
 });
 
-final plantRegistrationPlaceProvider = FutureProvider<List<PlaceSummary>>((
-  ref,
-) {
-  if (ref.watch(useRemoteApiProvider)) {
-    return ref.watch(placeRepositoryProvider).fetchUserPlaces();
-  }
-
-  return ref.watch(placeListProvider);
-});
-
-final placeDetailProvider = FutureProvider.family<PlaceSummary, String>(
-  (ref, code) => ref.watch(placeRepositoryProvider).fetchPlace(code),
-  retry: (retryCount, error) => null,
-);
-
 class PlaceListNotifier extends Notifier<List<PlaceSummary>> {
   int _nextId = 1;
 

--- a/lib/features/place/presentation/providers/plant_registration_place_provider.dart
+++ b/lib/features/place/presentation/providers/plant_registration_place_provider.dart
@@ -1,0 +1,16 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+export 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+
+final plantRegistrationPlaceProvider = FutureProvider<List<PlaceSummary>>((
+  ref,
+) {
+  if (ref.watch(useRemoteApiProvider)) {
+    return ref.watch(placeRepositoryProvider).fetchUserPlaces();
+  }
+
+  return ref.watch(placeListProvider);
+});

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -6,7 +6,7 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';

--- a/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
@@ -1,0 +1,43 @@
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('placeDetailProvider', () {
+    test('장소 상세 조회를 repository에 위임한다', () async {
+      final repository = _StaticPlaceRepository(
+        const PlaceSummary(id: 'place-1', name: '거실', address: '서울시 성북구'),
+      );
+      final container = ProviderContainer(
+        overrides: [placeRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+
+      final summary = await container.read(
+        placeDetailProvider('place-1').future,
+      );
+
+      expect(summary.id, 'place-1');
+      expect(summary.name, '거실');
+      expect(summary.address, '서울시 성북구');
+      expect(repository.lastCode, 'place-1');
+    });
+  });
+}
+
+class _StaticPlaceRepository extends PlaceRepository {
+  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+
+  final PlaceSummary summary;
+  String? lastCode;
+
+  @override
+  Future<PlaceSummary> fetchPlace(String code) async {
+    lastCode = code;
+    return summary;
+  }
+}

--- a/test/features/place/presentation/providers/plant_registration_place_provider_test.dart
+++ b/test/features/place/presentation/providers/plant_registration_place_provider_test.dart
@@ -1,0 +1,45 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('plantRegistrationPlaceProvider', () {
+    test('remote mode는 소속 장소 조회를 repository에 위임한다', () async {
+      final repository = _StaticPlaceRepository([
+        const PlaceSummary(id: 'place-1', name: '거실'),
+        const PlaceSummary(id: 'place-2', name: '작업실'),
+      ]);
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final places = await container.read(
+        plantRegistrationPlaceProvider.future,
+      );
+
+      expect([for (final place in places) place.name], ['거실', '작업실']);
+      expect(repository.fetchUserPlacesCalls, 1);
+    });
+  });
+}
+
+class _StaticPlaceRepository extends PlaceRepository {
+  _StaticPlaceRepository(this.places) : super(PlaceRemoteDataSource(Dio()));
+
+  final List<PlaceSummary> places;
+  int fetchUserPlacesCalls = 0;
+
+  @override
+  Future<List<PlaceSummary>> fetchUserPlaces() async {
+    fetchUserPlacesCalls++;
+    return places;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #123

## 구현 범위
- `place_list_provider.dart`에서 장소 상세/식물 등록용 장소 Provider를 분리했습니다.
- 장소 상세 조회 Provider를 `place_detail_remote_provider.dart`로 이동했습니다.
- 식물 등록용 장소 조회 Provider를 `plant_registration_place_provider.dart`로 이동했습니다.
- 장소 수정/나가기 Controller와 식물 등록 폼의 import를 새 Provider 위치에 맞춰 정리했습니다.
- 새 Provider 경계를 검증하는 단위 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

## 문서 반영 여부
- 기존 `docs/lib-refactoring-direction.md`, `docs/state-management-guide.md` 방향에 맞춘 Provider 파일 경계 정리라 별도 문서 갱신은 없습니다.

## 리뷰 포인트
- `place_list_provider.dart`가 목록 책임만 남도록 분리된 범위가 적절한지 확인 부탁드립니다.
- `plant_registration_place_provider.dart`의 위치와 export 범위가 식물 등록 폼 사용에 적절한지 확인 부탁드립니다.
