### PR TITLE
Refactor: 상세 액션 UI 분리 #157

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -12,9 +12,9 @@ import 'package:commonplant_frontend/features/place/presentation/providers/place
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_fab.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_header.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/place_exit_dialog.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_plant_list.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
-import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
@@ -35,23 +35,11 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
   void _showExitDialog(BuildContext context) {
     final isExiting = ref.read(placeExitControllerProvider).isSubmitting;
 
-    showCommonDialog<void>(
-      context: context,
-      child: CommonDialogCard(
-        title: '장소를 나가시겠어요?',
-        message: '나가면 더 이상 식물을 관리할 수 없어요.',
-        actions: [
-          CommonDialogActionButton(
-            label: '취소',
-            foregroundColor: AppColors.textBody,
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-          CommonDialogActionButton.confirm(
-            label: '나가기',
-            foregroundColor: AppColors.danger,
-            onPressed: isExiting ? null : () => _confirmExit(context),
-          ),
-        ],
+    unawaited(
+      showPlaceExitDialog(
+        context: context,
+        isExiting: isExiting,
+        onConfirm: () => _handleExitConfirmed(context),
       ),
     );
   }
@@ -103,12 +91,12 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
     );
   }
 
-  void _confirmExit(BuildContext context) {
+  void _handleExitConfirmed(BuildContext context) {
     Navigator.of(context).pop();
-    unawaited(_exitPlace(context));
+    unawaited(_handleExitResult(context));
   }
 
-  Future<void> _exitPlace(BuildContext context) async {
+  Future<void> _handleExitResult(BuildContext context) async {
     final result = await ref
         .read(placeExitControllerProvider.notifier)
         .exit(widget.placeId);

--- a/lib/features/place/presentation/widgets/place_exit_dialog.dart
+++ b/lib/features/place/presentation/widgets/place_exit_dialog.dart
@@ -1,0 +1,29 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
+import 'package:flutter/material.dart';
+
+Future<void> showPlaceExitDialog({
+  required BuildContext context,
+  required bool isExiting,
+  required VoidCallback onConfirm,
+}) async {
+  await showCommonDialog<void>(
+    context: context,
+    child: CommonDialogCard(
+      title: '장소를 나가시겠어요?',
+      message: '나가면 더 이상 식물을 관리할 수 없어요.',
+      actions: [
+        CommonDialogActionButton(
+          label: '취소',
+          foregroundColor: AppColors.textBody,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        CommonDialogActionButton.confirm(
+          label: '나가기',
+          foregroundColor: AppColors.danger,
+          onPressed: isExiting ? null : onConfirm,
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -1,24 +1,20 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
-import 'package:commonplant_frontend/core/theme/app_sizes.dart';
-import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_care_summary.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_delete_dialog.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_content_width.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_menu_button.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_hero.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_info_section.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_memo_preview_section.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
-import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
-import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
-import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -34,69 +30,14 @@ class PlantDetailPage extends ConsumerStatefulWidget {
 }
 
 class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
-  void _showPlantMenu(BuildContext context, String? placeCode) {
-    showGeneralDialog<void>(
-      context: context,
-      barrierDismissible: true,
-      barrierLabel: '식물 상세 메뉴 닫기',
-      barrierColor: Colors.black.withValues(alpha: 0.4),
-      transitionDuration: Duration.zero,
-      pageBuilder: (dialogContext, _, _) {
-        return Material(
-          type: MaterialType.transparency,
-          child: Stack(
-            children: [
-              Positioned(
-                top:
-                    MediaQuery.paddingOf(dialogContext).top +
-                    AppSizes.navigationBarHeight +
-                    AppSpacing.x8,
-                right: AppSpacing.x20,
-                child: CommonEditDeletePopup(
-                  onEdit: () {
-                    Navigator.of(dialogContext).pop();
-                    context.push(
-                      AppRoutePaths.plantEditLocation(
-                        widget.plantId,
-                        placeId: placeCode,
-                      ),
-                    );
-                  },
-                  onDelete: () {
-                    Navigator.of(dialogContext).pop();
-                    _showDeleteDialog(context, placeCode);
-                  },
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
   void _showDeleteDialog(BuildContext context, String? placeCode) {
     final isDeleting = ref.read(plantDeleteControllerProvider).isSubmitting;
 
-    showCommonDialog<void>(
-      context: context,
-      child: CommonDialogCard(
-        title: '식물을 삭제할까요?',
-        message: '삭제하면 기록된 메모도 함께 사라져요.',
-        actions: [
-          CommonDialogActionButton(
-            label: '취소',
-            foregroundColor: AppColors.textBody,
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-          CommonDialogActionButton.confirm(
-            label: '삭제',
-            foregroundColor: AppColors.danger,
-            onPressed: isDeleting
-                ? null
-                : () => _confirmDelete(context, placeCode),
-          ),
-        ],
+    unawaited(
+      showPlantDeleteDialog(
+        context: context,
+        isDeleting: isDeleting,
+        onConfirm: () => _handleDeleteConfirmed(context, placeCode),
       ),
     );
   }
@@ -134,12 +75,15 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
     );
   }
 
-  void _confirmDelete(BuildContext context, String? placeCode) {
+  void _handleDeleteConfirmed(BuildContext context, String? placeCode) {
     Navigator.of(context).pop();
-    unawaited(_deletePlant(context, placeCode));
+    unawaited(_handleDeleteResult(context, placeCode));
   }
 
-  Future<void> _deletePlant(BuildContext context, String? placeCode) async {
+  Future<void> _handleDeleteResult(
+    BuildContext context,
+    String? placeCode,
+  ) async {
     final result = await ref
         .read(plantDeleteControllerProvider.notifier)
         .delete(plantId: widget.plantId, placeCode: placeCode);
@@ -171,8 +115,16 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
         color: AppColors.textStrong,
         fontWeight: FontWeight.w700,
       ),
-      trailing: _PlantDetailMenuButton(
-        onPressed: () => _showPlantMenu(context, detail.placeCode),
+      trailing: PlantDetailMenuButton(
+        onEdit: () {
+          context.push(
+            AppRoutePaths.plantEditLocation(
+              widget.plantId,
+              placeId: detail.placeCode,
+            ),
+          );
+        },
+        onDelete: () => _showDeleteDialog(context, detail.placeCode),
       ),
       bodyPadding: EdgeInsets.zero,
       child: SizedBox(
@@ -198,37 +150,6 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
             PlantInfoSection(wateringCycleLabel: detail.wateringCycleLabel),
             const SizedBox(height: 82),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _PlantDetailMenuButton extends StatelessWidget {
-  const _PlantDetailMenuButton({required this.onPressed});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: '식물 상세 메뉴',
-      child: ExcludeSemantics(
-        child: IconButton(
-          tooltip: '식물 상세 메뉴',
-          onPressed: onPressed,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints.tightFor(
-            width: AppSizes.navigationBarSideWidth,
-            height: AppSizes.navigationBarHeight,
-          ),
-          icon: const CommonSvgIcon(
-            AppIconAssets.shape,
-            width: 4,
-            height: 20,
-            color: AppColors.textStrong,
-          ),
         ),
       ),
     );

--- a/lib/features/plant/presentation/widgets/plant_delete_dialog.dart
+++ b/lib/features/plant/presentation/widgets/plant_delete_dialog.dart
@@ -1,0 +1,29 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
+import 'package:flutter/material.dart';
+
+Future<void> showPlantDeleteDialog({
+  required BuildContext context,
+  required bool isDeleting,
+  required VoidCallback onConfirm,
+}) async {
+  await showCommonDialog<void>(
+    context: context,
+    child: CommonDialogCard(
+      title: '식물을 삭제할까요?',
+      message: '삭제하면 기록된 메모도 함께 사라져요.',
+      actions: [
+        CommonDialogActionButton(
+          label: '취소',
+          foregroundColor: AppColors.textBody,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        CommonDialogActionButton.confirm(
+          label: '삭제',
+          foregroundColor: AppColors.danger,
+          onPressed: isDeleting ? null : onConfirm,
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/plant/presentation/widgets/plant_detail_menu_button.dart
+++ b/lib/features/plant/presentation/widgets/plant_detail_menu_button.dart
@@ -1,0 +1,79 @@
+import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/shared/widgets/common_edit_delete_popup.dart';
+import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
+import 'package:flutter/material.dart';
+
+class PlantDetailMenuButton extends StatelessWidget {
+  const PlantDetailMenuButton({
+    super.key,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: '식물 상세 메뉴',
+      child: ExcludeSemantics(
+        child: IconButton(
+          tooltip: '식물 상세 메뉴',
+          onPressed: () => _showMenu(context),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints.tightFor(
+            width: AppSizes.navigationBarSideWidth,
+            height: AppSizes.navigationBarHeight,
+          ),
+          icon: const CommonSvgIcon(
+            AppIconAssets.shape,
+            width: 4,
+            height: 20,
+            color: AppColors.textStrong,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showMenu(BuildContext context) {
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: '식물 상세 메뉴 닫기',
+      barrierColor: Colors.black.withValues(alpha: 0.4),
+      transitionDuration: Duration.zero,
+      pageBuilder: (dialogContext, _, _) {
+        return Material(
+          type: MaterialType.transparency,
+          child: Stack(
+            children: [
+              Positioned(
+                top:
+                    MediaQuery.paddingOf(dialogContext).top +
+                    AppSizes.navigationBarHeight +
+                    AppSpacing.x8,
+                right: AppSpacing.x20,
+                child: CommonEditDeletePopup(
+                  onEdit: () {
+                    Navigator.of(dialogContext).pop();
+                    onEdit();
+                  },
+                  onDelete: () {
+                    Navigator.of(dialogContext).pop();
+                    onDelete();
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #157

## 구현 범위

- 장소 상세의 나가기 확인 dialog를 `showPlaceExitDialog`로 분리했습니다.
- 식물 상세의 더보기 메뉴 버튼을 `PlantDetailMenuButton`으로 분리하고, page는 edit/delete callback 연결만 담당하도록 정리했습니다.
- 식물 삭제 확인 dialog를 `showPlantDeleteDialog`로 분리했습니다.
- action confirm/result 처리 메서드 이름을 `_handleExitConfirmed`, `_handleExitResult`, `_handleDeleteConfirmed`, `_handleDeleteResult`로 통일했습니다.

## 테스트

- `fvm flutter test test/features/place/presentation/pages/place_detail_page_test.dart test/features/plant/presentation/pages/plant_detail_page_test.dart test/features/place/presentation/providers/place_exit_controller_test.dart test/features/plant/presentation/providers/plant_delete_controller_test.dart`
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --cached --check`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트

- navigation과 snackbar 처리는 기존처럼 page에 남기고, dialog/menu UI만 feature widget으로 분리했습니다.
- `BuildContext`는 controller로 넘기지 않는 기존 경계를 유지했습니다.
