### PR TITLE
Refactor: 초대 화면 위젯 분리 #155

### DIFF
--- a/lib/features/place/presentation/fixtures/place_invitation_fixture.dart
+++ b/lib/features/place/presentation/fixtures/place_invitation_fixture.dart
@@ -1,0 +1,28 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:flutter/material.dart';
+
+const List<PlaceInvitation> placeInvitationFixture = <PlaceInvitation>[
+  PlaceInvitation(
+    id: 'invite-1',
+    inviterName: '커먼맘',
+    placeName: '스윗홈_욕실',
+    address: '서울시 노원구 광운로 20',
+    avatarAsset: AppImageAssets.placeInvitationAvatarCommonMom,
+  ),
+  PlaceInvitation(
+    id: 'invite-2',
+    inviterName: '커먼맘',
+    placeName: '스윗홈_베란다',
+    address: '서울시 노원구 광운로 20',
+    avatarAsset: AppImageAssets.placeInvitationAvatarCommonMom,
+  ),
+  PlaceInvitation(
+    id: 'invite-3',
+    inviterName: '도라에몽',
+    placeName: '낫 스윗 회사_중앙',
+    address: '서울시 강남구 커먼로 55',
+    avatarAsset: AppImageAssets.placeInvitationAvatarDoraemon,
+    avatarAlignment: Alignment.topCenter,
+  ),
+];

--- a/lib/features/place/presentation/models/place_invitation.dart
+++ b/lib/features/place/presentation/models/place_invitation.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+enum PlaceInvitationResult { accepted, deleted }
+
+class PlaceInvitation {
+  const PlaceInvitation({
+    required this.id,
+    required this.inviterName,
+    required this.placeName,
+    required this.address,
+    required this.avatarAsset,
+    this.avatarAlignment = Alignment.center,
+  });
+
+  final String id;
+  final String inviterName;
+  final String placeName;
+  final String address;
+  final String avatarAsset;
+  final Alignment avatarAlignment;
+}

--- a/lib/features/place/presentation/pages/place_invitations_page.dart
+++ b/lib/features/place/presentation/pages/place_invitations_page.dart
@@ -1,17 +1,12 @@
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_radius.dart';
-import 'package:commonplant_frontend/core/theme/app_sizes.dart';
-import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_invitation_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_invitation_list_item.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:flutter/material.dart';
 
-const double _invitationContentGap = 14;
-const double _invitationButtonGap = 8;
 const double _invitationItemGap = 24;
