### PR TITLE
Refactor: 검색 상태 Riverpod 전환 #170

### DIFF
--- a/lib/features/place/presentation/fixtures/address_search_fixture.dart
+++ b/lib/features/place/presentation/fixtures/address_search_fixture.dart
@@ -1,0 +1,50 @@
+import 'package:commonplant_frontend/features/place/presentation/models/address_search_result.dart';
+
+const List<AddressSearchResult> addressSearchFixture = [
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '1호선',
+    address: '서울 구로구 경인로 688',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+    highlighted: true,
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+  AddressSearchResult(
+    titlePrefix: '신도림역',
+    titleSuffix: '2호선',
+    address: '서울 구로구 새말로 지하 117-21',
+  ),
+];

--- a/lib/features/place/presentation/models/address_search_result.dart
+++ b/lib/features/place/presentation/models/address_search_result.dart
@@ -1,0 +1,15 @@
+class AddressSearchResult {
+  const AddressSearchResult({
+    required this.titlePrefix,
+    required this.titleSuffix,
+    required this.address,
+    this.highlighted = false,
+  });
+
+  final String titlePrefix;
+  final String titleSuffix;
+  final String address;
+  final bool highlighted;
+
+  String get title => '$titlePrefix $titleSuffix';
+}

--- a/lib/features/place/presentation/pages/address_search_page.dart
+++ b/lib/features/place/presentation/pages/address_search_page.dart
@@ -3,9 +3,12 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/address_search_result.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/address_search_controller.dart';
+import 'package:commonplant_frontend/features/place/presentation/widgets/address_search_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
-import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const double _addressSearchResultHeight = 72;
 const double _addressSearchResultGap = 4;
@@ -14,85 +17,12 @@ const double _addressSearchButtonHeight = 36;
 const double _addressSearchResultVerticalPadding = AppSpacing.x10;
 const double _addressSearchResultTextWidth = 219;
 
