### PR TITLE
Refactor: 라우트 파라미터 정리 #149

### DIFF
--- a/lib/app/router/app_routes.dart
+++ b/lib/app/router/app_routes.dart
@@ -180,12 +180,12 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
       parameterName: 'placeId',
       builder: (placeId) => PlaceDetailPage(
         placeId: placeId,
-        role: placeDetailRoleFromQuery(state.uri.queryParameters['role']),
+        role: placeDetailRoleFromQuery(_queryParameter(state, 'role')),
       ),
     ),
     AppRouteNames.plantSearch => const PlantSearchPage(),
     AppRouteNames.plantCreateDetails => PlantFormPage(
-      initialPlantName: state.uri.queryParameters['name'],
+      initialPlantName: _queryParameter(state, 'name'),
     ),
     AppRouteNames.plantEdit => _buildWithRequiredPathParameter(
       route: route,
@@ -193,7 +193,7 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
       parameterName: 'plantId',
       builder: (plantId) => PlantFormPage(
         plantId: plantId,
-        placeId: state.uri.queryParameters['placeId'],
+        placeId: _queryParameter(state, 'placeId'),
       ),
     ),
     AppRouteNames.memoWrite => _buildWithRequiredPathParameter(
@@ -214,7 +214,7 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
       parameterName: 'plantId',
       builder: (plantId) => PlantDetailPage(
         plantId: plantId,
-        placeId: state.uri.queryParameters['placeId'],
+        placeId: _queryParameter(state, 'placeId'),
       ),
     ),
     _ => RoutePlaceholderPage(
@@ -222,6 +222,10 @@ Widget _buildRoutePage(AppRouteSpec route, GoRouterState state) {
       pathParameters: state.pathParameters,
     ),
   };
+}
+
+String? _queryParameter(GoRouterState state, String parameterName) {
+  return optionalQueryParameter(state.uri.queryParameters, parameterName);
 }
 
 Widget _buildWithRequiredPathParameter({
@@ -243,7 +247,7 @@ Widget _buildWithRequiredPathParameter({
 }
 
 TermsNextDestination _termsNextDestination(GoRouterState state) {
-  return switch (state.uri.queryParameters['next']) {
+  return switch (_queryParameter(state, 'next')) {
     'home' => TermsNextDestination.home,
     _ => TermsNextDestination.profile,
   };

--- a/lib/app/router/route_parameters.dart
+++ b/lib/app/router/route_parameters.dart
@@ -2,11 +2,22 @@ String? requiredPathParameter(
   Map<String, String> pathParameters,
   String parameterName,
 ) {
-  final value = pathParameters[parameterName]?.trim();
+  return _normalizedParameter(pathParameters[parameterName]);
+}
 
-  if (value == null || value.isEmpty) {
+String? optionalQueryParameter(
+  Map<String, String> queryParameters,
+  String parameterName,
+) {
+  return _normalizedParameter(queryParameters[parameterName]);
+}
+
+String? _normalizedParameter(String? value) {
+  final normalized = value?.trim();
+
+  if (normalized == null || normalized.isEmpty) {
     return null;
   }
 
-  return value;
+  return normalized;
 }

--- a/test/app/router/app_router_test.dart
+++ b/test/app/router/app_router_test.dart
@@ -26,6 +26,16 @@ void main() {
     expect(requiredPathParameter(const {'placeId': '   '}, 'placeId'), isNull);
   });
 
+  test('선택 query parameter는 값이 있을 때 trim한 문자열을 반환한다', () {
+    expect(optionalQueryParameter(const {}, 'placeId'), isNull);
+    expect(optionalQueryParameter(const {'placeId': ''}, 'placeId'), isNull);
+    expect(optionalQueryParameter(const {'placeId': '   '}, 'placeId'), isNull);
+    expect(
+      optionalQueryParameter(const {'placeId': ' place-1 '}, 'placeId'),
+      'place-1',
+    );
+  });
+
   testWidgets('route parameter 오류 화면이 누락된 parameter와 route 정보를 표시한다', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈
- Closes #149

## 구현 범위
- `optionalQueryParameter` helper를 추가해 optional query parameter의 trim/null 규칙을 정리했습니다.
- `role`, `placeId`, `name`, `next` query 접근을 helper 호출로 교체했습니다.
- router test에 optional query parameter 정규화 테스트를 추가했습니다.

## 테스트
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/app/router/app_router_test.dart`
- `fvm flutter test`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트
- optional query parameter를 `null`로 정규화하는 규칙이 라우팅 흐름에 적절한지
- route builder에서 query parameter 접근이 충분히 helper로 모였는지
