### PR TITLE
Refactor: 장소 폼 위젯 분리 #147

### DIFF
--- a/lib/features/place/presentation/pages/place_form_page.dart
+++ b/lib/features/place/presentation/pages/place_form_page.dart
@@ -1,16 +1,8 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_sizes.dart';
-import 'package:commonplant_frontend/core/theme/app_spacing.dart';
-import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
-import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
-import 'package:commonplant_frontend/shared/widgets/common_button.dart';
-import 'package:commonplant_frontend/shared/widgets/common_place_image_add_button.dart';
-import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
-import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_form_scaffold.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_form_status_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -56,14 +48,14 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
 
       return editInfo.when(
         loading: () {
-          return const _PlaceFormStatusScaffold(
+          return const PlaceFormStatusScaffold(
             title: '장소 정보를 불러오고 있어요',
             message: '장소 수정 정보를 준비하고 있어요',
             isLoading: true,
           );
         },
         error: (error, stackTrace) {
-          return _PlaceFormStatusScaffold(
+          return PlaceFormStatusScaffold(
             title: '장소 정보를 불러오지 못했어요',
             message: '잠시 후 다시 시도해 주세요',
             actionLabel: '다시 시도',
@@ -72,7 +64,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
         },
         data: (info) {
           if (info == null) {
-            return const _PlaceFormStatusScaffold(
+            return const PlaceFormStatusScaffold(
               title: '장소 정보를 찾을 수 없어요',
               message: '다시 장소 목록에서 선택해 주세요',
             );
@@ -99,7 +91,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     final canSubmit = currentName.isNotEmpty && hasChanges && !isSubmitting;
 
     if (!widget.isEdit) {
-      return _PlaceCreateScaffold(
+      return PlaceCreateScaffold(
         nameController: _nameController,
         address: _address,
         canSubmit: canSubmit,
@@ -112,7 +104,7 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
       );
     }
 
-    return _PlaceEditScaffold(
+    return PlaceEditScaffold(
       nameController: _nameController,
       address: _address,
       canSubmit: canSubmit,
@@ -182,285 +174,5 @@ class _PlaceFormPageState extends ConsumerState<PlaceFormPage> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
-  }
-}
-
-class _PlaceFormStatusScaffold extends StatelessWidget {
-  const _PlaceFormStatusScaffold({
-    required this.title,
-    required this.message,
-    this.actionLabel,
-    this.onAction,
-    this.isLoading = false,
-  });
-
-  final String title;
-  final String message;
-  final String? actionLabel;
-  final VoidCallback? onAction;
-  final bool isLoading;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: Column(
-          children: [
-            CommonNavigationBar(
-              title: '장소 수정',
-              titleStyle: AppTextStyles.size18Medium.copyWith(
-                color: AppColors.textStrong,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            Expanded(
-              child: Center(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.x20,
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (isLoading)
-                        SizedBox.square(
-                          dimension: AppSizes.iconLarge,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 3,
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              AppColors.brandStrong,
-                            ),
-                          ),
-                        ),
-                      const SizedBox(height: AppSpacing.x16),
-                      Text(
-                        title,
-                        textAlign: TextAlign.center,
-                        style: AppTextStyles.size18Medium.copyWith(
-                          color: AppColors.textStrong,
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.x8),
-                      Text(
-                        message,
-                        textAlign: TextAlign.center,
-                        style: AppTextStyles.size14Medium.copyWith(
-                          color: AppColors.textBody,
-                        ),
-                      ),
-                      if (actionLabel != null && onAction != null) ...[
-                        const SizedBox(height: AppSpacing.x24),
-                        SizedBox(
-                          width: AppSizes.smallButtonWidth,
-                          child: CommonButton.secondary(
-                            label: actionLabel!,
-                            size: CommonButtonSize.medium,
-                            onPressed: onAction,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PlaceEditScaffold extends StatelessWidget {
-  const _PlaceEditScaffold({
-    required this.nameController,
-    required this.address,
-    required this.canSubmit,
-    required this.isSubmitting,
-    required this.onNameChanged,
-    required this.onImageTap,
-    required this.onAddressTap,
-    required this.onAddressClear,
-    required this.onComplete,
-  });
-
-  final TextEditingController nameController;
-  final String? address;
-  final bool canSubmit;
-  final bool isSubmitting;
-  final ValueChanged<String> onNameChanged;
-  final VoidCallback onImageTap;
-  final VoidCallback onAddressTap;
-  final VoidCallback onAddressClear;
-  final VoidCallback onComplete;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-          child: Column(
-            children: [
-              CommonNavigationBar(
-                title: '장소 수정',
-                titleStyle: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.textStrong,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              Expanded(
-                child: Stack(
-                  children: [
-                    SingleChildScrollView(
-                      padding: const EdgeInsets.fromLTRB(
-                        AppSpacing.x20,
-                        AppSpacing.x24,
-                        AppSpacing.x20,
-                        AppSizes.buttonHeight + AppSpacing.x40,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Center(
-                            child: CommonPlaceImageAddButton(
-                              imageAsset: AppImageAssets.placeEditLivingRoom,
-                              imageSemanticsLabel: '장소 대표 이미지',
-                              onTap: onImageTap,
-                            ),
-                          ),
-                          const SizedBox(height: AppSpacing.x32),
-                          CommonTextField(
-                            controller: nameController,
-                            hintText: '장소 이름을 입력해 주세요',
-                            maxLength: 10,
-                            forceFocusedDecoration: true,
-                            onChanged: onNameChanged,
-                          ),
-                          const SizedBox(height: AppSpacing.x32),
-                          CommonAddressOrPlaceField(
-                            label: '주소',
-                            value: address,
-                            onTap: onAddressTap,
-                            onClear: onAddressClear,
-                          ),
-                        ],
-                      ),
-                    ),
-                    Positioned(
-                      left: AppSpacing.x20,
-                      right: AppSpacing.x20,
-                      bottom: AppSpacing.x16,
-                      child: CommonButton(
-                        label: '완료',
-                        isLoading: isSubmitting,
-                        onPressed: canSubmit ? onComplete : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlaceCreateScaffold extends StatelessWidget {
-  const _PlaceCreateScaffold({
-    required this.nameController,
-    required this.address,
-    required this.canSubmit,
-    required this.isSubmitting,
-    required this.onNameChanged,
-    required this.onImageTap,
-    required this.onAddressTap,
-    required this.onAddressClear,
-    required this.onNext,
-  });
-
-  final TextEditingController nameController;
-  final String? address;
-  final bool canSubmit;
-  final bool isSubmitting;
-  final ValueChanged<String> onNameChanged;
-  final VoidCallback onImageTap;
-  final VoidCallback onAddressTap;
-  final VoidCallback onAddressClear;
-  final VoidCallback onNext;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-          child: Column(
-            children: [
-              CommonNavigationBar(
-                title: '장소 등록',
-                titleStyle: AppTextStyles.size18Medium.copyWith(
-                  color: AppColors.textStrong,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              Expanded(
-                child: Stack(
-                  children: [
-                    SingleChildScrollView(
-                      padding: const EdgeInsets.fromLTRB(
-                        AppSpacing.x20,
-                        AppSpacing.x24,
-                        AppSpacing.x20,
-                        AppSizes.buttonHeight + AppSpacing.x40,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Center(
-                            child: CommonPlaceImageAddButton(onTap: onImageTap),
-                          ),
-                          const SizedBox(height: AppSpacing.x32),
-                          CommonTextField(
-                            controller: nameController,
-                            hintText: '장소의 이름을 입력해 주세요',
-                            maxLength: 10,
-                            onChanged: onNameChanged,
-                          ),
-                          const SizedBox(height: AppSpacing.x32),
-                          CommonAddressOrPlaceField(
-                            label: '주소',
-                            value: address,
-                            onTap: onAddressTap,
-                            onClear: onAddressClear,
-                          ),
-                        ],
-                      ),
-                    ),
-                    Positioned(
-                      left: AppSpacing.x20,
-                      right: AppSpacing.x20,
-                      bottom: AppSpacing.x16,
-                      child: CommonButton(
-                        label: '다음',
-                        isLoading: isSubmitting,
-                        onPressed: canSubmit ? onNext : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/features/place/presentation/widgets/place_form_scaffold.dart
+++ b/lib/features/place/presentation/widgets/place_form_scaffold.dart
@@ -1,0 +1,206 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/shared/widgets/common_address_or_place_field.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_place_image_add_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
+import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
+import 'package:flutter/material.dart';
+
+class PlaceCreateScaffold extends StatelessWidget {
+  const PlaceCreateScaffold({
+    super.key,
+    required this.nameController,
+    required this.address,
+    required this.canSubmit,
+    required this.isSubmitting,
+    required this.onNameChanged,
+    required this.onImageTap,
+    required this.onAddressTap,
+    required this.onAddressClear,
+    required this.onNext,
+  });
+
+  final TextEditingController nameController;
+  final String? address;
+  final bool canSubmit;
+  final bool isSubmitting;
+  final ValueChanged<String> onNameChanged;
+  final VoidCallback onImageTap;
+  final VoidCallback onAddressTap;
+  final VoidCallback onAddressClear;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '장소 등록',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.x20,
+                        AppSpacing.x24,
+                        AppSpacing.x20,
+                        AppSizes.buttonHeight + AppSpacing.x40,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Center(
+                            child: CommonPlaceImageAddButton(onTap: onImageTap),
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonTextField(
+                            controller: nameController,
+                            hintText: '장소의 이름을 입력해 주세요',
+                            maxLength: 10,
+                            onChanged: onNameChanged,
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonAddressOrPlaceField(
+                            label: '주소',
+                            value: address,
+                            onTap: onAddressTap,
+                            onClear: onAddressClear,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Positioned(
+                      left: AppSpacing.x20,
+                      right: AppSpacing.x20,
+                      bottom: AppSpacing.x16,
+                      child: CommonButton(
+                        label: '다음',
+                        isLoading: isSubmitting,
+                        onPressed: canSubmit ? onNext : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class PlaceEditScaffold extends StatelessWidget {
+  const PlaceEditScaffold({
+    super.key,
+    required this.nameController,
+    required this.address,
+    required this.canSubmit,
+    required this.isSubmitting,
+    required this.onNameChanged,
+    required this.onImageTap,
+    required this.onAddressTap,
+    required this.onAddressClear,
+    required this.onComplete,
+  });
+
+  final TextEditingController nameController;
+  final String? address;
+  final bool canSubmit;
+  final bool isSubmitting;
+  final ValueChanged<String> onNameChanged;
+  final VoidCallback onImageTap;
+  final VoidCallback onAddressTap;
+  final VoidCallback onAddressClear;
+  final VoidCallback onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+          child: Column(
+            children: [
+              CommonNavigationBar(
+                title: '장소 수정',
+                titleStyle: AppTextStyles.size18Medium.copyWith(
+                  color: AppColors.textStrong,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.x20,
+                        AppSpacing.x24,
+                        AppSpacing.x20,
+                        AppSizes.buttonHeight + AppSpacing.x40,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Center(
+                            child: CommonPlaceImageAddButton(
+                              imageAsset: AppImageAssets.placeEditLivingRoom,
+                              imageSemanticsLabel: '장소 대표 이미지',
+                              onTap: onImageTap,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonTextField(
+                            controller: nameController,
+                            hintText: '장소 이름을 입력해 주세요',
+                            maxLength: 10,
+                            forceFocusedDecoration: true,
+                            onChanged: onNameChanged,
+                          ),
+                          const SizedBox(height: AppSpacing.x32),
+                          CommonAddressOrPlaceField(
+                            label: '주소',
+                            value: address,
+                            onTap: onAddressTap,
+                            onClear: onAddressClear,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Positioned(
+                      left: AppSpacing.x20,
+                      right: AppSpacing.x20,
+                      bottom: AppSpacing.x16,
+                      child: CommonButton(
+                        label: '완료',
+                        isLoading: isSubmitting,
+                        onPressed: canSubmit ? onComplete : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/place/presentation/widgets/place_form_status_scaffold.dart
+++ b/lib/features/place/presentation/widgets/place_form_status_scaffold.dart
@@ -1,0 +1,95 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/shared/widgets/common_button.dart';
+import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
+import 'package:flutter/material.dart';
+
+class PlaceFormStatusScaffold extends StatelessWidget {
+  const PlaceFormStatusScaffold({
+    super.key,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+    this.isLoading = false,
+  });
+
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            CommonNavigationBar(
+              title: '장소 수정',
+              titleStyle: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textStrong,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.x20,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (isLoading)
+                        SizedBox.square(
+                          dimension: AppSizes.iconLarge,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 3,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              AppColors.brandStrong,
+                            ),
+                          ),
+                        ),
+                      const SizedBox(height: AppSpacing.x16),
+                      Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.size18Medium.copyWith(
+                          color: AppColors.textStrong,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.x8),
+                      Text(
+                        message,
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.size14Medium.copyWith(
+                          color: AppColors.textBody,
+                        ),
+                      ),
+                      if (actionLabel != null && onAction != null) ...[
+                        const SizedBox(height: AppSpacing.x24),
+                        SizedBox(
+                          width: AppSizes.smallButtonWidth,
+                          child: CommonButton.secondary(
+                            label: actionLabel!,
+                            size: CommonButtonSize.medium,
+                            onPressed: onAction,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #147

## 구현 범위
- `PlaceFormStatusScaffold`를 `features/place/presentation/widgets`로 분리했습니다.
- `PlaceCreateScaffold`, `PlaceEditScaffold`를 `features/place/presentation/widgets`로 분리했습니다.
- `PlaceFormPage`는 edit info 적용, provider watch/read, submit 결과 처리 중심으로 축소했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/features/place/presentation/pages/place_form_page_test.dart test/features/place/presentation/providers/place_form_controller_test.dart`
- `fvm flutter test`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트
- 새 widget 파일의 public API가 page 책임 축소 목적에 맞는지
- 장소 등록/수정 화면의 기존 동작과 텍스트가 유지되는지