-class AddressSearchPage extends StatefulWidget {
+class AddressSearchPage extends ConsumerWidget {
   const AddressSearchPage({super.key});
 
   @override
-  State<AddressSearchPage> createState() => _AddressSearchPageState();
-}
-
-class _AddressSearchPageState extends State<AddressSearchPage> {
-  final TextEditingController _searchController = TextEditingController(
-    text: '신도림역',
-  );
-
-  static const List<_AddressSearchResult> _addresses = [
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '1호선',
-      address: '서울 구로구 경인로 688',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-      highlighted: true,
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-    _AddressSearchResult(
-      titlePrefix: '신도림역',
-      titleSuffix: '2호선',
-      address: '서울 구로구 새말로 지하 117-21',
-    ),
-  ];
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final query = _searchController.text.trim();
-    final results = query.isEmpty
-        ? _addresses
-        : _addresses
-              .where(
-                (result) =>
-                    result.title.contains(query) ||
-                    result.address.contains(query),
-              )
-              .toList();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchState = ref.watch(addressSearchControllerProvider);
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -106,11 +36,11 @@ class _AddressSearchPageState extends State<AddressSearchPage> {
                 fontWeight: FontWeight.w700,
               ),
             ),
-            CommonSearchTextField(
-              controller: _searchController,
-              hintText: '주소를 입력해 주세요.',
-              horizontalPadding: AppSpacing.x20,
-              onChanged: (_) => setState(() {}),
+            AddressSearchField(
+              initialQuery: searchState.query,
+              onChanged: ref
+                  .read(addressSearchControllerProvider.notifier)
+                  .updateQuery,
             ),
             const SizedBox(height: _addressSearchResultGap),
             Expanded(
@@ -118,11 +48,11 @@ class _AddressSearchPageState extends State<AddressSearchPage> {
                 padding: const EdgeInsets.only(
                   bottom: AppSpacing.x40 + AppSizes.navigationBarHeight,
                 ),
-                itemCount: results.length,
+                itemCount: searchState.results.length,
                 separatorBuilder: (_, _) =>
                     const SizedBox(height: _addressSearchResultGap),
                 itemBuilder: (context, index) {
-                  final result = results[index];
+                  final result = searchState.results[index];
 
                   return _AddressSearchResultTile(
                     result: result,
@@ -144,7 +74,7 @@ class _AddressSearchResultTile extends StatelessWidget {
     required this.onSelect,
   });
 
-  final _AddressSearchResult result;
+  final AddressSearchResult result;
   final VoidCallback onSelect;
 
   @override
@@ -192,7 +122,7 @@ class _AddressSearchResultTile extends StatelessWidget {
 class _AddressSearchResultTitle extends StatelessWidget {
   const _AddressSearchResultTitle({required this.result});
 
-  final _AddressSearchResult result;
+  final AddressSearchResult result;
 
   @override
   Widget build(BuildContext context) {
@@ -251,20 +181,4 @@ class _AddressSearchSelectButton extends StatelessWidget {
       ),
     );
   }
-}
-
-class _AddressSearchResult {
-  const _AddressSearchResult({
-    required this.titlePrefix,
-    required this.titleSuffix,
-    required this.address,
-    this.highlighted = false,
-  });
-
-  final String titlePrefix;
-  final String titleSuffix;
-  final String address;
-  final bool highlighted;
-
-  String get title => '$titlePrefix $titleSuffix';
 }

--- a/lib/features/place/presentation/providers/address_search_controller.dart
+++ b/lib/features/place/presentation/providers/address_search_controller.dart
@@ -1,0 +1,49 @@
+import 'package:commonplant_frontend/features/place/presentation/fixtures/address_search_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/address_search_result.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const String initialAddressSearchQuery = '신도림역';
+
+final addressSearchControllerProvider =
+    NotifierProvider.autoDispose<AddressSearchController, AddressSearchState>(
+      AddressSearchController.new,
+    );
+
+class AddressSearchState {
+  const AddressSearchState({required this.query, required this.results});
+
+  final String query;
+  final List<AddressSearchResult> results;
+}
+
+class AddressSearchController extends Notifier<AddressSearchState> {
+  @override
+  AddressSearchState build() {
+    return AddressSearchState(
+      query: initialAddressSearchQuery,
+      results: _matchingAddresses(initialAddressSearchQuery),
+    );
+  }
+
+  void updateQuery(String query) {
+    state = AddressSearchState(
+      query: query,
+      results: _matchingAddresses(query),
+    );
+  }
+
+  List<AddressSearchResult> _matchingAddresses(String value) {
+    final query = value.trim();
+
+    if (query.isEmpty) {
+      return addressSearchFixture;
+    }
+
+    return List.unmodifiable(
+      addressSearchFixture.where(
+        (result) =>
+            result.title.contains(query) || result.address.contains(query),
+      ),
+    );
+  }
+}

--- a/lib/features/place/presentation/widgets/address_search_field.dart
+++ b/lib/features/place/presentation/widgets/address_search_field.dart
@@ -1,0 +1,43 @@
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
+import 'package:flutter/material.dart';
+
+class AddressSearchField extends StatefulWidget {
+  const AddressSearchField({
+    required this.initialQuery,
+    required this.onChanged,
+    super.key,
+  });
+
+  final String initialQuery;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<AddressSearchField> createState() => _AddressSearchFieldState();
+}
+
+class _AddressSearchFieldState extends State<AddressSearchField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialQuery);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CommonSearchTextField(
+      controller: _controller,
+      hintText: '주소를 입력해 주세요.',
+      horizontalPadding: AppSpacing.x20,
+      onChanged: widget.onChanged,
+    );
+  }
+}

--- a/lib/features/plant/presentation/fixtures/plant_search_fixture.dart
+++ b/lib/features/plant/presentation/fixtures/plant_search_fixture.dart
@@ -1,0 +1,8 @@
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_candidate.dart';
+
+const List<PlantCandidate> plantSearchFixture = [
+  PlantCandidate(name: '몬스테라 델리오사'),
+  PlantCandidate(name: '몬스테라 알보 바리에가타'),
+  PlantCandidate(name: '몬스테라 보르시지아나'),
+  PlantCandidate(name: '무늬 몬스테라'),
+];

--- a/lib/features/plant/presentation/models/plant_candidate.dart
+++ b/lib/features/plant/presentation/models/plant_candidate.dart
@@ -1,0 +1,5 @@
+class PlantCandidate {
+  const PlantCandidate({required this.name});
+
+  final String name;
+}

--- a/lib/features/plant/presentation/pages/plant_search_page.dart
+++ b/lib/features/plant/presentation/pages/plant_search_page.dart
@@ -3,38 +3,20 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_candidate.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_search_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class PlantSearchPage extends StatefulWidget {
+class PlantSearchPage extends ConsumerWidget {
   const PlantSearchPage({super.key});
 
   @override
-  State<PlantSearchPage> createState() => _PlantSearchPageState();
-}
-
-class _PlantSearchPageState extends State<PlantSearchPage> {
-  final TextEditingController _searchController = TextEditingController();
-
-  static const List<_PlantCandidate> _plants = [
-    _PlantCandidate(name: '몬스테라 델리오사'),
-    _PlantCandidate(name: '몬스테라 알보 바리에가타'),
-    _PlantCandidate(name: '몬스테라 보르시지아나'),
-    _PlantCandidate(name: '무늬 몬스테라'),
-  ];
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final hasQuery = _normalize(_searchController.text).isNotEmpty;
-    final results = _matchingPlants(_searchController.text);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchState = ref.watch(plantSearchControllerProvider);
 
     return CommonScaffold(
       title: '식물 등록  (1/2)',
@@ -49,16 +31,17 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             CommonSearchTextField(
-              controller: _searchController,
               hintText: '식물을 입력해 주세요.',
               horizontalPadding: AppSpacing.x20,
               iconTextSpacing: AppSpacing.x12,
-              onChanged: (_) => setState(() {}),
+              onChanged: ref
+                  .read(plantSearchControllerProvider.notifier)
+                  .updateQuery,
             ),
-            if (results.isNotEmpty) ...[
+            if (searchState.results.isNotEmpty) ...[
               const SizedBox(height: AppSpacing.x8),
               _PlantSearchResultList(
-                plants: results,
+                plants: searchState.results,
                 onSelected: (plant) => context.push(
                   Uri(
                     path: AppRoutePaths.plantCreateDetails,
@@ -66,28 +49,12 @@ class _PlantSearchPageState extends State<PlantSearchPage> {
                   ).toString(),
                 ),
               ),
-            ] else if (hasQuery)
+            ] else if (searchState.hasQuery)
               const _PlantSearchEmptyState(),
           ],
         ),
       ),
     );
-  }
-
-  List<_PlantCandidate> _matchingPlants(String value) {
-    final query = _normalize(value);
-
-    if (query.isEmpty) {
-      return const [];
-    }
-
-    return _plants
-        .where((plant) => _normalize(plant.name).contains(query))
-        .toList(growable: false);
-  }
-
-  String _normalize(String value) {
-    return value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
   }
 }
 
