### PR TITLE
Refactor: 상세 route page 상태 제거 #168

### DIFF
--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -21,32 +21,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class PlaceDetailPage extends ConsumerStatefulWidget {
+class PlaceDetailPage extends ConsumerWidget {
   const PlaceDetailPage({super.key, required this.placeId, this.role});
 
   final String placeId;
   final PlaceDetailRole? role;
 
-  @override
-  ConsumerState<PlaceDetailPage> createState() => _PlaceDetailPageState();
-}
-
-class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
-  void _showExitDialog(BuildContext context) {
+  void _showExitDialog(BuildContext context, WidgetRef ref) {
     final isExiting = ref.read(placeExitControllerProvider).isSubmitting;
 
     unawaited(
       showPlaceExitDialog(
         context: context,
         isExiting: isExiting,
-        onConfirm: () => _handleExitConfirmed(context),
+        onConfirm: () => _handleExitConfirmed(context, ref),
       ),
     );
   }
 
   @override
-  Widget build(BuildContext context) {
-    final request = (placeId: widget.placeId, role: widget.role);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final request = (placeId: placeId, role: role);
     final detailState = ref.watch(placeDetailViewProvider(request));
 
     return detailState.when(
@@ -63,7 +58,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
           );
         }
 
-        return _buildScaffold(context, detail);
+        return _buildScaffold(context, ref, detail);
       },
       error: (error, stackTrace) {
         return _buildStatusScaffold(
@@ -91,17 +86,17 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
     );
   }
 
-  void _handleExitConfirmed(BuildContext context) {
+  void _handleExitConfirmed(BuildContext context, WidgetRef ref) {
     Navigator.of(context).pop();
-    unawaited(_handleExitResult(context));
+    unawaited(_handleExitResult(context, ref));
   }
 
-  Future<void> _handleExitResult(BuildContext context) async {
+  Future<void> _handleExitResult(BuildContext context, WidgetRef ref) async {
     final result = await ref
         .read(placeExitControllerProvider.notifier)
-        .exit(widget.placeId);
+        .exit(placeId);
 
-    if (!mounted || !context.mounted) {
+    if (!context.mounted) {
       return;
     }
 
@@ -121,7 +116,11 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
-  Widget _buildScaffold(BuildContext context, PlaceDetailFixtureData detail) {
+  Widget _buildScaffold(
+    BuildContext context,
+    WidgetRef ref,
+    PlaceDetailFixtureData detail,
+  ) {
     return CommonScaffold(
       title: 'My place',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -130,9 +129,9 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
       ),
       bodyPadding: EdgeInsets.zero,
       floatingActionButton: PlaceDetailFab(
-        placeId: widget.placeId,
+        placeId: placeId,
         canEditPlace: detail.role == PlaceDetailRole.leader,
-        onExit: () => _showExitDialog(context),
+        onExit: () => _showExitDialog(context, ref),
       ),
       child: SizedBox(
         width: double.infinity,
@@ -142,14 +141,14 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
             child: Column(
               children: [
                 PlaceDetailHeader(
-                  placeId: widget.placeId,
+                  placeId: placeId,
                   name: detail.name,
                   address: detail.address,
                   sunlightLabel: detail.sunlightLabel,
                   humidityLabel: detail.humidityLabel,
                   friends: detail.friends,
                 ),
-                PlacePlantList(placeId: widget.placeId, plants: detail.plants),
+                PlacePlantList(placeId: placeId, plants: detail.plants),
               ],
             ),
           ),

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -19,32 +19,31 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class PlantDetailPage extends ConsumerStatefulWidget {
+class PlantDetailPage extends ConsumerWidget {
   const PlantDetailPage({super.key, required this.plantId, this.placeId});
 
   final String plantId;
   final String? placeId;
 
-  @override
-  ConsumerState<PlantDetailPage> createState() => _PlantDetailPageState();
-}
-
-class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
-  void _showDeleteDialog(BuildContext context, String? placeCode) {
+  void _showDeleteDialog(
+    BuildContext context,
+    WidgetRef ref,
+    String? placeCode,
+  ) {
     final isDeleting = ref.read(plantDeleteControllerProvider).isSubmitting;
 
     unawaited(
       showPlantDeleteDialog(
         context: context,
         isDeleting: isDeleting,
-        onConfirm: () => _handleDeleteConfirmed(context, placeCode),
+        onConfirm: () => _handleDeleteConfirmed(context, ref, placeCode),
       ),
     );
   }
 
   @override
-  Widget build(BuildContext context) {
-    final request = (plantId: widget.plantId, placeCode: widget.placeId);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final request = (plantId: plantId, placeCode: placeId);
     final detailState = ref.watch(plantDetailViewProvider(request));
 
     return detailState.when(
@@ -57,7 +56,7 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
           );
         }
 
-        return _buildScaffold(context, detail);
+        return _buildScaffold(context, ref, detail);
       },
       error: (error, stackTrace) => PlantStateScaffold(
         title: 'My plant',
@@ -75,20 +74,25 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
     );
   }
 
-  void _handleDeleteConfirmed(BuildContext context, String? placeCode) {
+  void _handleDeleteConfirmed(
+    BuildContext context,
+    WidgetRef ref,
+    String? placeCode,
+  ) {
     Navigator.of(context).pop();
-    unawaited(_handleDeleteResult(context, placeCode));
+    unawaited(_handleDeleteResult(context, ref, placeCode));
   }
 
   Future<void> _handleDeleteResult(
     BuildContext context,
+    WidgetRef ref,
     String? placeCode,
   ) async {
     final result = await ref
         .read(plantDeleteControllerProvider.notifier)
-        .delete(plantId: widget.plantId, placeCode: placeCode);
+        .delete(plantId: plantId, placeCode: placeCode);
 
-    if (!mounted || !context.mounted) {
+    if (!context.mounted) {
       return;
     }
 
@@ -108,7 +112,11 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 
-  Widget _buildScaffold(BuildContext context, PlantDetailFixtureData detail) {
+  Widget _buildScaffold(
+    BuildContext context,
+    WidgetRef ref,
+    PlantDetailFixtureData detail,
+  ) {
     return CommonScaffold(
       title: 'My plant',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -118,13 +126,10 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
       trailing: PlantDetailMenuButton(
         onEdit: () {
           context.push(
-            AppRoutePaths.plantEditLocation(
-              widget.plantId,
-              placeId: detail.placeCode,
-            ),
+            AppRoutePaths.plantEditLocation(plantId, placeId: detail.placeCode),
           );
         },
-        onDelete: () => _showDeleteDialog(context, detail.placeCode),
+        onDelete: () => _showDeleteDialog(context, ref, detail.placeCode),
       ),
       bodyPadding: EdgeInsets.zero,
       child: SizedBox(
@@ -146,7 +151,7 @@ class _PlantDetailPageState extends ConsumerState<PlantDetailPage> {
               startDate: detail.startDate,
               lastWateredDate: detail.lastWateredDate,
             ),
-            MemoPreviewSection(plantId: widget.plantId, memos: detail.memos),
+            MemoPreviewSection(plantId: plantId, memos: detail.memos),
             PlantInfoSection(wateringCycleLabel: detail.wateringCycleLabel),
             const SizedBox(height: 82),
           ],


### PR DESCRIPTION
## 관련 이슈

- Closes #168
- Parent: #165
- 계획 문서 PR: #167

## 구현 범위

- `PlaceDetailPage`를 `ConsumerStatefulWidget`에서 `ConsumerWidget`으로 전환
- `PlantDetailPage`를 `ConsumerStatefulWidget`에서 `ConsumerWidget`으로 전환
- async action helper가 `WidgetRef`와 `BuildContext`를 명시적으로 받도록 정리
- State의 `mounted` 대신 `context.mounted`로 비동기 UI 안전성 유지

## 주요 변경사항

- 실제 mutable field가 없던 두 route page의 State class를 제거했습니다.
- 장소 나가기와 식물 삭제 Controller, dialog, navigation, snackbar 책임은 기존대로 유지했습니다.
- feature route/page StatefulWidget 수가 11개에서 9개로 감소했습니다.

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test test/features/place/presentation/pages/place_detail_page_test.dart test/features/place/presentation/providers/place_exit_controller_test.dart test/features/plant/presentation/pages/plant_detail_page_test.dart test/features/plant/presentation/providers/plant_delete_controller_test.dart`
- `fvm flutter test`

모든 검증을 통과했습니다.

## 리뷰 포인트

- `WidgetRef`를 action helper에 명시적으로 전달하는 구조가 route page 책임에 적절한지
- Stateful 제거 후 dialog/action/navigation 동작이 동일하게 유지되는지

## 문서 반영

- 3차 계획 문서는 #167에서 별도로 리뷰 중입니다.

## Breaking change

- 없음
