### PR TITLE
Refactor: 공용 위젯 스타일 분리 #139

### DIFF
--- a/lib/shared/widgets/common_button.dart
+++ b/lib/shared/widgets/common_button.dart
@@ -101,37 +101,6 @@ class CommonButton extends StatelessWidget {
 
   VoidCallback? get _effectiveOnPressed => isLoading ? null : onPressed;
 
-  double get _height {
-    switch (size) {
-      case CommonButtonSize.large:
-        return AppSizes.buttonHeight;
-      case CommonButtonSize.medium:
-        return AppSizes.mediumButtonHeight;
-      case CommonButtonSize.small:
-        return AppSizes.smallButtonHeight;
-    }
-  }
-
-  double get _radius {
-    switch (size) {
-      case CommonButtonSize.large:
-      case CommonButtonSize.small:
-        return AppRadius.small;
-      case CommonButtonSize.medium:
-        return AppRadius.xSmall;
-    }
-  }
-
-  double? get _defaultWidth {
-    switch (size) {
-      case CommonButtonSize.small:
-        return AppSizes.smallButtonWidth;
-      case CommonButtonSize.medium:
-      case CommonButtonSize.large:
-        return null;
-    }
-  }
-
   Widget _buildChild(TextStyle textStyle) {
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -169,64 +138,12 @@ class CommonButton extends StatelessWidget {
     );
   }
 
-  TextStyle _buttonTextStyle(AppThemeTokens tokens) {
-    final baseStyle = switch (size) {
-      CommonButtonSize.large => AppTextStyles.size16Medium,
-      CommonButtonSize.medium => AppTextStyles.size14Medium,
-      CommonButtonSize.small => AppTextStyles.size14Medium,
-    };
-
-    final effectiveForegroundColor =
-        foregroundColor ??
-        switch (variant) {
-          CommonButtonVariant.primary || CommonButtonVariant.dark =>
-            _effectiveOnPressed == null ? tokens.textDisabled : tokens.onBrand,
-          CommonButtonVariant.secondary || CommonButtonVariant.text =>
-            _effectiveOnPressed == null
-                ? tokens.textDisabled
-                : tokens.brandAccent,
-          CommonButtonVariant.neutral =>
-            _effectiveOnPressed == null
-                ? tokens.textDisabled
-                : tokens.textStrong,
-        };
-
-    return baseStyle.copyWith(color: effectiveForegroundColor);
-  }
-
-  Color _backgroundColor(AppThemeTokens tokens) {
-    if (_effectiveOnPressed == null) {
-      return backgroundColor ?? tokens.surfaceDisabled;
-    }
-
-    return backgroundColor ??
-        switch (variant) {
-          CommonButtonVariant.primary => tokens.brandStrong,
-          CommonButtonVariant.secondary => tokens.surfaceBase,
-          CommonButtonVariant.dark => tokens.textStrong,
-          CommonButtonVariant.neutral => tokens.surfaceDisabled,
-          CommonButtonVariant.text => Colors.transparent,
-        };
-  }
-
-  Color _borderColor(AppThemeTokens tokens) {
-    return borderColor ?? Colors.transparent;
-  }
-
-  BorderSide get _borderSide {
-    if (borderColor == null) {
-      return BorderSide.none;
-    }
-
-    return const BorderSide(width: 1);
-  }
-
-  Widget _wrapWidth(Widget child) {
+  Widget _wrapWidth(_CommonButtonMetrics metrics, Widget child) {
     return SizedBox(
       width: fullWidth || (size == CommonButtonSize.large && width == null)
           ? double.infinity
-          : width ?? _defaultWidth,
-      height: _height,
+          : width ?? metrics.defaultWidth,
+      height: metrics.height,
       child: child,
     );
   }
@@ -235,102 +152,225 @@ class CommonButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens =
         Theme.of(context).extension<AppThemeTokens>() ?? AppThemeTokens.light;
-
-    final buttonShape = RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(_radius),
-      side: _borderSide.copyWith(color: _borderColor(tokens)),
+    final metrics = _CommonButtonMetrics.resolve(size, variant);
+    final buttonStyle = _CommonButtonStyle.resolve(
+      tokens: tokens,
+      variant: variant,
+      size: size,
+      enabled: _effectiveOnPressed != null,
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      borderColor: borderColor,
     );
-    final textStyle = _buttonTextStyle(tokens);
 
     switch (variant) {
       case CommonButtonVariant.primary:
         return _wrapWidth(
+          metrics,
           FilledButton(
             onPressed: _effectiveOnPressed,
-            style: FilledButton.styleFrom(
-              backgroundColor: _backgroundColor(tokens),
-              foregroundColor: textStyle.color,
-              minimumSize: Size(0, _height),
-              maximumSize: Size(double.infinity, _height),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              shape: buttonShape,
-              textStyle: textStyle,
-            ),
-            child: _buildChild(textStyle),
+            style: buttonStyle.filledButtonStyle(metrics),
+            child: _buildChild(buttonStyle.textStyle),
           ),
         );
       case CommonButtonVariant.secondary:
         return _wrapWidth(
+          metrics,
           OutlinedButton(
             onPressed: _effectiveOnPressed,
-            style: OutlinedButton.styleFrom(
-              backgroundColor: _backgroundColor(tokens),
-              foregroundColor: textStyle.color,
-              minimumSize: Size(0, _height),
-              maximumSize: Size(double.infinity, _height),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              side: _borderSide.copyWith(color: _borderColor(tokens)),
-              shape: buttonShape,
-              textStyle: textStyle,
-            ),
-            child: _buildChild(textStyle),
+            style: buttonStyle.outlinedButtonStyle(metrics),
+            child: _buildChild(buttonStyle.textStyle),
           ),
         );
       case CommonButtonVariant.dark:
         return _wrapWidth(
+          metrics,
           FilledButton(
             onPressed: _effectiveOnPressed,
-            style: FilledButton.styleFrom(
-              backgroundColor: _backgroundColor(tokens),
-              foregroundColor: textStyle.color,
-              minimumSize: Size(0, _height),
-              maximumSize: Size(double.infinity, _height),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              elevation: 0,
-              shape: buttonShape,
-              textStyle: textStyle,
-            ),
-            child: _buildChild(textStyle),
+            style: buttonStyle.filledButtonStyle(metrics, elevation: 0),
+            child: _buildChild(buttonStyle.textStyle),
           ),
         );
       case CommonButtonVariant.neutral:
         return _wrapWidth(
+          metrics,
           FilledButton(
             onPressed: _effectiveOnPressed,
-            style: FilledButton.styleFrom(
-              backgroundColor: _backgroundColor(tokens),
-              foregroundColor: textStyle.color,
-              minimumSize: Size(0, _height),
-              maximumSize: Size(double.infinity, _height),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x20),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              elevation: 0,
-              shape: buttonShape,
-              textStyle: textStyle,
-            ),
-            child: _buildChild(textStyle),
+            style: buttonStyle.filledButtonStyle(metrics, elevation: 0),
+            child: _buildChild(buttonStyle.textStyle),
           ),
         );
       case CommonButtonVariant.text:
         return _wrapWidth(
+          metrics,
           TextButton(
             onPressed: _effectiveOnPressed,
-            style: TextButton.styleFrom(
-              backgroundColor: _backgroundColor(tokens),
-              foregroundColor: textStyle.color,
-              minimumSize: Size(0, _height),
-              maximumSize: Size(double.infinity, _height),
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x12),
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              shape: buttonShape,
-              textStyle: textStyle,
-            ),
-            child: _buildChild(textStyle),
+            style: buttonStyle.textButtonStyle(metrics),
+            child: _buildChild(buttonStyle.textStyle),
           ),
         );
     }