@@ -97,8 +64,8 @@ class _PlantSearchResultList extends StatelessWidget {
     required this.onSelected,
   });
 
-  final List<_PlantCandidate> plants;
-  final ValueChanged<_PlantCandidate> onSelected;
+  final List<PlantCandidate> plants;
+  final ValueChanged<PlantCandidate> onSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -122,7 +89,7 @@ class _PlantSearchResultTile extends StatelessWidget {
     required this.onTap,
   });
 
-  final _PlantCandidate plant;
+  final PlantCandidate plant;
   final bool isHighlighted;
   final VoidCallback onTap;
 
@@ -188,10 +155,4 @@ class _PlantSearchEmptyState extends StatelessWidget {
       ),
     );
   }
-}
-
-class _PlantCandidate {
-  const _PlantCandidate({required this.name});
-
-  final String name;
 }

--- a/lib/features/plant/presentation/providers/plant_search_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_search_controller.dart
@@ -1,0 +1,46 @@
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_search_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_candidate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantSearchControllerProvider =
+    NotifierProvider.autoDispose<PlantSearchController, PlantSearchState>(
+      PlantSearchController.new,
+    );
+
+class PlantSearchState {
+  const PlantSearchState({required this.query, required this.results});
+
+  final String query;
+  final List<PlantCandidate> results;
+
+  bool get hasQuery => _normalize(query).isNotEmpty;
+}
+
+class PlantSearchController extends Notifier<PlantSearchState> {
+  @override
+  PlantSearchState build() {
+    return const PlantSearchState(query: '', results: []);
+  }
+
+  void updateQuery(String query) {
+    state = PlantSearchState(query: query, results: _matchingPlants(query));
+  }
+
+  List<PlantCandidate> _matchingPlants(String value) {
+    final query = _normalize(value);
+
+    if (query.isEmpty) {
+      return const [];
+    }
+
+    return List.unmodifiable(
+      plantSearchFixture.where(
+        (plant) => _normalize(plant.name).contains(query),
+      ),
+    );
+  }
+}
+
+String _normalize(String value) {
+  return value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
+}

--- a/test/features/place/presentation/pages/address_search_page_test.dart
+++ b/test/features/place/presentation/pages/address_search_page_test.dart
@@ -1,12 +1,15 @@
 import 'package:commonplant_frontend/features/place/presentation/pages/address_search_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('주소 검색 화면은 Figma 기준 검색어와 결과 목록을 표시한다', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(const MaterialApp(home: AddressSearchPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: AddressSearchPage())),
+    );
 
     expect(find.text('주소 검색'), findsOneWidget);
     expect(find.text('신도림역'), findsOneWidget);
