### PR TITLE
Refactor: 식물 폼 화면 분리 #131

### DIFF
--- a/lib/features/plant/presentation/fixtures/plant_registration_place_fixture.dart
+++ b/lib/features/plant/presentation/fixtures/plant_registration_place_fixture.dart
@@ -1,0 +1,25 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+
+const plantRegistrationPlaceFallbacks = [
+  PlantRegistrationPlace(
+    id: 'place-1',
+    name: '스윗 홈_거실',
+    imageAsset: AppImageAssets.placeEditLivingRoom,
+  ),
+  PlantRegistrationPlace(
+    id: 'place-2',
+    name: '낫 스윗 회사_가든',
+    imageAsset: AppImageAssets.placeDetailMonstera,
+  ),
+  PlantRegistrationPlace(
+    id: 'place-3',
+    name: '집_작업실',
+    imageAsset: AppImageAssets.placeEditLivingRoom,
+  ),
+  PlantRegistrationPlace(
+    id: 'place-4',
+    name: '본가_거실',
+    imageAsset: AppImageAssets.placeDetailMonstera,
+  ),
+];

--- a/lib/features/plant/presentation/models/plant_registration_place.dart
+++ b/lib/features/plant/presentation/models/plant_registration_place.dart
@@ -1,0 +1,11 @@
+class PlantRegistrationPlace {
+  const PlantRegistrationPlace({
+    required this.id,
+    required this.name,
+    required this.imageAsset,
+  });
+
+  final String id;
+  final String name;
+  final String imageAsset;
+}

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,21 +1,12 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_radius.dart';
-import 'package:commonplant_frontend/core/theme/app_sizes.dart';
-import 'package:commonplant_frontend/core/theme/app_spacing.dart';
-import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_form_scaffold.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
-import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
-import 'package:commonplant_frontend/shared/widgets/common_button.dart';
-import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
-import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
-import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
-import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -45,29 +36,6 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   String _initialEditPlantName = plantFormDefaultEditName;
   bool _hasAppliedEditInfo = false;
 
-  static const List<_PlantRegistrationPlace> _places = [
-    _PlantRegistrationPlace(
-      id: 'place-1',
-      name: '스윗 홈_거실',
-      imageAsset: AppImageAssets.placeEditLivingRoom,
-    ),
-    _PlantRegistrationPlace(
-      id: 'place-2',
-      name: '낫 스윗 회사_가든',
-      imageAsset: AppImageAssets.placeDetailMonstera,
-    ),
-    _PlantRegistrationPlace(
-      id: 'place-3',
-      name: '집_작업실',
-      imageAsset: AppImageAssets.placeEditLivingRoom,
-    ),
-    _PlantRegistrationPlace(
-      id: 'place-4',
-      name: '본가_거실',
-      imageAsset: AppImageAssets.placeDetailMonstera,
-    ),
-  ];
-
   @override
   void initState() {
     super.initState();
@@ -75,7 +43,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     _nameController = TextEditingController(
       text: widget.isEdit ? plantFormDefaultEditName : '',
     );
-    _selectedPlaceId = widget.isEdit ? null : _places.first.id;
+    _selectedPlaceId = widget.isEdit
+        ? null
+        : plantRegistrationPlaceFallbacks.first.id;
   }
 
   @override
@@ -87,7 +57,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   @override
   Widget build(BuildContext context) {
     if (widget.isEdit) {
-      return _buildEditMode();
+      return _buildEditRoute();
     }
 
     final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
@@ -95,10 +65,12 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       remotePlaces.value ?? const [],
     );
     final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
-    final places = registrationPlaces.isEmpty ? _places : registrationPlaces;
+    final places = registrationPlaces.isEmpty
+        ? plantRegistrationPlaceFallbacks
+        : registrationPlaces;
     final selectedPlaceId = _effectiveSelectedPlaceId(places);
 
-    return _PlantCreateScaffold(
+    return PlantCreateScaffold(
       places: places,
       selectedPlaceId: selectedPlaceId,
       wateringDate: '2023. 01. 30',
@@ -109,7 +81,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     );
   }
 