+  }
+}
+
+class _CommonButtonMetrics {
+  const _CommonButtonMetrics({
+    required this.height,
+    required this.radius,
+    required this.padding,
+    required this.baseTextStyle,
+    this.defaultWidth,
+  });
+
+  final double height;
+  final double radius;
+  final EdgeInsetsGeometry padding;
+  final TextStyle baseTextStyle;
+  final double? defaultWidth;
+
+  static _CommonButtonMetrics resolve(
+    CommonButtonSize size,
+    CommonButtonVariant variant,
+  ) {
+    return _CommonButtonMetrics(
+      height: switch (size) {
+        CommonButtonSize.large => AppSizes.buttonHeight,
+        CommonButtonSize.medium => AppSizes.mediumButtonHeight,
+        CommonButtonSize.small => AppSizes.smallButtonHeight,
+      },
+      radius: switch (size) {
+        CommonButtonSize.large || CommonButtonSize.small => AppRadius.small,
+        CommonButtonSize.medium => AppRadius.xSmall,
+      },
+      padding: EdgeInsets.symmetric(
+        horizontal: variant == CommonButtonVariant.text
+            ? AppSpacing.x12
+            : AppSpacing.x20,
+      ),
+      baseTextStyle: switch (size) {
+        CommonButtonSize.large => AppTextStyles.size16Medium,
+        CommonButtonSize.medium => AppTextStyles.size14Medium,
+        CommonButtonSize.small => AppTextStyles.size14Medium,
+      },
+      defaultWidth: switch (size) {
+        CommonButtonSize.small => AppSizes.smallButtonWidth,
+        CommonButtonSize.medium || CommonButtonSize.large => null,
+      },
+    );
+  }
+}
+
+class _CommonButtonStyle {
+  const _CommonButtonStyle({
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.borderSide,
+    required this.textStyle,
+  });
+
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final BorderSide borderSide;
+  final TextStyle textStyle;
+
+  static _CommonButtonStyle resolve({
+    required AppThemeTokens tokens,
+    required CommonButtonVariant variant,
+    required CommonButtonSize size,
+    required bool enabled,
+    required Color? backgroundColor,
+    required Color? foregroundColor,
+    required Color? borderColor,
+  }) {
+    final metrics = _CommonButtonMetrics.resolve(size, variant);
+    final resolvedForegroundColor =
+        foregroundColor ??
+        switch (variant) {
+          CommonButtonVariant.primary || CommonButtonVariant.dark =>
+            enabled ? tokens.onBrand : tokens.textDisabled,
+          CommonButtonVariant.secondary || CommonButtonVariant.text =>
+            enabled ? tokens.brandAccent : tokens.textDisabled,
+          CommonButtonVariant.neutral =>
+            enabled ? tokens.textStrong : tokens.textDisabled,
+        };
+
+    return _CommonButtonStyle(
+      backgroundColor:
+          backgroundColor ?? _resolveBackgroundColor(tokens, variant, enabled),
+      foregroundColor: resolvedForegroundColor,
+      borderSide: borderColor == null
+          ? BorderSide.none
+          : BorderSide(width: 1, color: borderColor),
+      textStyle: metrics.baseTextStyle.copyWith(color: resolvedForegroundColor),
+    );
+  }
+
+  static Color _resolveBackgroundColor(
+    AppThemeTokens tokens,
+    CommonButtonVariant variant,
+    bool enabled,
+  ) {
+    if (!enabled) {
+      return tokens.surfaceDisabled;
+    }
+
+    return switch (variant) {
+      CommonButtonVariant.primary => tokens.brandStrong,
+      CommonButtonVariant.secondary => tokens.surfaceBase,
+      CommonButtonVariant.dark => tokens.textStrong,
+      CommonButtonVariant.neutral => tokens.surfaceDisabled,
+      CommonButtonVariant.text => Colors.transparent,
+    };
+  }
+
+  RoundedRectangleBorder shape(_CommonButtonMetrics metrics) {
+    return RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(metrics.radius),
+      side: borderSide,
+    );
+  }
+
+  ButtonStyle filledButtonStyle(
+    _CommonButtonMetrics metrics, {
+    double? elevation,
+  }) {
+    return FilledButton.styleFrom(
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      minimumSize: Size(0, metrics.height),
+      maximumSize: Size(double.infinity, metrics.height),
+      padding: metrics.padding,
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      elevation: elevation,
+      shape: shape(metrics),
+      textStyle: textStyle,
+    );
+  }
+
+  ButtonStyle outlinedButtonStyle(_CommonButtonMetrics metrics) {
+    return OutlinedButton.styleFrom(
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      minimumSize: Size(0, metrics.height),
+      maximumSize: Size(double.infinity, metrics.height),
+      padding: metrics.padding,
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      side: borderSide,
+      shape: shape(metrics),
+      textStyle: textStyle,
+    );
+  }
+
+  ButtonStyle textButtonStyle(_CommonButtonMetrics metrics) {
+    return TextButton.styleFrom(
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      minimumSize: Size(0, metrics.height),
+      maximumSize: Size(double.infinity, metrics.height),
+      padding: metrics.padding,
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      shape: shape(metrics),
+      textStyle: textStyle,
+    );
   }
 }