@@ -26,23 +29,25 @@ void main() {
     final navigatorKey = GlobalKey<NavigatorState>();
 
     await tester.pumpWidget(
-      MaterialApp(
-        navigatorKey: navigatorKey,
-        home: Builder(
-          builder: (context) {
-            return Scaffold(
-              body: TextButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => const AddressSearchPage(),
-                    ),
-                  );
-                },
-                child: const Text('주소 검색 열기'),
-              ),
-            );
-          },
+      ProviderScope(
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const AddressSearchPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('주소 검색 열기'),
+                ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/test/features/place/presentation/providers/address_search_controller_test.dart
+++ b/test/features/place/presentation/providers/address_search_controller_test.dart
@@ -1,0 +1,40 @@
+import 'package:commonplant_frontend/features/place/presentation/providers/address_search_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('주소 검색은 초기 검색어와 결과를 제공한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final state = container.read(addressSearchControllerProvider);
+
+    expect(state.query, initialAddressSearchQuery);
+    expect(state.results, isNotEmpty);
+    expect(state.results.first.title, '신도림역 1호선');
+  });
+
+  test('주소나 장소명으로 검색 결과를 필터링한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(addressSearchControllerProvider.notifier).updateQuery('경인로');
+
+    final state = container.read(addressSearchControllerProvider);
+    expect(state.query, '경인로');
+    expect(state.results, hasLength(1));
+    expect(state.results.single.address, '서울 구로구 경인로 688');
+  });
+
+  test('빈 검색어는 주소 전체 목록을 보여준다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(addressSearchControllerProvider.notifier).updateQuery(' ');
+
+    expect(
+      container.read(addressSearchControllerProvider).results,
+      hasLength(9),
+    );
+  });
+}

--- a/test/features/plant/presentation/pages/plant_search_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_search_page_test.dart
@@ -8,7 +8,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('식물 등록 검색 전에는 결과를 표시하지 않는다', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantSearchPage())),
+    );
 
     expect(find.text('식물 등록  (1/2)'), findsOneWidget);
     expect(find.text('식물을 입력해 주세요.'), findsOneWidget);
@@ -17,7 +19,9 @@ void main() {
   });
 
   testWidgets('식물 검색어를 입력하면 Figma 기준 결과 목록을 표시한다', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantSearchPage())),
+    );
 
     await tester.enterText(find.byType(TextField), '몬스테라');
     await tester.pump();
@@ -30,7 +34,9 @@ void main() {
   });
 
   testWidgets('식물 검색 결과가 없으면 빈 상태 안내를 표시한다', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantSearchPage())),
+    );
 
     await tester.enterText(find.byType(TextField), '선인장');
     await tester.pump();
@@ -62,7 +68,9 @@ void main() {
   });
 
   testWidgets('검색어 삭제를 누르면 결과 목록을 닫는다', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: PlantSearchPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantSearchPage())),
+    );
 
     await tester.enterText(find.byType(TextField), '몬스테라');
     await tester.pump();

--- a/test/features/plant/presentation/providers/plant_search_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_search_controller_test.dart
@@ -1,0 +1,39 @@
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_search_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('식물 검색 초기 상태는 결과를 보여주지 않는다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final state = container.read(plantSearchControllerProvider);
+
+    expect(state.hasQuery, isFalse);
+    expect(state.results, isEmpty);
+  });
+
+  test('공백을 제거하고 식물 이름을 검색한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(plantSearchControllerProvider.notifier).updateQuery('몬스 테라');
+
+    final state = container.read(plantSearchControllerProvider);
+    expect(state.hasQuery, isTrue);
+    expect(state.results, hasLength(4));
+  });
+
+  test('검색어를 비우면 결과를 초기화한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(plantSearchControllerProvider.notifier);
+
+    controller.updateQuery('몬스테라');
+    controller.updateQuery('');
+
+    final state = container.read(plantSearchControllerProvider);
+    expect(state.hasQuery, isFalse);
+    expect(state.results, isEmpty);
+  });
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #170
- Parent: #165
- 계획 문서 PR: #167

## 구현 범위

- `AddressSearchPage`와 `PlantSearchPage`를 `ConsumerWidget`으로 전환
- 검색어와 필터 결과를 화면별 auto-dispose `NotifierProvider`로 이동
- 검색 결과 model과 mock fixture를 page에서 분리
- 주소 검색의 `TextEditingController`만 작은 leaf 위젯에서 관리
- Controller 단위 테스트와 기존 widget test 보강

## 주요 변경사항

- route page의 `setState`와 `TextEditingController` 소유를 제거했습니다.
- 검색 상태는 immutable state와 Controller를 통해 한 방향으로 갱신됩니다.
- Provider는 `BuildContext`나 Flutter 위젯 객체를 소유하지 않습니다.
- 이 브랜치 기준 feature route/page StatefulWidget 수가 11개에서 9개로 감소했습니다.

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- 검색 Controller/page 대상 테스트 13개
- `fvm flutter test` 전체 193개

모든 검증을 통과했습니다.

## 리뷰 포인트

- 검색 state와 fixture/model의 책임 분리가 읽기 쉬운지
- 주소 검색의 lifecycle state를 leaf 위젯에만 남긴 경계가 적절한지
- 검색/삭제/화면 이동 동작이 기존과 동일한지

## 문서 반영

- Riverpod 우선 원칙과 3차 실행 계획은 #167에서 별도로 리뷰 중입니다.

## Breaking change

- 없음