-  Widget _buildEditMode() {
+  Widget _buildEditRoute() {
     final plantId = widget.plantId!;
     final editInfo = ref.watch(plantFormEditInfoProvider(plantId));
 
@@ -151,7 +123,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
         trimmedName != _initialEditPlantName &&
         !isSubmitting;
 
-    return _PlantEditScaffold(
+    return PlantEditScaffold(
       nameController: _nameController,
       canSubmit: canSubmit,
       isSubmitting: isSubmitting,
@@ -183,10 +155,12 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     return plantName;
   }
 
-  _PlantRegistrationPlace? get _selectedPlace {
+  PlantRegistrationPlace? get _selectedPlace {
     final remotePlaces = ref.read(plantRegistrationPlaceProvider).value;
     final places = _registrationPlacesFromSummaries(remotePlaces ?? const []);
-    final effectivePlaces = places.isEmpty ? _places : places;
+    final effectivePlaces = places.isEmpty
+        ? plantRegistrationPlaceFallbacks
+        : places;
     final selectedPlaceId = _selectedPlaceId;
 
     if (selectedPlaceId == null) {
@@ -202,7 +176,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     return effectivePlaces.isEmpty ? null : effectivePlaces.first;
   }
 
-  String? _effectiveSelectedPlaceId(List<_PlantRegistrationPlace> places) {
+  String? _effectiveSelectedPlaceId(List<PlantRegistrationPlace> places) {
     final selectedPlaceId = _selectedPlaceId;
 
     if (selectedPlaceId != null) {
@@ -255,7 +229,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       return;
     }
 
-    _showSubmitErrorIfNeeded();
+    _showSubmitErrorSnackBar();
   }
 
   Future<void> _submitEdit() async {
@@ -289,10 +263,10 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
       return;
     }
 
-    _showSubmitErrorIfNeeded();
+    _showSubmitErrorSnackBar();
   }
 
-  void _showSubmitErrorIfNeeded() {
+  void _showSubmitErrorSnackBar() {
     final errorMessage = ref.read(plantFormControllerProvider).errorMessage;
 
     if (!mounted || errorMessage == null) {
@@ -304,391 +278,16 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
-  List<_PlantRegistrationPlace> _registrationPlacesFromSummaries(
+  List<PlantRegistrationPlace> _registrationPlacesFromSummaries(
     List<PlaceSummary> summaries,
   ) {
     return [
       for (final place in summaries)
-        _PlantRegistrationPlace(
+        PlantRegistrationPlace(
           id: place.id,
           name: place.name,
           imageAsset: AppImageAssets.placeEditLivingRoom,
         ),
     ];
   }
-}
-
-class _PlantEditScaffold extends StatelessWidget {
-  const _PlantEditScaffold({
-    required this.nameController,
-    required this.canSubmit,
-    required this.isSubmitting,
-    required this.onChanged,
-    required this.onSubmit,
-  });
-
-  final TextEditingController nameController;
-  final bool canSubmit;
-  final bool isSubmitting;
-  final ValueChanged<String> onChanged;
-  final VoidCallback onSubmit;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-          child: Column(
-            children: [
-              CommonNavigationBar(
-                title: '식물 수정',
-                titleStyle: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.textStrong,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.x20,
-                    AppSpacing.x24,
-                    AppSpacing.x20,
-                    AppSpacing.x24,
-                  ),
-                  child: Column(
-                    children: [
-                      const _PlantEditPhotoButton(),
-                      const SizedBox(height: AppSpacing.x32),
-                      CommonTextField(
-                        controller: nameController,
-                        maxLength: 10,
-                        forceFocusedDecoration: true,
-                        onChanged: onChanged,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.x20,
-                  0,
-                  AppSpacing.x20,
-                  AppSpacing.x16,
-                ),
-                child: CommonButton(
-                  label: '완료',
-                  isLoading: isSubmitting,
-                  onPressed: canSubmit ? onSubmit : null,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlantEditPhotoButton extends StatelessWidget {
-  const _PlantEditPhotoButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: AppSizes.plantEditPhotoCanvasSize,
-      height: AppSizes.plantEditPhotoCanvasSize,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          Positioned(
-            left: AppSpacing.x10,
-            top: AppSpacing.x10,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(AppRadius.medium),
-              child: Image.asset(
-                AppImageAssets.plantEditMonstera,
-                width: AppSizes.plantEditPhotoImageSize,
-                height: AppSizes.plantEditPhotoImageSize,
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
-          Positioned(
-            left: AppSizes.plantEditPhotoOverlayOffset,
-            top: AppSizes.plantEditPhotoOverlayOffset,
-            child: Semantics(
-              label: '식물 사진 수정',
-              button: true,
-              child: DecoratedBox(
-                decoration: const BoxDecoration(
-                  color: AppColors.iconInactive,
-                  shape: BoxShape.circle,
-                ),
-                child: SizedBox.square(
-                  dimension: AppSizes.plantEditPhotoCameraSize,
-                  child: Center(
-                    child: CommonSvgIcon(
-                      AppIconAssets.cameraAlt,
-                      width: AppSizes.iconLarge,
-                      height: AppSizes.iconLarge,
-                      color: AppColors.white,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PlantCreateScaffold extends StatelessWidget {
-  const _PlantCreateScaffold({
-    required this.places,
-    required this.selectedPlaceId,
-    required this.wateringDate,
-    required this.isSubmitting,
-    required this.onPlaceSelected,
-    required this.onCancel,
-    required this.onSubmit,
-  });
-
-  final List<_PlantRegistrationPlace> places;
-  final String? selectedPlaceId;
-  final String wateringDate;
-  final bool isSubmitting;
-  final ValueChanged<_PlantRegistrationPlace> onPlaceSelected;
-  final VoidCallback onCancel;
-  final VoidCallback onSubmit;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-          child: Column(
-            children: [
-              CommonNavigationBar(
-                title: '식물 등록 (2/2)',
-                titleStyle: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.textStrong,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.x20,
-                    AppSpacing.x24,
-                    AppSpacing.x20,
-                    AppSpacing.x24,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _PlantPlacePicker(
-                        places: places,
-                        selectedPlaceId: selectedPlaceId,
-                        onPlaceSelected: onPlaceSelected,
-                      ),
-                      const SizedBox(height: AppSpacing.x32),
-                      _PlantWateringDateField(date: wateringDate),
-                    ],
-                  ),
-                ),
-              ),
-              _PlantFormBottomActions(
-                isSubmitting: isSubmitting,
-                onCancel: onCancel,
-                onSubmit: onSubmit,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlantPlacePicker extends StatelessWidget {
-  const _PlantPlacePicker({
-    required this.places,
-    required this.selectedPlaceId,
-    required this.onPlaceSelected,
-  });
-
-  final List<_PlantRegistrationPlace> places;
-  final String? selectedPlaceId;
-  final ValueChanged<_PlantRegistrationPlace> onPlaceSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const CommonAddressOrPlaceField(label: '장소 선택'),
-        const SizedBox(height: AppSpacing.x4),
-        SizedBox(
-          height: AppSizes.placeCardHeight,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            itemCount: places.length,
-            separatorBuilder: (_, _) => const SizedBox(width: AppSpacing.x8),
-            itemBuilder: (context, index) {
-              final place = places[index];
-              final isSelected = place.id == selectedPlaceId;
-
-              return Semantics(
-                selected: isSelected,
-                child: CommonPlaceCard(
-                  title: place.name,
-                  imageProvider: AssetImage(place.imageAsset),
-                  onTap: () => onPlaceSelected(place),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlantWateringDateField extends StatelessWidget {
-  const _PlantWateringDateField({required this.date});
-
-  final String date;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        DecoratedBox(
-          decoration: const BoxDecoration(
-            border: Border(
-              bottom: BorderSide(color: AppColorPrimitives.grayGray2),
-            ),
-          ),
-          child: SizedBox(
-            width: double.infinity,
-            height: AppSizes.addressOrPlaceFieldHeight,
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '마지막으로 물 준 날짜',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTextStyles.size18Medium.copyWith(
-                      color: AppColors.textStrong,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.x12),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: AppColors.surfaceDisabled,
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: AppSpacing.x8,
-                    ),
-                    child: Text(
-                      date,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTextStyles.size18Medium.copyWith(
-                        color: AppColors.textStrong,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: AppSpacing.x4),
-        Text(
-          '선택하지 않을 시, 등록일을 기준으로 설정합니다',
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTextStyles.size12Medium.copyWith(
-            color: AppColors.brandStrong,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _PlantFormBottomActions extends StatelessWidget {
-  const _PlantFormBottomActions({
-    required this.isSubmitting,
-    required this.onCancel,
-    required this.onSubmit,
-  });
-
-  final bool isSubmitting;
-  final VoidCallback onCancel;
-  final VoidCallback onSubmit;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.x20,
-        0,
-        AppSpacing.x20,
-        AppSpacing.x16,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: CommonButton.dark(
-              label: '취소',
-              size: CommonButtonSize.medium,
-              backgroundColor: AppColors.textBody,
-              foregroundColor: AppColors.white,
-              onPressed: onCancel,
-            ),
-          ),
-          const SizedBox(width: AppSpacing.x8),
-          Expanded(
-            child: CommonButton(
-              label: '등록',
-              size: CommonButtonSize.medium,
-              backgroundColor: AppColors.brandAccent,
-              foregroundColor: AppColors.white,
-              isLoading: isSubmitting,
-              onPressed: onSubmit,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PlantRegistrationPlace {
-  const _PlantRegistrationPlace({
-    required this.id,
-    required this.name,
-    required this.imageAsset,
-  });
-
-  final String id;
-  final String name;
-  final String imageAsset;
 }

--- a/lib/features/plant/presentation/widgets/plant_edit_photo_button.dart
+++ b/lib/features/plant/presentation/widgets/plant_edit_photo_button.dart
@@ -1,0 +1,63 @@
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:flutter/material.dart';
+
+class PlantEditPhotoButton extends StatelessWidget {
+  const PlantEditPhotoButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppSizes.plantEditPhotoCanvasSize,
+      height: AppSizes.plantEditPhotoCanvasSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            left: AppSpacing.x10,
+            top: AppSpacing.x10,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AppRadius.medium),
+              child: Image.asset(
+                AppImageAssets.plantEditMonstera,
+                width: AppSizes.plantEditPhotoImageSize,
+                height: AppSizes.plantEditPhotoImageSize,
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          Positioned(
+            left: AppSizes.plantEditPhotoOverlayOffset,
+            top: AppSizes.plantEditPhotoOverlayOffset,
+            child: Semantics(
+              label: '식물 사진 수정',
+              button: true,
+              child: DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: AppColors.iconInactive,
+                  shape: BoxShape.circle,
+                ),
+                child: SizedBox.square(
+                  dimension: AppSizes.plantEditPhotoCameraSize,
+                  child: Center(
+                    child: CommonSvgIcon(
+                      AppIconAssets.cameraAlt,
+                      width: AppSizes.iconLarge,
+                      height: AppSizes.iconLarge,
+                      color: AppColors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/plant/presentation/widgets/plant_form_bottom_actions.dart
+++ b/lib/features/plant/presentation/widgets/plant_form_bottom_actions.dart
@@ -1,0 +1,53 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:flutter/material.dart';
+
+class PlantFormBottomActions extends StatelessWidget {
+  const PlantFormBottomActions({
+    required this.isSubmitting,
+    required this.onCancel,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final bool isSubmitting;
+  final VoidCallback onCancel;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        0,
+        AppSpacing.x20,
+        AppSpacing.x16,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: CommonButton.dark(
+              label: '취소',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.textBody,
+              foregroundColor: AppColors.white,
+              onPressed: onCancel,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.x8),
+          Expanded(
+            child: CommonButton(
+              label: '등록',
+              size: CommonButtonSize.medium,
+              backgroundColor: AppColors.brandAccent,
+              foregroundColor: AppColors.white,
+              isLoading: isSubmitting,
+              onPressed: onSubmit,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
+++ b/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
@@ -1,0 +1,160 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_edit_photo_button.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_form_bottom_actions.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_place_picker.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_watering_date_field.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
+import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
+import 'package:flutter/material.dart';
+
+class PlantEditScaffold extends StatelessWidget {
+  const PlantEditScaffold({
+    required this.nameController,
+    required this.canSubmit,
+    required this.isSubmitting,
+    required this.onChanged,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final TextEditingController nameController;
+  final bool canSubmit;
+  final bool isSubmitting;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '식물 수정',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                  ),
+                  child: Column(
+                    children: [
+                      const PlantEditPhotoButton(),
+                      const SizedBox(height: AppSpacing.x32),
+                      CommonTextField(
+                        controller: nameController,
+                        maxLength: 10,
+                        forceFocusedDecoration: true,
+                        onChanged: onChanged,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.x20,
+                  0,
+                  AppSpacing.x20,
+                  AppSpacing.x16,
+                ),
+                child: CommonButton(
+                  label: '완료',
+                  isLoading: isSubmitting,
+                  onPressed: canSubmit ? onSubmit : null,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class PlantCreateScaffold extends StatelessWidget {
+  const PlantCreateScaffold({
+    required this.places,
+    required this.selectedPlaceId,
+    required this.wateringDate,
+    required this.isSubmitting,
+    required this.onPlaceSelected,
+    required this.onCancel,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final List<PlantRegistrationPlace> places;
+  final String? selectedPlaceId;
+  final String wateringDate;
+  final bool isSubmitting;
+  final ValueChanged<PlantRegistrationPlace> onPlaceSelected;
+  final VoidCallback onCancel;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '식물 등록 (2/2)',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      PlantPlacePicker(
+                        places: places,
+                        selectedPlaceId: selectedPlaceId,
+                        onPlaceSelected: onPlaceSelected,
+                      ),
+                      const SizedBox(height: AppSpacing.x32),
+                      PlantWateringDateField(date: wateringDate),
+                    ],
+                  ),
+                ),
+              ),
+              PlantFormBottomActions(
+                isSubmitting: isSubmitting,
+                onCancel: onCancel,
+                onSubmit: onSubmit,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plant/presentation/widgets/plant_place_picker.dart
+++ b/lib/features/plant/presentation/widgets/plant_place_picker.dart
@@ -1,0 +1,51 @@
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
+import 'package:commonplant_frontend/shared/widgets/common_place_card.dart';
+import 'package:flutter/material.dart';
+
+class PlantPlacePicker extends StatelessWidget {
+  const PlantPlacePicker({
+    required this.places,
+    required this.selectedPlaceId,
+    required this.onPlaceSelected,
+    super.key,
+  });
+
+  final List<PlantRegistrationPlace> places;
+  final String? selectedPlaceId;
+  final ValueChanged<PlantRegistrationPlace> onPlaceSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const CommonAddressOrPlaceField(label: '장소 선택'),
+        const SizedBox(height: AppSpacing.x4),
+        SizedBox(
+          height: AppSizes.placeCardHeight,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: places.length,
+            separatorBuilder: (_, _) => const SizedBox(width: AppSpacing.x8),
+            itemBuilder: (context, index) {
+              final place = places[index];
+              final isSelected = place.id == selectedPlaceId;
+
+              return Semantics(
+                selected: isSelected,
+                child: CommonPlaceCard(
+                  title: place.name,
+                  imageProvider: AssetImage(place.imageAsset),
+                  onTap: () => onPlaceSelected(place),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/plant/presentation/widgets/plant_watering_date_field.dart
+++ b/lib/features/plant/presentation/widgets/plant_watering_date_field.dart
@@ -1,0 +1,75 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class PlantWateringDateField extends StatelessWidget {
+  const PlantWateringDateField({required this.date, super.key});
+
+  final String date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        DecoratedBox(
+          decoration: const BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: AppColorPrimitives.grayGray2),
+            ),
+          ),
+          child: SizedBox(
+            width: double.infinity,
+            height: AppSizes.addressOrPlaceFieldHeight,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '마지막으로 물 준 날짜',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.size18Medium.copyWith(
+                      color: AppColors.textStrong,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.x12),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AppColors.surfaceDisabled,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 6,
+                      vertical: AppSpacing.x8,
+                    ),
+                    child: Text(
+                      date,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyles.size18Medium.copyWith(
+                        color: AppColors.textStrong,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x4),
+        Text(
+          '선택하지 않을 시, 등록일을 기준으로 설정합니다',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size12Medium.copyWith(
+            color: AppColors.brandStrong,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #131

## 구현 범위
- 동작 변경 없이 파일 책임을 분리했습니다.
- `PlantFormPage`에서 생성/수정 scaffold와 입력 보조 widget 구현을 feature 전용 widget 파일로 이동했습니다.
- 등록 장소 표시 모델과 local fallback fixture를 분리해 page의 읽기 범위를 줄였습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/features/plant/presentation/pages/plant_form_page_test.dart`
- `fvm flutter test test/features/plant/presentation/providers/plant_form_controller_test.dart`
- `fvm flutter test`

## 리뷰 포인트
- create/edit scaffold, place picker, watering date field, bottom actions 파일 경계가 자연스러운지
- page가 submit/navigation/snackbar 연결 이상의 UI 세부사항을 계속 들고 있지 않은지
- public widget/model API가 불필요하게 넓어지지 않았는지

## 문서 반영 여부
- 문서 변경 없음: 기존 리팩터링 계획 Task 2 실행 범위입니다.

## Breaking change 여부
- 없음