-
-enum _InvitationResult { accepted, deleted }
 
 class PlaceInvitationsPage extends StatefulWidget {
   const PlaceInvitationsPage({super.key});
@@ -21,34 +16,10 @@ class PlaceInvitationsPage extends StatefulWidget {
 }
 
 class _PlaceInvitationsPageState extends State<PlaceInvitationsPage> {
-  final Map<String, _InvitationResult> _results = <String, _InvitationResult>{};
+  final Map<String, PlaceInvitationResult> _results =
+      <String, PlaceInvitationResult>{};
 
-  static const List<_PlaceInvitation> _invitations = [
-    _PlaceInvitation(
-      id: 'invite-1',
-      inviterName: '커먼맘',
-      placeName: '스윗홈_욕실',
-      address: '서울시 노원구 광운로 20',
-      avatarAsset: AppImageAssets.placeInvitationAvatarCommonMom,
-    ),
-    _PlaceInvitation(
-      id: 'invite-2',
-      inviterName: '커먼맘',
-      placeName: '스윗홈_베란다',
-      address: '서울시 노원구 광운로 20',
-      avatarAsset: AppImageAssets.placeInvitationAvatarCommonMom,
-    ),
-    _PlaceInvitation(
-      id: 'invite-3',
-      inviterName: '도라에몽',
-      placeName: '낫 스윗 회사_중앙',
-      address: '서울시 강남구 커먼로 55',
-      avatarAsset: AppImageAssets.placeInvitationAvatarDoraemon,
-      avatarAlignment: Alignment.topCenter,
-    ),
-  ];
-
-  void _setResult(String id, _InvitationResult result) {
+  void _setResult(String id, PlaceInvitationResult result) {
     setState(() => _results[id] = result);
   }
 
@@ -63,279 +34,20 @@ class _PlaceInvitationsPageState extends State<PlaceInvitationsPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (final invitation in _invitations) ...[
-            _InvitationListItem(
+          for (final invitation in placeInvitationFixture) ...[
+            PlaceInvitationListItem(
               invitation: invitation,
               result: _results[invitation.id],
               onAccept: () =>
-                  _setResult(invitation.id, _InvitationResult.accepted),
+                  _setResult(invitation.id, PlaceInvitationResult.accepted),
               onDelete: () =>
-                  _setResult(invitation.id, _InvitationResult.deleted),
+                  _setResult(invitation.id, PlaceInvitationResult.deleted),
             ),
-            if (invitation.id != _invitations.last.id)
+            if (invitation.id != placeInvitationFixture.last.id)
               const SizedBox(height: _invitationItemGap),
           ],
         ],
       ),
     );
   }
-}
-
-class _InvitationListItem extends StatelessWidget {
-  const _InvitationListItem({
-    required this.invitation,
-    required this.result,
-    required this.onAccept,
-    required this.onDelete,
-  });
-
-  final _PlaceInvitation invitation;
-  final _InvitationResult? result;
-  final VoidCallback onAccept;
-  final VoidCallback onDelete;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _InvitationAvatar(invitation: invitation),
-        const SizedBox(width: _invitationContentGap),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _InvitationDescription(invitation: invitation, result: result),
-              const SizedBox(height: _invitationButtonGap),
-              if (result == null)
-                _InvitationActions(
-                  invitation: invitation,
-                  onAccept: onAccept,
-                  onDelete: onDelete,
-                )
-              else
-                const SizedBox(
-                  height: AppSizes.placeInvitationActionButtonHeight,
-                ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _InvitationAvatar extends StatelessWidget {
-  const _InvitationAvatar({required this.invitation});
-
-  final _PlaceInvitation invitation;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: '${invitation.inviterName} 프로필 사진',
-      image: true,
-      child: ClipOval(
-        child: Image.asset(
-          invitation.avatarAsset,
-          width: AppSizes.placeInvitationAvatarSize,
-          height: AppSizes.placeInvitationAvatarSize,
-          fit: BoxFit.cover,
-          alignment: invitation.avatarAlignment,
-        ),
-      ),
-    );
-  }
-}
-
-class _InvitationDescription extends StatelessWidget {
-  const _InvitationDescription({
-    required this.invitation,
-    required this.result,
-  });
-
-  final _PlaceInvitation invitation;
-  final _InvitationResult? result;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          invitation.inviterName,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTextStyles.size16Bold.copyWith(
-            color: AppColors.textHeadline,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.x4),
-        if (result == null)
-          _InvitationPlaceLine(invitation: invitation)
-        else
-          _InvitationResultText(invitation: invitation, result: result!),
-      ],
-    );
-  }
-}
-
-class _InvitationPlaceLine extends StatelessWidget {
-  const _InvitationPlaceLine({required this.invitation});
-
-  final _PlaceInvitation invitation;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Text(
-          invitation.placeName,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTextStyles.size14Bold.copyWith(color: AppColors.textStrong),
-        ),
-        const SizedBox(width: AppSpacing.x4),
-        Flexible(
-          child: Text(
-            invitation.address,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: AppTextStyles.size12Medium.copyWith(
-              color: AppColors.textBody,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _InvitationResultText extends StatelessWidget {
-  const _InvitationResultText({required this.invitation, required this.result});
-
-  final _PlaceInvitation invitation;
-  final _InvitationResult result;
-
-  @override
-  Widget build(BuildContext context) {
-    final message = switch (result) {
-      _InvitationResult.accepted => '${invitation.placeName}에서 함께 해보세요:)',
-      _InvitationResult.deleted => '요청 삭제됨',
-    };
-
-    final color = switch (result) {
-      _InvitationResult.accepted => AppColors.brandStrong,
-      _InvitationResult.deleted => AppColors.textStrong,
-    };
-
-    return Text(
-      message,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: AppTextStyles.size14Medium.copyWith(color: color),
-    );
-  }
-}
-
-class _InvitationActions extends StatelessWidget {
-  const _InvitationActions({
-    required this.invitation,
-    required this.onAccept,
-    required this.onDelete,
-  });
-
-  final _PlaceInvitation invitation;
-  final VoidCallback onAccept;
-  final VoidCallback onDelete;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        _InvitationActionButton(
-          label: '확인',
-          semanticsLabel: '${invitation.placeName} 확인',
-          backgroundColor: AppColors.brandPrimary,
-          foregroundColor: AppColors.white,
-          onPressed: onAccept,
-        ),
-        const SizedBox(width: _invitationButtonGap),
-        _InvitationActionButton(
-          label: '삭제',
-          semanticsLabel: '${invitation.placeName} 삭제',
-          backgroundColor: AppColors.borderDefault,
-          foregroundColor: AppColors.textStrong,
-          onPressed: onDelete,
-        ),
-      ],
-    );
-  }
-}
-
-class _InvitationActionButton extends StatelessWidget {
-  const _InvitationActionButton({
-    required this.label,
-    required this.semanticsLabel,
-    required this.backgroundColor,
-    required this.foregroundColor,
-    required this.onPressed,
-  });
-
-  final String label;
-  final String semanticsLabel;
-  final Color backgroundColor;
-  final Color foregroundColor;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: semanticsLabel,
-      button: true,
-      container: true,
-      child: ExcludeSemantics(
-        child: Material(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(AppRadius.small),
-          child: InkWell(
-            onTap: onPressed,
-            borderRadius: BorderRadius.circular(AppRadius.small),
-            child: SizedBox(
-              width: AppSizes.placeInvitationActionButtonWidth,
-              height: AppSizes.placeInvitationActionButtonHeight,
-              child: Center(
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyles.size14Bold.copyWith(
-                    color: foregroundColor,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _PlaceInvitation {
-  const _PlaceInvitation({
-    required this.id,
-    required this.inviterName,
-    required this.placeName,
-    required this.address,
-    required this.avatarAsset,
-    this.avatarAlignment = Alignment.center,
-  });
-
-  final String id;
-  final String inviterName;
-  final String placeName;
-  final String address;
-  final String avatarAsset;
-  final Alignment avatarAlignment;
 }

--- a/lib/features/place/presentation/widgets/place_invitation_list_item.dart
+++ b/lib/features/place/presentation/widgets/place_invitation_list_item.dart
@@ -1,0 +1,252 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:flutter/material.dart';
+
+const double _invitationContentGap = 14;
+const double _invitationButtonGap = 8;
+
+class PlaceInvitationListItem extends StatelessWidget {
+  const PlaceInvitationListItem({
+    super.key,
+    required this.invitation,
+    required this.result,
+    required this.onAccept,
+    required this.onDelete,
+  });
+
+  final PlaceInvitation invitation;
+  final PlaceInvitationResult? result;
+  final VoidCallback onAccept;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _InvitationAvatar(invitation: invitation),
+        const SizedBox(width: _invitationContentGap),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _InvitationDescription(invitation: invitation, result: result),
+              const SizedBox(height: _invitationButtonGap),
+              if (result == null)
+                _InvitationActions(
+                  invitation: invitation,
+                  onAccept: onAccept,
+                  onDelete: onDelete,
+                )
+              else
+                const SizedBox(
+                  height: AppSizes.placeInvitationActionButtonHeight,
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InvitationAvatar extends StatelessWidget {
+  const _InvitationAvatar({required this.invitation});
+
+  final PlaceInvitation invitation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '${invitation.inviterName} 프로필 사진',
+      image: true,
+      child: ClipOval(
+        child: Image.asset(
+          invitation.avatarAsset,
+          width: AppSizes.placeInvitationAvatarSize,
+          height: AppSizes.placeInvitationAvatarSize,
+          fit: BoxFit.cover,
+          alignment: invitation.avatarAlignment,
+        ),
+      ),
+    );
+  }
+}
+
+class _InvitationDescription extends StatelessWidget {
+  const _InvitationDescription({
+    required this.invitation,
+    required this.result,
+  });
+
+  final PlaceInvitation invitation;
+  final PlaceInvitationResult? result;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          invitation.inviterName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size16Bold.copyWith(
+            color: AppColors.textHeadline,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x4),
+        if (result == null)
+          _InvitationPlaceLine(invitation: invitation)
+        else
+          _InvitationResultText(invitation: invitation, result: result!),
+      ],
+    );
+  }
+}
+
+class _InvitationPlaceLine extends StatelessWidget {
+  const _InvitationPlaceLine({required this.invitation});
+
+  final PlaceInvitation invitation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          invitation.placeName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.size14Bold.copyWith(color: AppColors.textStrong),
+        ),
+        const SizedBox(width: AppSpacing.x4),
+        Flexible(
+          child: Text(
+            invitation.address,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTextStyles.size12Medium.copyWith(
+              color: AppColors.textBody,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InvitationResultText extends StatelessWidget {
+  const _InvitationResultText({required this.invitation, required this.result});
+
+  final PlaceInvitation invitation;
+  final PlaceInvitationResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = switch (result) {
+      PlaceInvitationResult.accepted => '${invitation.placeName}에서 함께 해보세요:)',
+      PlaceInvitationResult.deleted => '요청 삭제됨',
+    };
+
+    final color = switch (result) {
+      PlaceInvitationResult.accepted => AppColors.brandStrong,
+      PlaceInvitationResult.deleted => AppColors.textStrong,
+    };
+
+    return Text(
+      message,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: AppTextStyles.size14Medium.copyWith(color: color),
+    );
+  }
+}
+
+class _InvitationActions extends StatelessWidget {
+  const _InvitationActions({
+    required this.invitation,
+    required this.onAccept,
+    required this.onDelete,
+  });
+
+  final PlaceInvitation invitation;
+  final VoidCallback onAccept;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _InvitationActionButton(
+          label: '확인',
+          semanticsLabel: '${invitation.placeName} 확인',
+          backgroundColor: AppColors.brandPrimary,
+          foregroundColor: AppColors.white,
+          onPressed: onAccept,
+        ),
+        const SizedBox(width: _invitationButtonGap),
+        _InvitationActionButton(
+          label: '삭제',
+          semanticsLabel: '${invitation.placeName} 삭제',
+          backgroundColor: AppColors.borderDefault,
+          foregroundColor: AppColors.textStrong,
+          onPressed: onDelete,
+        ),
+      ],
+    );
+  }
+}
+
+class _InvitationActionButton extends StatelessWidget {
+  const _InvitationActionButton({
+    required this.label,
+    required this.semanticsLabel,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.onPressed,
+  });
+
+  final String label;
+  final String semanticsLabel;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      container: true,
+      child: ExcludeSemantics(
+        child: Material(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(AppRadius.small),
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(AppRadius.small),
+            child: SizedBox(
+              width: AppSizes.placeInvitationActionButtonWidth,
+              height: AppSizes.placeInvitationActionButtonHeight,
+              child: Center(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.size14Bold.copyWith(
+                    color: foregroundColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #155

## 구현 범위

- 장소 친구 요청 화면의 invitation model을 `PlaceInvitation`으로 분리했습니다.
- local invitation fixture를 `placeInvitationFixture`로 이동했습니다.
- invitation list item과 avatar/description/place line/result/actions 하위 UI를 `PlaceInvitationListItem` 파일로 분리했습니다.
- `PlaceInvitationsPage`는 action result state, fixture 순회, accept/delete callback 연결 중심으로 정리했습니다.

## 테스트

- `fvm flutter test test/features/place/presentation/pages/place_invitations_page_test.dart`
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --cached --check`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트

- `PlaceInvitationResult`를 page와 list item이 함께 쓰는 presentation model 타입으로 노출했습니다.
- UI 동작 변경 없이 파일 책임만 나누는 범위로 제한했습니다.
