### PR TITLE
Refactor: 상세 뷰 경계 정리 #159

### DIFF
--- a/lib/features/place/presentation/providers/place_detail_view_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_view_provider.dart
@@ -1,4 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
@@ -12,32 +13,48 @@ final placeDetailViewProvider =
       PlaceDetailViewRequest
     >((ref, request) {
       if (!ref.watch(useRemoteApiProvider)) {
-        return AsyncData(
-          placeDetailFixture(request.placeId, role: request.role),
-        );
+        return AsyncData(ref.watch(placeLocalDetailViewProvider(request)));
       }
 
-      return ref.watch(remotePlaceDetailViewProvider(request));
+      return ref.watch(placeRemoteDetailViewProvider(request));
     });
 
-final remotePlaceDetailViewProvider =
+final placeLocalDetailViewProvider =
+    Provider.family<PlaceDetailFixtureData, PlaceDetailViewRequest>((
+      ref,
+      request,
+    ) {
+      return placeDetailFixture(request.placeId, role: request.role);
+    });
+
+final placeRemoteDetailViewProvider =
     FutureProvider.family<PlaceDetailFixtureData?, PlaceDetailViewRequest>((
       ref,
       request,
     ) async {
-      final fixture = placeDetailFixture(request.placeId, role: request.role);
+      final fixture = ref.watch(placeLocalDetailViewProvider(request));
       final summary = await ref.watch(
         placeDetailProvider(request.placeId).future,
       );
 
-      if (summary.name.trim().isEmpty) {
-        return null;
-      }
-
-      return fixture.applySummary(summary);
+      return applyRemotePlaceSummaryToFixture(
+        fixture: fixture,
+        summary: summary,
+      );
     }, retry: (retryCount, error) => null);
+
+PlaceDetailFixtureData? applyRemotePlaceSummaryToFixture({
+  required PlaceDetailFixtureData fixture,
+  required PlaceSummary summary,
+}) {
+  if (summary.name.trim().isEmpty) {
+    return null;
+  }
+
+  return fixture.applySummary(summary);
+}
 
 void invalidatePlaceDetailView(WidgetRef ref, PlaceDetailViewRequest request) {
   ref.invalidate(placeDetailProvider(request.placeId));
-  ref.invalidate(remotePlaceDetailViewProvider(request));
+  ref.invalidate(placeRemoteDetailViewProvider(request));
 }

--- a/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
@@ -1,4 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,30 +12,45 @@ final plantDetailViewProvider =
       PlantDetailViewRequest
     >((ref, request) {
       if (!ref.watch(useRemoteApiProvider)) {
-        return AsyncData(plantDetailFixture(placeCode: request.placeCode));
+        return AsyncData(ref.watch(plantLocalDetailViewProvider(request)));
       }
 
-      return ref.watch(remotePlantDetailViewProvider(request));
+      return ref.watch(plantRemoteDetailViewProvider(request));
     });
 
-final remotePlantDetailViewProvider =
+final plantLocalDetailViewProvider =
+    Provider.family<PlantDetailFixtureData, PlantDetailViewRequest>((
+      ref,
+      request,
+    ) {
+      return plantDetailFixture(placeCode: request.placeCode);
+    });
+
+final plantRemoteDetailViewProvider =
     FutureProvider.family<PlantDetailFixtureData?, PlantDetailViewRequest>((
       ref,
       request,
     ) async {
-      final fixture = plantDetailFixture(placeCode: request.placeCode);
+      final fixture = ref.watch(plantLocalDetailViewProvider(request));
       final detail = await ref.watch(
         remotePlantDetailProvider(request.plantId).future,
       );
 
-      if (detail.name.trim().isEmpty) {
-        return null;
-      }
-
-      return fixture.applyRemote(detail);
+      return applyRemotePlantDetailToFixture(fixture: fixture, detail: detail);
     }, retry: (retryCount, error) => null);
+
+PlantDetailFixtureData? applyRemotePlantDetailToFixture({
+  required PlantDetailFixtureData fixture,
+  required PlantDetail detail,
+}) {
+  if (detail.name.trim().isEmpty) {
+    return null;
+  }
+
+  return fixture.applyRemote(detail);
+}
 
 void invalidatePlantDetailView(WidgetRef ref, PlantDetailViewRequest request) {
   ref.invalidate(remotePlantDetailProvider(request.plantId));
-  ref.invalidate(remotePlantDetailViewProvider(request));
+  ref.invalidate(plantRemoteDetailViewProvider(request));
 }

--- a/test/features/place/presentation/providers/place_detail_view_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_view_provider_test.dart
@@ -43,7 +43,7 @@ void main() {
       addTearDown(container.dispose);
 
       final request = (placeId: 'remote-place', role: PlaceDetailRole.leader);
-      await container.read(remotePlaceDetailViewProvider(request).future);
+      await container.read(placeRemoteDetailViewProvider(request).future);
 
       final detail = container
           .read(placeDetailViewProvider(request))
@@ -68,7 +68,7 @@ void main() {
       addTearDown(container.dispose);
 
       final request = (placeId: 'empty-place', role: null);
-      await container.read(remotePlaceDetailViewProvider(request).future);
+      await container.read(placeRemoteDetailViewProvider(request).future);
 
       expect(
         container.read(placeDetailViewProvider(request)).requireValue,

--- a/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
@@ -43,7 +43,7 @@ void main() {
       addTearDown(container.dispose);
 
       final request = (plantId: 'remote-plant', placeCode: 'fallback-place');
-      await container.read(remotePlantDetailViewProvider(request).future);
+      await container.read(plantRemoteDetailViewProvider(request).future);
 
       final detail = container
           .read(plantDetailViewProvider(request))
@@ -70,7 +70,7 @@ void main() {
       addTearDown(container.dispose);
 
       final request = (plantId: 'empty-plant', placeCode: null);
-      await container.read(remotePlantDetailViewProvider(request).future);
+      await container.read(plantRemoteDetailViewProvider(request).future);
 
       expect(
         container.read(plantDetailViewProvider(request)).requireValue,


### PR DESCRIPTION
## 관련 이슈

- Closes #159

## 구현 범위

- Place 상세 view provider에 `placeLocalDetailViewProvider`와 `placeRemoteDetailViewProvider` 경계를 명시했습니다.
- Plant 상세 view provider에 `plantLocalDetailViewProvider`와 `plantRemoteDetailViewProvider` 경계를 명시했습니다.
- remote 응답 적용 로직을 `applyRemotePlaceSummaryToFixture`, `applyRemotePlantDetailToFixture` 함수로 분리했습니다.
- 기존 facade provider인 `placeDetailViewProvider`, `plantDetailViewProvider` 이름은 유지했습니다.

## 테스트

- `fvm flutter test test/features/place/presentation/providers/place_detail_view_provider_test.dart test/features/plant/presentation/providers/plant_detail_view_provider_test.dart`
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --cached --check`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트

- 화면 호출부의 provider API는 유지하고, 내부 local/remote 경계만 이름으로 드러냈습니다.
- remote empty 판단과 fixture merge 규칙은 기존 동작을 그대로 함수로 이동했습니다.