--- a/lib/shared/widgets/common_text_field.dart
+++ b/lib/shared/widgets/common_text_field.dart
@@ -118,37 +118,6 @@ class _CommonTextFieldState extends State<CommonTextField> {
     }
   }
 
-  bool _isEnabled(CommonTextFieldState state) {
-    return widget.enabled && state != CommonTextFieldState.disabled;
-  }
-
-  Color _lineColor(CommonTextFieldState state) {
-    switch (state) {
-      case CommonTextFieldState.error:
-        return AppColors.danger;
-      case CommonTextFieldState.success:
-        return AppColors.brandStrong;
-      case CommonTextFieldState.disabled:
-        return AppColors.textDisabled;
-      case CommonTextFieldState.normal:
-        return _usesFocusedDecoration
-            ? AppColors.textHeadline
-            : AppColors.textDisabled;
-    }
-  }
-
-  Color _helperColor(CommonTextFieldState state) {
-    switch (state) {
-      case CommonTextFieldState.error:
-        return AppColors.danger;
-      case CommonTextFieldState.success:
-        return AppColors.brandStrong;
-      case CommonTextFieldState.disabled:
-      case CommonTextFieldState.normal:
-        return AppColors.textBody;
-    }
-  }
-
   void _clearText() {
     _controller.clear();
     widget.onChanged?.call('');
@@ -193,35 +162,32 @@ class _CommonTextFieldState extends State<CommonTextField> {
   @override
   Widget build(BuildContext context) {
     final validation = _validation;
+    final fieldStyle = _CommonTextFieldStyle.resolve(
+      state: validation.state,
+      enabled: widget.enabled,
+      usesFocusedDecoration: _usesFocusedDecoration,
+    );
     final trailing = _buildTrailing();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         DecoratedBox(
-          decoration: BoxDecoration(
-            border: Border(
-              bottom: BorderSide(color: _lineColor(validation.state)),
-            ),
-          ),
+          decoration: fieldStyle.decoration,
           child: Row(
             children: [
               Expanded(
                 child: TextField(
                   controller: _controller,
                   focusNode: _focusNode,
-                  enabled: _isEnabled(validation.state),
+                  enabled: fieldStyle.enabled,
                   onChanged: widget.onChanged,
                   maxLength: widget.maxLength,
                   keyboardType: widget.keyboardType,
-                  style: AppTextStyles.size18Medium.copyWith(
-                    color: AppColors.textHeadline,
-                  ),
+                  style: fieldStyle.inputTextStyle,
                   decoration: InputDecoration(
                     hintText: widget.hintText,
-                    hintStyle: AppTextStyles.size18Medium.copyWith(
-                      color: AppColors.textDisabled,
-                    ),
+                    hintStyle: fieldStyle.hintTextStyle,
                     counterText: '',
                     border: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
@@ -240,15 +206,65 @@ class _CommonTextFieldState extends State<CommonTextField> {
         ),
         if (validation.helperText != null) ...[
           const SizedBox(height: AppSpacing.x8),
-          Text(
-            validation.helperText!,
-            style: AppTextStyles.size12Medium.copyWith(
-              color: _helperColor(validation.state),
-            ),
-          ),
+          Text(validation.helperText!, style: fieldStyle.helperTextStyle),
         ],
       ],
     );
+  }
+}
+
+class _CommonTextFieldStyle {
+  const _CommonTextFieldStyle({
+    required this.enabled,
+    required this.lineColor,
+    required this.helperColor,
+  });
+
+  final bool enabled;
+  final Color lineColor;
+  final Color helperColor;
+
+  static _CommonTextFieldStyle resolve({
+    required CommonTextFieldState state,
+    required bool enabled,
+    required bool usesFocusedDecoration,
+  }) {
+    return _CommonTextFieldStyle(
+      enabled: enabled && state != CommonTextFieldState.disabled,
+      lineColor: switch (state) {
+        CommonTextFieldState.error => AppColors.danger,
+        CommonTextFieldState.success => AppColors.brandStrong,
+        CommonTextFieldState.disabled => AppColors.textDisabled,
+        CommonTextFieldState.normal =>
+          usesFocusedDecoration
+              ? AppColors.textHeadline
+              : AppColors.textDisabled,
+      },
+      helperColor: switch (state) {
+        CommonTextFieldState.error => AppColors.danger,
+        CommonTextFieldState.success => AppColors.brandStrong,
+        CommonTextFieldState.disabled ||
+        CommonTextFieldState.normal => AppColors.textBody,
+      },
+    );
+  }
+
+  BoxDecoration get decoration {
+    return BoxDecoration(
+      border: Border(bottom: BorderSide(color: lineColor)),
+    );
+  }
+
+  TextStyle get inputTextStyle {
+    return AppTextStyles.size18Medium.copyWith(color: AppColors.textHeadline);
+  }
+
+  TextStyle get hintTextStyle {
+    return AppTextStyles.size18Medium.copyWith(color: AppColors.textDisabled);
+  }
+
+  TextStyle get helperTextStyle {
+    return AppTextStyles.size12Medium.copyWith(color: helperColor);
   }
 }
 

--- a/test/shared/widgets/common_text_field_test.dart
+++ b/test/shared/widgets/common_text_field_test.dart
@@ -1,0 +1,49 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CommonTextField는 disabled 상태에서 입력을 막고 helper를 표시한다', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CommonTextField(
+            state: CommonTextFieldState.disabled,
+            helperText: '입력할 수 없습니다',
+          ),
+        ),
+      ),
+    );
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+
+    expect(textField.enabled, isFalse);
+    expect(find.text('입력할 수 없습니다'), findsOneWidget);
+  });
+
+  testWidgets('CommonTextField는 error 상태의 line과 helper 색상을 적용한다', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CommonTextField(
+            state: CommonTextFieldState.error,
+            helperText: '다시 입력해 주세요',
+          ),
+        ),
+      ),
+    );
+
+    final decoratedBox = tester.widget<DecoratedBox>(find.byType(DecoratedBox));
+    final decoration = decoratedBox.decoration as BoxDecoration;
+    final border = decoration.border! as Border;
+    final helper = tester.widget<Text>(find.text('다시 입력해 주세요'));
+
+    expect(border.bottom.color, AppColors.danger);
+    expect(helper.style?.color, AppColors.danger);
+  });
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #139

## 구현 범위
- `CommonButton`의 size/variant별 metrics와 style resolution을 private helper로 분리했습니다.
- `CommonTextField`의 상태별 enabled, line, helper style 계산을 private helper로 분리했습니다.
- `CommonTextField` disabled/error 상태 동작을 shared widget 테스트로 보강했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/shared/widgets/common_button_test.dart`
- `fvm flutter test test/shared/widgets/common_scaffold_test.dart`
- `fvm flutter test test/shared/widgets/common_text_field_test.dart`
- `fvm flutter test`

## 리뷰 포인트
- 기존 public constructor, enum, 호출부 동작이 유지되는지
- style resolution helper가 build 흐름에서 충분히 분리되었는지
- 공용 위젯의 variant 추가 시 수정 위치가 예측 가능한지
