### PR TITLE
Refactor: API 매퍼 책임 정리 #161

### DIFF
--- a/lib/core/network/api_response_parser.dart
+++ b/lib/core/network/api_response_parser.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:commonplant_frontend/core/network/api_exception.dart';
 
+// Swagger response wrappers are still being finalized; keep this parser broad
+// and move domain-specific interpretation into feature mappers.
 typedef JsonMap = Map<String, Object?>;
 
 JsonMap jsonObjectFromResponse(Object? data, {required String context}) {

--- a/lib/features/place/data/mappers/place_mapper.dart
+++ b/lib/features/place/data/mappers/place_mapper.dart
@@ -1,6 +1,21 @@
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 
+List<PlaceSummary> placeSummariesFromResponse(Object? data) {
+  final items = jsonListFromResponse(data, context: '장소 목록 조회');
+
+  return [for (final item in items) placeSummaryFromJson(item)];
+}
+
+PlaceSummary placeSummaryFromResponse(
+  Object? data, {
+  required String fallbackId,
+}) {
+  final object = unwrapJsonObject(data, context: '장소 조회');
+
+  return placeSummaryFromJson(object, fallbackId: fallbackId);
+}
+
 PlaceSummary placeSummaryFromJson(JsonMap json, {String? fallbackId}) {
   return PlaceSummary(
     id:

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -1,5 +1,4 @@
 import 'package:commonplant_frontend/core/network/api_client.dart';
-import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.dart';
@@ -22,23 +21,20 @@ class PlaceRepository {
 
   Future<List<PlaceSummary>> fetchMyGardenPlaces() async {
     final data = await _remoteDataSource.getMyGarden();
-    final items = jsonListFromResponse(data, context: '내 정원 조회');
 
-    return [for (final item in items) placeSummaryFromJson(item)];
+    return placeSummariesFromResponse(data);
   }
 
   Future<List<PlaceSummary>> fetchUserPlaces() async {
     final data = await _remoteDataSource.getUserPlaces();
-    final items = jsonListFromResponse(data, context: '소속 장소 조회');
 
-    return [for (final item in items) placeSummaryFromJson(item)];
+    return placeSummariesFromResponse(data);
   }
 
   Future<PlaceSummary> fetchPlace(String code) async {
     final data = await _remoteDataSource.getPlace(code);
-    final object = unwrapJsonObject(data, context: '장소 조회');
 
-    return placeSummaryFromJson(object, fallbackId: code);
+    return placeSummaryFromResponse(data, fallbackId: code);
   }
 
   Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image}) {

--- a/lib/features/plant/data/mappers/plant_mapper.dart
+++ b/lib/features/plant/data/mappers/plant_mapper.dart
@@ -2,6 +2,27 @@ import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
 
+List<PlantSummary> plantSummariesFromResponse(Object? data) {
+  final items = jsonListFromResponse(data, context: '식물 목록 조회');
+
+  return [for (final item in items) plantSummaryFromJson(item)];
+}
+
+PlantDetail plantDetailFromResponse(
+  Object? data, {
+  required String fallbackId,
+}) {
+  final object = unwrapJsonObject(data, context: '식물 상세 조회');
+
+  return plantDetailFromJson(object, fallbackId: fallbackId);
+}
+
+PlantEditInfo plantEditInfoFromResponse(Object? data) {
+  final object = unwrapJsonObject(data, context: '식물 수정 정보 조회');
+
+  return plantEditInfoFromJson(object);
+}
+
 PlantSummary plantSummaryFromJson(JsonMap json) {
   return PlantSummary(
     id: readRequiredString(json, const ['id', 'plantId'], '식물 ID'),

--- a/lib/features/plant/data/repositories/plant_repository.dart
+++ b/lib/features/plant/data/repositories/plant_repository.dart
@@ -1,5 +1,4 @@
 import 'package:commonplant_frontend/core/network/api_client.dart';
-import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/mappers/plant_mapper.dart';
@@ -23,9 +22,8 @@ class PlantRepository {
 
   Future<List<PlantSummary>> fetchPlants({int page = 0, int size = 20}) async {
     final data = await _remoteDataSource.getPlants(page: page, size: size);
-    final items = jsonListFromResponse(data, context: '식물 목록 조회');
 
-    return [for (final item in items) plantSummaryFromJson(item)];
+    return plantSummariesFromResponse(data);
   }
 
   Future<void> createPlant(CreatePlantRequest request, {MultipartFile? image}) {
@@ -34,16 +32,14 @@ class PlantRepository {
 
   Future<PlantDetail> fetchPlant({required String plantId}) async {
     final data = await _remoteDataSource.getPlant(plantId: plantId);
-    final object = unwrapJsonObject(data, context: '식물 상세 조회');
 
-    return plantDetailFromJson(object, fallbackId: plantId);
+    return plantDetailFromResponse(data, fallbackId: plantId);
   }
 
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
     final data = await _remoteDataSource.getPlantEditInfo(plantId: plantId);
-    final object = unwrapJsonObject(data, context: '식물 수정 정보 조회');
 
-    return plantEditInfoFromJson(object);
+    return plantEditInfoFromResponse(data);
   }
 
   Future<void> updatePlant({

--- a/test/features/place/data/mappers/place_mapper_test.dart
+++ b/test/features/place/data/mappers/place_mapper_test.dart
@@ -2,6 +2,40 @@ import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.da
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('placeSummariesFromResponse', () {
+    test('wrapper 응답에서 장소 요약 목록을 만든다', () {
+      final summaries = placeSummariesFromResponse({
+        'result': {
+          'content': {
+            'items': [
+              {
+                'placeCode': 'place-nano-id',
+                'placeName': '거실 정원',
+                'placeAddress': '서울시 성북구',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(summaries, hasLength(1));
+      expect(summaries.single.id, 'place-nano-id');
+      expect(summaries.single.name, '거실 정원');
+      expect(summaries.single.address, '서울시 성북구');
+    });
+  });
+
+  group('placeSummaryFromResponse', () {
+    test('wrapper 응답에서 fallbackId를 보존해 장소 요약을 만든다', () {
+      final summary = placeSummaryFromResponse({
+        'result': {'name': '루프탑'},
+      }, fallbackId: 'fallback-place');
+
+      expect(summary.id, 'fallback-place');
+      expect(summary.name, '루프탑');
+    });
+  });
+
   group('placeSummaryFromJson', () {
     test('Swagger 장소 필드를 화면용 요약 모델로 매핑한다', () {
       final summary = placeSummaryFromJson(const <String, Object?>{

--- a/test/features/plant/data/mappers/plant_mapper_test.dart
+++ b/test/features/plant/data/mappers/plant_mapper_test.dart
@@ -1,8 +1,33 @@
-import 'package:commonplant_frontend/core/network/api_response_parser.dart';
 import 'package:commonplant_frontend/features/plant/data/mappers/plant_mapper.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('plantSummariesFromResponse', () {
+    test('Swagger 식물 목록 wrapper에서 요약 모델 목록을 만든다', () {
+      final summaries = plantSummariesFromResponse({
+        'result': {
+          'content': {
+            'items': [
+              {
+                'plantId': 1,
+                'nickname': '거실 몬스테라',
+                'representativeImageUrl': 'https://example.com/monstera.png',
+              },
+            ],
+            'totalCount': 1,
+            'page': 0,
+            'size': 20,
+          },
+        },
+      });
+
+      expect(summaries, hasLength(1));
+      expect(summaries.single.id, '1');
+      expect(summaries.single.name, '거실 몬스테라');
+      expect(summaries.single.imageUrl, 'https://example.com/monstera.png');
+    });
+  });
+
   group('plantSummaryFromJson', () {
     test('Swagger PlantSummary 필드를 화면용 요약 모델로 매핑한다', () {
       final summary = plantSummaryFromJson({
@@ -43,6 +68,24 @@ void main() {
     });
   });
 
+  group('plantDetailFromResponse', () {
+    test('Swagger 상세 wrapper에서 상세 모델을 만든다', () {
+      final detail = plantDetailFromResponse({
+        'result': {
+          'plantId': 1,
+          'scientificNameKo': '몬스테라',
+          'scientificNameEn': 'Monstera deliciosa',
+          'placeName': '거실 정원',
+        },
+      }, fallbackId: 'fallback-plant');
+
+      expect(detail.id, '1');
+      expect(detail.name, '몬스테라');
+      expect(detail.species, 'Monstera deliciosa');
+      expect(detail.placeName, '거실 정원');
+    });
+  });
+
   group('plantEditInfoFromJson', () {
     test('Swagger EditInfoResponse를 수정 정보 모델로 매핑한다', () {
       final editInfo = plantEditInfoFromJson(const <String, Object?>{
@@ -59,31 +102,21 @@ void main() {
     });
   });
 
-  group('jsonListFromResponse + plantSummaryFromJson', () {
-    test('Swagger 식물 목록 wrapper에서 요약 모델 목록을 만든다', () {
-      final items = jsonListFromResponse({
+  group('plantEditInfoFromResponse', () {
+    test('Swagger 수정 정보 wrapper에서 수정 정보 모델을 만든다', () {
+      final editInfo = plantEditInfoFromResponse({
         'result': {
-          'content': {
-            'items': [
-              {
-                'plantId': 1,
-                'nickname': '거실 몬스테라',
-                'representativeImageUrl': 'https://example.com/monstera.png',
-              },
-            ],
-            'totalCount': 1,
-            'page': 0,
-            'size': 20,
-          },
+          'imageKey': 'images/user-nano-id/monstera.png',
+          'imageUrl': 'https://example.com/monstera.png',
+          'nickname': '거실 몬스테라',
+          'lastWateredDate': '2026-05-12',
         },
-      }, context: '식물 목록 조회');
+      });
 
-      final summaries = [for (final item in items) plantSummaryFromJson(item)];
-
-      expect(summaries, hasLength(1));
-      expect(summaries.single.id, '1');
-      expect(summaries.single.name, '거실 몬스테라');
-      expect(summaries.single.imageUrl, 'https://example.com/monstera.png');
+      expect(editInfo.name, '거실 몬스테라');
+      expect(editInfo.imageKey, 'images/user-nano-id/monstera.png');
+      expect(editInfo.imageUrl, 'https://example.com/monstera.png');
+      expect(editInfo.lastWateredDate, '2026-05-12');
     });
   });
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #161

## 구현 범위

- Place repository의 list/detail response unwrap을 `place_mapper.dart`의 `placeSummariesFromResponse`, `placeSummaryFromResponse`로 이동했습니다.
- Plant repository의 list/detail/edit response unwrap을 `plant_mapper.dart`의 `plantSummariesFromResponse`, `plantDetailFromResponse`, `plantEditInfoFromResponse`로 이동했습니다.
- `api_response_parser.dart` 상단에 Swagger wrapper 확정 전 parser 책임을 명시했습니다.
- Friend/Image/Memo DTO 확정이나 `jsonListFromResponse` fallback key 제거는 진행하지 않았습니다.

## 테스트

- `fvm flutter test test/features/place/data/mappers/place_mapper_test.dart test/features/place/data/repositories/place_repository_test.dart test/features/plant/data/mappers/plant_mapper_test.dart test/features/plant/data/repositories/plant_repository_test.dart`
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --cached --check`
- `git diff --check HEAD~1 HEAD`

## 리뷰 포인트

- repository는 datasource 호출 후 mapper 함수만 호출하도록 단순화했습니다.
- 공통 parser는 wrapper 탐색을 계속 넓게 유지하고, 도메인별 interpretation은 mapper 함수로 모았습니다.
