### PR TITLE
Refactor: API 응답 경계 명시 #141

### DIFF
--- a/lib/features/friend/data/datasources/friend_remote_data_source.dart
+++ b/lib/features/friend/data/datasources/friend_remote_data_source.dart
@@ -7,7 +7,7 @@ class FriendRemoteDataSource {
 
   final Dio _dio;
 
-  Future<Object?> getRequests() async {
+  Future<Object?> getRequestsRaw() async {
     try {
       final response = await _dio.get<Object?>('/friends/requests');
 

--- a/lib/features/friend/data/repositories/friend_repository.dart
+++ b/lib/features/friend/data/repositories/friend_repository.dart
@@ -17,7 +17,7 @@ class FriendRepository {
   final FriendRemoteDataSource _remoteDataSource;
 
   Future<Object?> fetchRequestsRaw() {
-    return _remoteDataSource.getRequests();
+    return _remoteDataSource.getRequestsRaw();
   }
 
   Future<void> sendRequest(SendFriendRequest request) {

--- a/lib/features/image/data/datasources/image_remote_data_source.dart
+++ b/lib/features/image/data/datasources/image_remote_data_source.dart
@@ -6,7 +6,7 @@ class ImageRemoteDataSource {
 
   final Dio _dio;
 
-  Future<Object?> getDownloadUrl(String key) async {
+  Future<Object?> getDownloadUrlRaw(String key) async {
     try {
       final response = await _dio.get<Object?>(
         '/s3/images',

--- a/lib/features/image/data/repositories/image_repository.dart
+++ b/lib/features/image/data/repositories/image_repository.dart
@@ -16,8 +16,8 @@ class ImageRepository {
 
   final ImageRemoteDataSource _remoteDataSource;
 
-  Future<Object?> getDownloadUrl(String key) {
-    return _remoteDataSource.getDownloadUrl(key);
+  Future<Object?> getDownloadUrlRaw(String key) {
+    return _remoteDataSource.getDownloadUrlRaw(key);
   }
 
   Future<void> uploadImages(List<MultipartFile> images) {

--- a/test/features/friend/data/datasources/friend_remote_data_source_test.dart
+++ b/test/features/friend/data/datasources/friend_remote_data_source_test.dart
@@ -11,7 +11,7 @@ void main() {
       final adapter = _CapturingAdapter();
       final dataSource = FriendRemoteDataSource(_dioWith(adapter));
 
-      await dataSource.getRequests();
+      await dataSource.getRequestsRaw();
 
       expect(adapter.latestOptions.method, 'GET');
       expect(adapter.latestOptions.path, '/friends/requests');

--- a/test/features/friend/data/repositories/friend_repository_test.dart
+++ b/test/features/friend/data/repositories/friend_repository_test.dart
@@ -1,0 +1,79 @@
+import 'package:commonplant_frontend/features/friend/data/datasources/friend_remote_data_source.dart';
+import 'package:commonplant_frontend/features/friend/data/dtos/friend_requests.dart';
+import 'package:commonplant_frontend/features/friend/data/repositories/friend_repository.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FriendRepository', () {
+    test('친구 요청 목록 raw 응답은 datasource 값 그대로 반환한다', () async {
+      final dataSource = _RecordingFriendRemoteDataSource(
+        requestsRawResponse: const {
+          'success': true,
+          'result': [
+            {'friendId': 1},
+          ],
+        },
+      );
+      final repository = FriendRepository(dataSource);
+
+      final response = await repository.fetchRequestsRaw();
+
+      expect(response, same(dataSource.requestsRawResponse));
+    });
+
+    test('친구 요청 전송은 datasource에 request를 위임한다', () async {
+      final dataSource = _RecordingFriendRemoteDataSource();
+      final repository = FriendRepository(dataSource);
+      final request = SendFriendRequest(
+        receiverNames: const ['커먼2'],
+        placeCode: 'aBcDeF',
+      );
+
+      await expectLater(repository.sendRequest(request), completes);
+
+      expect(dataSource.latestSendRequest, same(request));
+    });
+
+    test('친구 요청 수락과 거절은 datasource에 request를 위임한다', () async {
+      final dataSource = _RecordingFriendRemoteDataSource();
+      final repository = FriendRepository(dataSource);
+      const request = FriendDecisionRequest(friendId: 1);
+
+      await expectLater(repository.acceptRequest(request), completes);
+      await expectLater(repository.declineRequest(request), completes);
+
+      expect(dataSource.latestAcceptRequest, same(request));
+      expect(dataSource.latestDeclineRequest, same(request));
+    });
+  });
+}
+
+class _RecordingFriendRemoteDataSource extends FriendRemoteDataSource {
+  _RecordingFriendRemoteDataSource({this.requestsRawResponse}) : super(Dio());
+
+  final Object? requestsRawResponse;
+  SendFriendRequest? latestSendRequest;
+  FriendDecisionRequest? latestAcceptRequest;
+  FriendDecisionRequest? latestDeclineRequest;
+
+  @override
+  Future<Object?> getRequestsRaw() async {
+    return requestsRawResponse;
+  }
+
+  @override
+  Future<void> sendRequest(SendFriendRequest request) async {
+    latestSendRequest = request;
+  }
+
+  @override
+  Future<void> acceptRequest(FriendDecisionRequest request) async {
+    latestAcceptRequest = request;
+  }
+
+  @override
+  Future<void> declineRequest(FriendDecisionRequest request) async {
+    latestDeclineRequest = request;
+  }
+}

--- a/test/features/image/data/datasources/image_remote_data_source_test.dart
+++ b/test/features/image/data/datasources/image_remote_data_source_test.dart
@@ -10,7 +10,7 @@ void main() {
       final adapter = _CapturingAdapter();
       final dataSource = ImageRemoteDataSource(_dioWith(adapter));
 
-      await dataSource.getDownloadUrl('images/user-nano-id/monstera.png');
+      await dataSource.getDownloadUrlRaw('images/user-nano-id/monstera.png');
 
       expect(adapter.latestOptions.method, 'GET');
       expect(adapter.latestOptions.path, '/s3/images');

--- a/test/features/image/data/repositories/image_repository_test.dart
+++ b/test/features/image/data/repositories/image_repository_test.dart
@@ -5,6 +5,22 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ImageRepository', () {
+    test('이미지 다운로드 URL raw 응답은 datasource 값 그대로 반환한다', () async {
+      final dataSource = _RecordingImageRemoteDataSource(
+        downloadUrlRawResponse: const {
+          'result': {'url': 'https://cdn.example.com/plant.png'},
+        },
+      );
+      final repository = ImageRepository(dataSource);
+
+      final response = await repository.getDownloadUrlRaw(
+        'images/user-nano-id/plant.png',
+      );
+
+      expect(dataSource.latestDownloadKey, 'images/user-nano-id/plant.png');
+      expect(response, same(dataSource.downloadUrlRawResponse));
+    });
+
     test('이미지 업로드는 반환값 없이 datasource에 위임한다', () async {
       final dataSource = _RecordingImageRemoteDataSource();
       final repository = ImageRepository(dataSource);
@@ -41,11 +57,19 @@ void main() {
 }
 
 class _RecordingImageRemoteDataSource extends ImageRemoteDataSource {
-  _RecordingImageRemoteDataSource() : super(Dio());
+  _RecordingImageRemoteDataSource({this.downloadUrlRawResponse}) : super(Dio());
 
+  final Object? downloadUrlRawResponse;
+  String? latestDownloadKey;
   List<MultipartFile>? latestUploadedImages;
   String? latestUpdatedKey;
   MultipartFile? latestUpdatedImage;
+
+  @override
+  Future<Object?> getDownloadUrlRaw(String key) async {
+    latestDownloadKey = key;
+    return downloadUrlRawResponse;
+  }
 
   @override
   Future<void> uploadImages(List<MultipartFile> images) async {


### PR DESCRIPTION
## 관련 이슈
- Closes #141

## 구현 범위
- Swagger schema가 아직 없는 Friend 요청 목록 GET 응답 메서드에 `Raw` 경계를 명시했습니다.
- Image download URL GET 응답도 schema 확정 전까지 `Raw` 메서드로만 노출되도록 이름을 정리했습니다.
- Friend/Image repository 테스트를 보강해 raw 응답은 datasource 값을 그대로 전달하고, write API는 `Future<void>` 경계를 유지하는 흐름을 확인했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/features/friend/data`
- `fvm flutter test test/features/image/data`
- `fvm flutter test`
- `git diff --check`

## 리뷰 포인트
- schema 미확정 응답에 DTO/value object를 추가하지 않은 범위가 적절한지
- `Raw` suffix가 추후 schema 확정 시 mapper 도입 지점을 드러내는지
- repository 테스트가 datasource 위임과 raw 경계를 충분히 고정하는지
