### PR TITLE
Refactor: 장소 친구 상태 Riverpod 전환 #172

### DIFF
--- a/lib/features/place/presentation/fixtures/friend_management_fixture.dart
+++ b/lib/features/place/presentation/fixtures/friend_management_fixture.dart
@@ -1,0 +1,11 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+
+const List<PlaceFriendProfile> friendManagementFixture = [
+  PlaceFriendProfile(
+    id: 'friend-1',
+    name: '커먼맘',
+    imageAsset: AppImageAssets.placeFriendAddCommonMom,
+  ),
+  PlaceFriendProfile(id: 'friend-2', name: '커먼 파파'),
+];

--- a/lib/features/place/presentation/fixtures/place_friend_fixture.dart
+++ b/lib/features/place/presentation/fixtures/place_friend_fixture.dart
@@ -1,6 +1,5 @@
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
-import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
 
 const List<PlaceFriendProfile> placeFriendFixture = <PlaceFriendProfile>[
   PlaceFriendProfile(
@@ -25,9 +24,3 @@ const List<PlaceFriendProfile> placeFriendFixture = <PlaceFriendProfile>[
   ),
   PlaceFriendProfile(id: 'friend-5', name: '커먼 파파'),
 ];
-
-List<PlaceFriendProfile> placeFriendsFromUsers(List<UserProfile> users) {
-  return [
-    for (final user in users) PlaceFriendProfile(id: user.id, name: user.name),
-  ];
-}

--- a/lib/features/place/presentation/pages/friend_management_page.dart
+++ b/lib/features/place/presentation/pages/friend_management_page.dart
@@ -1,9 +1,9 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/friend_management_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_bottom_actions.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_candidate_list.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selected_strip.dart';
@@ -11,56 +11,38 @@ import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 const double _friendManagementSelectedMarkHeight = 57;
 const double _friendManagementSelectedMarkGap = 4;
 
-class FriendManagementPage extends StatefulWidget {
+class FriendManagementPage extends ConsumerWidget {
   const FriendManagementPage({super.key, required this.placeId});
 
   final String placeId;
 
-  @override
-  State<FriendManagementPage> createState() => _FriendManagementPageState();
-}
-
-class _FriendManagementPageState extends State<FriendManagementPage> {
-  final TextEditingController _searchController = TextEditingController();
-  final Set<String> _selectedIds = <String>{'friend-1', 'friend-2'};
-
-  static const List<PlaceFriendProfile> _friends = [
-    PlaceFriendProfile(
-      id: 'friend-1',
-      name: '커먼맘',
-      imageAsset: AppImageAssets.placeFriendAddCommonMom,
-    ),
-    PlaceFriendProfile(id: 'friend-2', name: '커먼 파파'),
-  ];
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  void _toggleFriend(String friendId) {
-    final friend = _friends.firstWhere((friend) => friend.id == friendId);
-
-    if (_selectedIds.contains(friendId)) {
-      _showDeleteDialog(friend);
+  void _toggleFriend(
+    BuildContext context,
+    WidgetRef ref,
+    FriendManagementState state,
+    PlaceFriendProfile friend,
+  ) {
+    if (state.isSelected(friend.id)) {
+      _showDeleteDialog(context, ref, friend);
       return;
     }
 
-    setState(() => _selectedIds.add(friendId));
+    ref
+        .read(friendManagementControllerProvider(placeId).notifier)
+        .select(friend);
   }
 
-  void _removeFriend(String friendId) {
-    final friend = _friends.firstWhere((friend) => friend.id == friendId);
-    _showDeleteDialog(friend);
-  }
-
-  void _showDeleteDialog(PlaceFriendProfile friend) {
+  void _showDeleteDialog(
+    BuildContext context,
+    WidgetRef ref,
+    PlaceFriendProfile friend,
+  ) {
     showCommonDialog<void>(
       context: context,
       barrierColor: AppColors.textHeadline.withValues(alpha: 0.6),
@@ -76,7 +58,9 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
           CommonDialogActionButton.confirm(
             label: '삭제',
             onPressed: () {
-              setState(() => _selectedIds.remove(friend.id));
+              ref
+                  .read(friendManagementControllerProvider(placeId).notifier)
+                  .remove(friend);
               Navigator.of(context).pop();
             },
           ),
@@ -85,7 +69,7 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
     );
   }
 
-  void _leavePage() {
+  void _leavePage(BuildContext context) {
     final navigator = Navigator.of(context);
 
     if (navigator.canPop()) {
@@ -98,23 +82,19 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
       return;
     }
 
-    if (widget.placeId.isEmpty) {
+    if (placeId.isEmpty) {
       router.go(AppRoutePaths.home);
       return;
     }
 
-    router.go(AppRoutePaths.placeDetailLocation(widget.placeId));
+    router.go(AppRoutePaths.placeDetailLocation(placeId));
   }
 
   @override
-  Widget build(BuildContext context) {
-    final query = _searchController.text.trim();
-    final results = query.isEmpty
-        ? _friends
-        : _friends.where((friend) => friend.name.contains(query)).toList();
-    final selectedFriends = _friends
-        .where((friend) => _selectedIds.contains(friend.id))
-        .toList();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = friendManagementControllerProvider(placeId);
+    final state = ref.watch(provider);
+    final controller = ref.read(provider.notifier);
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -131,10 +111,10 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
                   fontWeight: FontWeight.w700,
                 ),
               ),
-              if (selectedFriends.isNotEmpty)
+              if (state.selectedFriends.isNotEmpty)
                 PlaceSelectedFriendMarkStrip(
-                  friends: selectedFriends,
-                  onRemove: _removeFriend,
+                  friends: state.selectedFriends,
+                  onRemove: (friend) => _showDeleteDialog(context, ref, friend),
                   padding: const EdgeInsets.fromLTRB(
                     AppSpacing.x20,
                     AppSpacing.x16,
@@ -145,22 +125,22 @@ class _FriendManagementPageState extends State<FriendManagementPage> {
                   separatorWidth: _friendManagementSelectedMarkGap,
                 ),
               CommonSearchTextField(
-                controller: _searchController,
                 hintText: '닉네임 검색',
                 horizontalPadding: AppSpacing.x16,
-                onChanged: (_) => setState(() {}),
+                onChanged: controller.updateQuery,
               ),
               Expanded(
                 child: PlaceFriendCandidateList(
-                  friends: results,
-                  selectedIds: _selectedIds,
+                  friends: state.results,
+                  selectedIds: state.selectedIds,
                   topPadding: 0,
-                  onToggle: _toggleFriend,
+                  onToggle: (friend) =>
+                      _toggleFriend(context, ref, state, friend),
                 ),
               ),
               PlaceFriendBottomActions(
-                onCancel: _leavePage,
-                onComplete: _leavePage,
+                onCancel: () => _leavePage(context),
+                onComplete: () => _leavePage(context),
               ),
             ],
           ),

--- a/lib/features/place/presentation/pages/place_friend_add_page.dart
+++ b/lib/features/place/presentation/pages/place_friend_add_page.dart
@@ -1,16 +1,14 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/place/presentation/fixtures/place_friend_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_friend_selection_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_bottom_actions.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_candidate_list.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_search_status_view.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_selected_strip.dart';
-import 'package:commonplant_frontend/features/user/presentation/providers/user_search_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:commonplant_frontend/shared/widgets/common_search_text_field.dart';
 import 'package:flutter/material.dart';
@@ -19,49 +17,10 @@ import 'package:go_router/go_router.dart';
 
 const double _friendAddTrailingWidth = 81;
 
-class PlaceFriendAddPage extends ConsumerStatefulWidget {
+class PlaceFriendAddPage extends ConsumerWidget {
   const PlaceFriendAddPage({super.key});
 
-  @override
-  ConsumerState<PlaceFriendAddPage> createState() => _PlaceFriendAddPageState();
-}
-
-class _PlaceFriendAddPageState extends ConsumerState<PlaceFriendAddPage> {
-  final TextEditingController _searchController = TextEditingController();
-  final Set<String> _selectedIds = <String>{};
-  final Map<String, PlaceFriendProfile> _remoteSelectedFriends =
-      <String, PlaceFriendProfile>{};
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  void _toggle(String id) {
-    setState(() {
-      if (_selectedIds.contains(id)) {
-        _selectedIds.remove(id);
-        _remoteSelectedFriends.remove(id);
-      } else {
-        _selectedIds.add(id);
-      }
-    });
-  }
-
-  void _toggleRemote(PlaceFriendProfile friend) {
-    setState(() {
-      if (_selectedIds.contains(friend.id)) {
-        _selectedIds.remove(friend.id);
-        _remoteSelectedFriends.remove(friend.id);
-      } else {
-        _selectedIds.add(friend.id);
-        _remoteSelectedFriends[friend.id] = friend;
-      }
-    });
-  }
-
-  void _cancel() {
+  void _cancel(BuildContext context) {
     final navigator = Navigator.of(context);
 
     if (navigator.canPop()) {
@@ -72,24 +31,17 @@ class _PlaceFriendAddPageState extends ConsumerState<PlaceFriendAddPage> {
     context.go(AppRoutePaths.home);
   }
 
-  void _complete() {
+  void _complete(BuildContext context) {
     context.go(AppRoutePaths.home);
   }
 
   @override
-  Widget build(BuildContext context) {
-    final query = _searchController.text.trim();
-    final useRemoteApi = ref.watch(useRemoteApiProvider);
-    final localResults = query.isEmpty
-        ? const <PlaceFriendProfile>[]
-        : placeFriendFixture
-              .where((friend) => friend.name.contains(query))
-              .toList();
-    final selectedFriends = useRemoteApi
-        ? _remoteSelectedFriends.values.toList()
-        : placeFriendFixture
-              .where((friend) => _selectedIds.contains(friend.id))
-              .toList();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectionState = ref.watch(placeFriendSelectionControllerProvider);
+    final searchState = ref.watch(placeFriendSearchProvider);
+    final controller = ref.read(
+      placeFriendSelectionControllerProvider.notifier,
+    );
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -105,35 +57,31 @@ class _PlaceFriendAddPageState extends ConsumerState<PlaceFriendAddPage> {
                   color: AppColors.textStrong,
                   fontWeight: FontWeight.w700,
                 ),
-                trailing: _FriendAddSkipButton(onPressed: _complete),
+                trailing: _FriendAddSkipButton(
+                  onPressed: () => _complete(context),
+                ),
               ),
-              if (selectedFriends.isNotEmpty)
+              if (selectionState.selectedFriends.isNotEmpty)
                 PlaceSelectedFriendMarkStrip(
-                  friends: selectedFriends,
-                  onRemove: _toggle,
+                  friends: selectionState.selectedFriends,
+                  onRemove: controller.remove,
                 ),
               CommonSearchTextField(
-                controller: _searchController,
                 hintText: '닉네임 검색',
                 horizontalPadding: AppSpacing.x16,
-                onChanged: (_) => setState(() {}),
+                onChanged: controller.updateQuery,
               ),
               Expanded(
-                child: useRemoteApi
-                    ? _RemoteFriendCandidateList(
-                        query: query,
-                        selectedIds: _selectedIds,
-                        onToggle: _toggleRemote,
-                      )
-                    : PlaceFriendCandidateList(
-                        friends: localResults,
-                        selectedIds: _selectedIds,
-                        onToggle: _toggle,
-                      ),
+                child: _FriendCandidateResults(
+                  searchState: searchState,
+                  selectedIds: selectionState.selectedIds,
+                  onToggle: controller.toggle,
+                  onRetry: controller.retrySearch,
+                ),
               ),
               PlaceFriendBottomActions(
-                onCancel: _cancel,
-                onComplete: _complete,
+                onCancel: () => _cancel(context),
+                onComplete: () => _complete(context),
               ),
             ],
           ),
@@ -143,30 +91,28 @@ class _PlaceFriendAddPageState extends ConsumerState<PlaceFriendAddPage> {
   }
 }
 
-class _RemoteFriendCandidateList extends ConsumerWidget {
-  const _RemoteFriendCandidateList({
-    required this.query,
+class _FriendCandidateResults extends StatelessWidget {
+  const _FriendCandidateResults({
+    required this.searchState,
     required this.selectedIds,
     required this.onToggle,
+    required this.onRetry,
   });
 
-  final String query;
+  final PlaceFriendSearchState searchState;
   final Set<String> selectedIds;
   final ValueChanged<PlaceFriendProfile> onToggle;
+  final VoidCallback onRetry;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    if (query.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    final users = ref.watch(userSearchProvider(query));
-
-    return users.when(
-      data: (items) {
-        final friends = placeFriendsFromUsers(items);
-
+  Widget build(BuildContext context) {
+    return searchState.result.when(
+      data: (friends) {
         if (friends.isEmpty) {
+          if (!searchState.showEmptyState) {
+            return const SizedBox.shrink();
+          }
+
           return const PlaceFriendSearchStatusView(
             title: '검색 결과가 없어요',
             message: '다른 닉네임으로 검색해 주세요',
@@ -176,17 +122,14 @@ class _RemoteFriendCandidateList extends ConsumerWidget {
         return PlaceFriendCandidateList(
           friends: friends,
           selectedIds: selectedIds,
-          onToggle: (id) {
-            final friend = friends.firstWhere((friend) => friend.id == id);
-            onToggle(friend);
-          },
+          onToggle: onToggle,
         );
       },
       error: (error, stackTrace) => PlaceFriendSearchStatusView(
         title: '사용자 검색에 실패했어요',
         message: '잠시 후 다시 시도해 주세요',
         actionLabel: '다시 시도',
-        onAction: () => ref.invalidate(userSearchProvider(query)),
+        onAction: onRetry,
       ),
       loading: () => const PlaceFriendSearchStatusView(
         title: '사용자를 검색하고 있어요',

--- a/lib/features/place/presentation/pages/place_invitations_page.dart
+++ b/lib/features/place/presentation/pages/place_invitations_page.dart
@@ -1,30 +1,22 @@
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_invitation_fixture.dart';
-import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_invitation_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_invitation_list_item.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const double _invitationItemGap = 24;
 
-class PlaceInvitationsPage extends StatefulWidget {
+class PlaceInvitationsPage extends ConsumerWidget {
   const PlaceInvitationsPage({super.key});
 
   @override
-  State<PlaceInvitationsPage> createState() => _PlaceInvitationsPageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(placeInvitationControllerProvider);
+    final controller = ref.read(placeInvitationControllerProvider.notifier);
 
-class _PlaceInvitationsPageState extends State<PlaceInvitationsPage> {
-  final Map<String, PlaceInvitationResult> _results =
-      <String, PlaceInvitationResult>{};
-
-  void _setResult(String id, PlaceInvitationResult result) {
-    setState(() => _results[id] = result);
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return CommonScaffold(
       title: '장소 친구 요청',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -37,11 +29,9 @@ class _PlaceInvitationsPageState extends State<PlaceInvitationsPage> {
           for (final invitation in placeInvitationFixture) ...[
             PlaceInvitationListItem(
               invitation: invitation,
-              result: _results[invitation.id],
-              onAccept: () =>
-                  _setResult(invitation.id, PlaceInvitationResult.accepted),
-              onDelete: () =>
-                  _setResult(invitation.id, PlaceInvitationResult.deleted),
+              result: state.resultFor(invitation.id),
+              onAccept: () => controller.accept(invitation.id),
+              onDelete: () => controller.delete(invitation.id),
             ),
             if (invitation.id != placeInvitationFixture.last.id)
               const SizedBox(height: _invitationItemGap),

--- a/lib/features/place/presentation/providers/friend_management_controller.dart
+++ b/lib/features/place/presentation/providers/friend_management_controller.dart
@@ -1,0 +1,86 @@
+import 'package:commonplant_frontend/features/place/presentation/fixtures/friend_management_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final friendManagementControllerProvider = NotifierProvider.autoDispose
+    .family<FriendManagementController, FriendManagementState, String>(
+      FriendManagementController.new,
+    );
+
+class FriendManagementState {
+  const FriendManagementState({
+    required this.placeId,
+    required this.query,
+    required this.selectedIds,
+  });
+
+  final String placeId;
+  final String query;
+  final Set<String> selectedIds;
+
+  List<PlaceFriendProfile> get results {
+    if (query.isEmpty) {
+      return friendManagementFixture;
+    }
+
+    return List.unmodifiable(
+      friendManagementFixture.where((friend) => friend.name.contains(query)),
+    );
+  }
+
+  List<PlaceFriendProfile> get selectedFriends => List.unmodifiable(
+    friendManagementFixture.where((friend) => selectedIds.contains(friend.id)),
+  );
+
+  bool isSelected(String friendId) {
+    return selectedIds.contains(friendId);
+  }
+
+  FriendManagementState copyWith({String? query, Set<String>? selectedIds}) {
+    return FriendManagementState(
+      placeId: placeId,
+      query: query ?? this.query,
+      selectedIds: selectedIds ?? this.selectedIds,
+    );
+  }
+}
+
+class FriendManagementController extends Notifier<FriendManagementState> {
+  FriendManagementController(this.placeId);
+
+  final String placeId;
+
+  @override
+  FriendManagementState build() {
+    return FriendManagementState(
+      placeId: placeId,
+      query: '',
+      selectedIds: Set.unmodifiable(
+        friendManagementFixture.map((friend) => friend.id),
+      ),
+    );
+  }
+
+  void updateQuery(String query) {
+    state = state.copyWith(query: query.trim());
+  }
+
+  void select(PlaceFriendProfile friend) {
+    if (state.isSelected(friend.id)) {
+      return;
+    }
+
+    state = state.copyWith(
+      selectedIds: Set.unmodifiable({...state.selectedIds, friend.id}),
+    );
+  }
+
+  void remove(PlaceFriendProfile friend) {
+    if (!state.isSelected(friend.id)) {
+      return;
+    }
+
+    final selectedIds = Set<String>.of(state.selectedIds)..remove(friend.id);
+    state = state.copyWith(selectedIds: Set.unmodifiable(selectedIds));
+  }
+}

--- a/lib/features/place/presentation/providers/place_friend_selection_controller.dart
+++ b/lib/features/place/presentation/providers/place_friend_selection_controller.dart
@@ -1,0 +1,150 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_friend_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/user_search_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeFriendSelectionControllerProvider =
+    NotifierProvider.autoDispose<
+      PlaceFriendSelectionController,
+      PlaceFriendSelectionState
+    >(PlaceFriendSelectionController.new);
+
+final placeFriendSearchProvider = Provider.autoDispose<PlaceFriendSearchState>((
+  ref,
+) {
+  final query = ref.watch(
+    placeFriendSelectionControllerProvider.select((state) => state.query),
+  );
+
+  if (query.isEmpty) {
+    return const PlaceFriendSearchState.idle();
+  }
+
+  if (!ref.watch(useRemoteApiProvider)) {
+    final friends = placeFriendFixture
+        .where((friend) => friend.name.contains(query))
+        .toList(growable: false);
+
+    return PlaceFriendSearchState.local(friends);
+  }
+
+  final result = ref
+      .watch(userSearchProvider(query))
+      .whenData(
+        (users) => List<PlaceFriendProfile>.unmodifiable(
+          users.map((user) => PlaceFriendProfile(id: user.id, name: user.name)),
+        ),
+      );
+
+  return PlaceFriendSearchState.remote(result);
+});
+
+class PlaceFriendSelectionState {
+  const PlaceFriendSelectionState({
+    required this.query,
+    required this.selectedFriendsById,
+  });
+
+  const PlaceFriendSelectionState.initial()
+    : query = '',
+      selectedFriendsById = const {};
+
+  final String query;
+  final Map<String, PlaceFriendProfile> selectedFriendsById;
+
+  Set<String> get selectedIds => Set.unmodifiable(selectedFriendsById.keys);
+
+  List<PlaceFriendProfile> get selectedFriends =>
+      List.unmodifiable(selectedFriendsById.values);
+
+  bool isSelected(String friendId) {
+    return selectedFriendsById.containsKey(friendId);
+  }
+
+  PlaceFriendSelectionState copyWith({
+    String? query,
+    Map<String, PlaceFriendProfile>? selectedFriendsById,
+  }) {
+    return PlaceFriendSelectionState(
+      query: query ?? this.query,
+      selectedFriendsById: selectedFriendsById ?? this.selectedFriendsById,
+    );
+  }
+}
+
+class PlaceFriendSearchState {
+  const PlaceFriendSearchState._({
+    required this.result,
+    required this.showEmptyState,
+  });
+
+  const PlaceFriendSearchState.idle()
+    : this._(
+        result: const AsyncData<List<PlaceFriendProfile>>([]),
+        showEmptyState: false,
+      );
+
+  PlaceFriendSearchState.local(List<PlaceFriendProfile> friends)
+    : this._(
+        result: AsyncData(List.unmodifiable(friends)),
+        showEmptyState: false,
+      );
+
+  const PlaceFriendSearchState.remote(
+    AsyncValue<List<PlaceFriendProfile>> result,
+  ) : this._(result: result, showEmptyState: true);
+
+  final AsyncValue<List<PlaceFriendProfile>> result;
+  final bool showEmptyState;
+}
+
+class PlaceFriendSelectionController
+    extends Notifier<PlaceFriendSelectionState> {
+  @override
+  PlaceFriendSelectionState build() {
+    return const PlaceFriendSelectionState.initial();
+  }
+
+  void updateQuery(String query) {
+    state = state.copyWith(query: query.trim());
+  }
+
+  void toggle(PlaceFriendProfile friend) {
+    final selectedFriends = Map<String, PlaceFriendProfile>.of(
+      state.selectedFriendsById,
+    );
+
+    if (selectedFriends.containsKey(friend.id)) {
+      selectedFriends.remove(friend.id);
+    } else {
+      selectedFriends[friend.id] = friend;
+    }
+
+    state = state.copyWith(
+      selectedFriendsById: Map.unmodifiable(selectedFriends),
+    );
+  }
+
+  void remove(PlaceFriendProfile friend) {
+    if (!state.isSelected(friend.id)) {
+      return;
+    }
+
+    final selectedFriends = Map<String, PlaceFriendProfile>.of(
+      state.selectedFriendsById,
+    )..remove(friend.id);
+
+    state = state.copyWith(
+      selectedFriendsById: Map.unmodifiable(selectedFriends),
+    );
+  }
+
+  void retrySearch() {
+    if (state.query.isEmpty) {
+      return;
+    }
+
+    ref.invalidate(userSearchProvider(state.query));
+  }
+}

--- a/lib/features/place/presentation/providers/place_invitation_controller.dart
+++ b/lib/features/place/presentation/providers/place_invitation_controller.dart
@@ -1,0 +1,41 @@
+import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeInvitationControllerProvider =
+    NotifierProvider.autoDispose<
+      PlaceInvitationController,
+      PlaceInvitationState
+    >(PlaceInvitationController.new);
+
+class PlaceInvitationState {
+  const PlaceInvitationState({required this.results});
+
+  const PlaceInvitationState.initial() : results = const {};
+
+  final Map<String, PlaceInvitationResult> results;
+
+  PlaceInvitationResult? resultFor(String invitationId) {
+    return results[invitationId];
+  }
+}
+
+class PlaceInvitationController extends Notifier<PlaceInvitationState> {
+  @override
+  PlaceInvitationState build() {
+    return const PlaceInvitationState.initial();
+  }
+
+  void accept(String invitationId) {
+    _setResult(invitationId, PlaceInvitationResult.accepted);
+  }
+
+  void delete(String invitationId) {
+    _setResult(invitationId, PlaceInvitationResult.deleted);
+  }
+
+  void _setResult(String invitationId, PlaceInvitationResult result) {
+    state = PlaceInvitationState(
+      results: Map.unmodifiable({...state.results, invitationId: result}),
+    );
+  }
+}

--- a/lib/features/place/presentation/widgets/place_friend_candidate_list.dart
+++ b/lib/features/place/presentation/widgets/place_friend_candidate_list.dart
@@ -20,7 +20,7 @@ class PlaceFriendCandidateList extends StatelessWidget {
 
   final List<PlaceFriendProfile> friends;
   final Set<String> selectedIds;
-  final ValueChanged<String> onToggle;
+  final ValueChanged<PlaceFriendProfile> onToggle;
   final double topPadding;
   final double bottomPadding;
 
@@ -41,7 +41,7 @@ class PlaceFriendCandidateList extends StatelessWidget {
         return _FriendCandidateTile(
           friend: friend,
           isSelected: isSelected,
-          onTap: () => onToggle(friend.id),
+          onTap: () => onToggle(friend),
         );
       },
     );

--- a/lib/features/place/presentation/widgets/place_friend_selected_strip.dart
+++ b/lib/features/place/presentation/widgets/place_friend_selected_strip.dart
@@ -31,7 +31,7 @@ class PlaceSelectedFriendMarkStrip extends StatelessWidget {
   });
 
   final List<PlaceFriendProfile> friends;
-  final ValueChanged<String> onRemove;
+  final ValueChanged<PlaceFriendProfile> onRemove;
   final EdgeInsetsGeometry padding;
   final double height;
   final double separatorWidth;
@@ -55,7 +55,7 @@ class PlaceSelectedFriendMarkStrip extends StatelessWidget {
               key: ValueKey('selected-friend-${friend.id}'),
               friend: friend,
               height: height,
-              onRemove: () => onRemove(friend.id),
+              onRemove: () => onRemove(friend),
             );
           },
         ),

--- a/test/features/place/presentation/pages/friend_management_page_test.dart
+++ b/test/features/place/presentation/pages/friend_management_page_test.dart
@@ -1,12 +1,15 @@
 import 'package:commonplant_frontend/features/place/presentation/pages/friend_management_page.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('친구 관리 기본 화면은 선택 친구와 검색 결과를 표시한다', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      const ProviderScope(
+        child: MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      ),
     );
 
     expect(find.text('친구 관리'), findsOneWidget);
@@ -21,7 +24,9 @@ void main() {
 
   testWidgets('선택 친구 삭제 버튼은 삭제 확인 알럿을 표시한다', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      const ProviderScope(
+        child: MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      ),
     );
 
     await tester.tap(
@@ -37,7 +42,9 @@ void main() {
 
   testWidgets('삭제 확인 후 친구 선택 상태를 해제한다', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      const ProviderScope(
+        child: MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      ),
     );
 
     await tester.tap(
@@ -60,7 +67,9 @@ void main() {
 
   testWidgets('닉네임 검색어로 친구 목록을 필터링한다', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      const ProviderScope(
+        child: MaterialApp(home: FriendManagementPage(placeId: 'place-1')),
+      ),
     );
 
     await tester.enterText(find.byType(TextField), '파파');

--- a/test/features/place/presentation/pages/place_invitations_page_test.dart
+++ b/test/features/place/presentation/pages/place_invitations_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_invitations_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -57,6 +58,8 @@ Future<void> _pumpPage(WidgetTester tester) async {
   addTearDown(tester.view.resetDevicePixelRatio);
   addTearDown(tester.view.resetPhysicalSize);
 
-  await tester.pumpWidget(const MaterialApp(home: PlaceInvitationsPage()));
+  await tester.pumpWidget(
+    const ProviderScope(child: MaterialApp(home: PlaceInvitationsPage())),
+  );
   await tester.pumpAndSettle();
 }

--- a/test/features/place/presentation/providers/friend_management_controller_test.dart
+++ b/test/features/place/presentation/providers/friend_management_controller_test.dart
@@ -1,0 +1,42 @@
+import 'package:commonplant_frontend/features/place/presentation/fixtures/friend_management_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/friend_management_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('친구 관리는 placeId별 초기 선택 상태를 제공한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final state = container.read(friendManagementControllerProvider('place-1'));
+
+    expect(state.placeId, 'place-1');
+    expect(state.selectedFriends, hasLength(2));
+    expect(state.results, hasLength(2));
+  });
+
+  test('검색어로 친구 목록을 필터링한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = friendManagementControllerProvider('place-1');
+
+    container.read(provider.notifier).updateQuery('파파');
+
+    expect(container.read(provider).results, hasLength(1));
+    expect(container.read(provider).results.single.name, '커먼 파파');
+  });
+
+  test('친구를 삭제하고 다시 선택할 수 있다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = friendManagementControllerProvider('place-1');
+    final controller = container.read(provider.notifier);
+    final friend = friendManagementFixture.first;
+
+    controller.remove(friend);
+    expect(container.read(provider).isSelected(friend.id), isFalse);
+
+    controller.select(friend);
+    expect(container.read(provider).isSelected(friend.id), isTrue);
+  });
+}

--- a/test/features/place/presentation/providers/place_friend_selection_controller_test.dart
+++ b/test/features/place/presentation/providers/place_friend_selection_controller_test.dart
@@ -1,0 +1,83 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_friend_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_friend_selection_controller.dart';
+import 'package:commonplant_frontend/features/user/data/datasources/user_remote_data_source.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/user_search_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('local 검색어에 맞는 Place friend 목록을 보여준다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container
+        .read(placeFriendSelectionControllerProvider.notifier)
+        .updateQuery('커먼맘');
+
+    final searchState = container.read(placeFriendSearchProvider);
+    expect(searchState.result.requireValue, hasLength(1));
+    expect(searchState.result.requireValue.single.name, '커먼맘');
+    expect(searchState.showEmptyState, isFalse);
+  });
+
+  test('친구 profile을 선택하고 다시 누르면 해제한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final controller = container.read(
+      placeFriendSelectionControllerProvider.notifier,
+    );
+    final friend = placeFriendFixture.first;
+
+    controller.toggle(friend);
+    expect(
+      container.read(placeFriendSelectionControllerProvider).selectedIds,
+      contains(friend.id),
+    );
+
+    controller.toggle(friend);
+    expect(
+      container.read(placeFriendSelectionControllerProvider).selectedIds,
+      isEmpty,
+    );
+  });
+
+  test('remote User 결과를 Place friend profile로 변환한다', () async {
+    final repository = _StaticUserRepository(const [
+      UserProfile(id: 'user-1', name: '커먼맘'),
+    ]);
+    final container = ProviderContainer(
+      overrides: [
+        useRemoteApiProvider.overrideWithValue(true),
+        userRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(placeFriendSearchProvider, (_, _) {});
+    addTearDown(subscription.close);
+
+    container
+        .read(placeFriendSelectionControllerProvider.notifier)
+        .updateQuery('커먼');
+    await container.read(userSearchProvider('커먼').future);
+
+    final searchState = container.read(placeFriendSearchProvider);
+    expect(searchState.showEmptyState, isTrue);
+    expect(searchState.result.requireValue.single.id, 'user-1');
+    expect(searchState.result.requireValue.single.name, '커먼맘');
+  });
+}
+
+class _StaticUserRepository extends UserRepository {
+  _StaticUserRepository(this.users) : super(UserRemoteDataSource(Dio()));
+
+  final List<UserProfile> users;
+
+  @override
+  Future<List<UserProfile>> searchUsers(String keyword) async {
+    return users;
+  }
+}

--- a/test/features/place/presentation/providers/place_invitation_controller_test.dart
+++ b/test/features/place/presentation/providers/place_invitation_controller_test.dart
@@ -1,0 +1,34 @@
+import 'package:commonplant_frontend/features/place/presentation/models/place_invitation.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_invitation_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('초대를 수락하면 accepted 결과를 저장한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container
+        .read(placeInvitationControllerProvider.notifier)
+        .accept('invite-1');
+
+    expect(
+      container.read(placeInvitationControllerProvider).resultFor('invite-1'),
+      PlaceInvitationResult.accepted,
+    );
+  });
+
+  test('초대를 삭제하면 deleted 결과를 저장한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container
+        .read(placeInvitationControllerProvider.notifier)
+        .delete('invite-2');
+
+    expect(
+      container.read(placeInvitationControllerProvider).resultFor('invite-2'),
+      PlaceInvitationResult.deleted,
+    );
+  });
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #172
- Parent: #165
- 3차 계획 문서: `docs/code-readability-refactoring-round-3-plan.md`

## 구현 범위

- `PlaceFriendAddPage`, `FriendManagementPage`, `PlaceInvitationsPage`를 `ConsumerWidget`으로 전환
- 친구 검색어와 선택 profile map을 `PlaceFriendSelectionController`로 이동
- 친구 관리 검색·선택 상태를 `placeId`별 auto-dispose family Controller로 이동
- 초대 수락·삭제 결과 map을 `PlaceInvitationController`로 이동
- local/remote 검색 분기와 User → Place profile 변환을 Place Provider 경계로 이동
- 친구 후보/선택 위젯 callback을 ID 대신 `PlaceFriendProfile` 중심으로 정리

## 주요 변경사항

- 대상 route page의 `setState`, mutable collection, `TextEditingController` 소유를 제거했습니다.
- remote loading/error/retry 및 local 검색 표시 차이를 `PlaceFriendSearchState`로 명시했습니다.
- dialog와 navigation은 기존처럼 page에서 수행합니다.
- feature route/page StatefulWidget 수가 7개에서 4개로 감소했습니다.

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- 관련 Controller/page 테스트 21개
- `fvm flutter test` 전체 201개

모든 검증을 통과했습니다.

## 리뷰 포인트

- local/remote 검색과 User mapping을 Place Provider 경계로 옮긴 구조가 읽기 쉬운지
- `PlaceFriendProfile` 기반 callback이 후보/선택 위젯 책임을 명확히 하는지
- 친구 삭제 dialog와 초대 결과 UI가 기존 동작을 유지하는지

## 문서 반영

- 새로운 패턴을 추가하지 않고 3차 계획 및 상태관리 가이드의 기존 Riverpod-first 기준을 적용해 별도 문서 변경은 없습니다.

## Breaking change

- 없음
