### PR TITLE
Refactor: 메모 작성 상태 Riverpod 전환 #174

### DIFF
--- a/lib/features/memo/presentation/pages/memo_write_page.dart
+++ b/lib/features/memo/presentation/pages/memo_write_page.dart
@@ -5,7 +5,9 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/memo/presentation/providers/memo_list_provider.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_write_controller.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_write_state.dart';
+import 'package:commonplant_frontend/features/memo/presentation/widgets/memo_content_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_photo_add_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
@@ -13,62 +15,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class MemoWritePage extends ConsumerStatefulWidget {
+class MemoWritePage extends ConsumerWidget {
   const MemoWritePage({super.key, required this.plantId});
 
   final String plantId;
 
-  @override
-  ConsumerState<MemoWritePage> createState() => _MemoWritePageState();
-}
+  void _submit(BuildContext context, WidgetRef ref) {
+    final provider = memoWriteControllerProvider(plantId);
+    final didSubmit = ref.read(provider.notifier).submit();
 
-class _MemoWritePageState extends ConsumerState<MemoWritePage> {
-  static const int _maxMemoLength = 200;
-  static const int _maxPhotoCount = 1;
+    if (didSubmit) {
+      context.go(AppRoutePaths.memoListLocation(plantId));
+      return;
+    }
 
-  final TextEditingController _memoController = TextEditingController();
-  bool _hasPhoto = false;
-
-  bool get _canSubmit => _memoController.text.trim().isNotEmpty;
-
-  @override
-  void initState() {
-    super.initState();
-    _memoController.addListener(_handleInputChanged);
+    final errorMessage = ref.read(provider).errorMessage;
+    if (errorMessage != null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(errorMessage)));
+    }
   }
 
   @override
-  void dispose() {
-    _memoController.removeListener(_handleInputChanged);
-    _memoController.dispose();
-    super.dispose();
-  }
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = memoWriteControllerProvider(plantId);
+    final state = ref.watch(provider);
+    final controller = ref.read(provider.notifier);
 
-  void _handleInputChanged() {
-    setState(() {});
-  }
-
-  void _selectPhoto() {
-    setState(() => _hasPhoto = true);
-  }
-
-  void _removePhoto() {
-    setState(() => _hasPhoto = false);
-  }
-
-  void _submit() {
-    ref
-        .read(memoListProvider.notifier)
-        .addMemo(
-          plantId: widget.plantId,
-          content: _memoController.text.trim(),
-          hasPhoto: _hasPhoto,
-        );
-    context.go(AppRoutePaths.memoListLocation(widget.plantId));
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.white,
       body: SafeArea(
@@ -96,14 +70,15 @@ class _MemoWritePageState extends ConsumerState<MemoWritePage> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       _MemoPhotoSection(
-                        hasPhoto: _hasPhoto,
-                        onAddPhoto: _selectPhoto,
-                        onRemovePhoto: _removePhoto,
+                        hasPhoto: state.hasPhoto,
+                        onAddPhoto: controller.selectPhoto,
+                        onRemovePhoto: controller.removePhoto,
                       ),
                       const SizedBox(height: AppSpacing.x32),
-                      _MemoContentField(
-                        controller: _memoController,
-                        maxLength: _maxMemoLength,
+                      MemoContentField(
+                        content: state.content,
+                        maxLength: memoWriteMaxContentLength,
+                        onChanged: controller.updateContent,
                       ),
                     ],
                   ),
@@ -118,7 +93,10 @@ class _MemoWritePageState extends ConsumerState<MemoWritePage> {
                 ),
                 child: CommonButton(
                   label: '완료',
-                  onPressed: _canSubmit ? _submit : null,
+                  isLoading: state.isSubmitting,
+                  onPressed: state.canSubmit
+                      ? () => _submit(context, ref)
+                      : null,
                 ),
               ),
             ],
@@ -151,7 +129,7 @@ class _MemoPhotoSection extends StatelessWidget {
             padding: const EdgeInsets.only(top: AppSpacing.x4),
             child: CommonPhotoAddButton(
               currentCount: hasPhoto ? 1 : 0,
-              maxCount: _MemoWritePageState._maxPhotoCount,
+              maxCount: memoWriteMaxPhotoCount,
               backgroundColor: hasPhoto ? AppColors.surfaceDisabled : null,
               onTap: hasPhoto ? null : onAddPhoto,
             ),
@@ -217,68 +195,6 @@ class _MemoSelectedPhoto extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _MemoContentField extends StatelessWidget {
-  const _MemoContentField({required this.controller, required this.maxLength});
-
-  final TextEditingController controller;
-  final int maxLength;
-
-  @override
-  Widget build(BuildContext context) {
-    final currentLength = controller.text.characters.length;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        DecoratedBox(
-          decoration: const BoxDecoration(
-            border: Border(bottom: BorderSide(color: AppColors.borderDefault)),
-          ),
-          child: TextField(
-            controller: controller,
-            maxLength: maxLength,
-            minLines: 1,
-            maxLines: 6,
-            keyboardType: TextInputType.multiline,
-            style: AppTextStyles.size16Medium.copyWith(
-              color: AppColors.textStrong,
-            ),
-            decoration: InputDecoration(
-              hintText: '메모 내용을 입력해 주세요',
-              hintStyle: AppTextStyles.size18Medium.copyWith(
-                color: AppColors.textDisabled,
-              ),
-              counterText: '',
-              border: InputBorder.none,
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                vertical: AppSpacing.x16,
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(height: AppSpacing.x8),
-        RichText(
-          text: TextSpan(
-            style: AppTextStyles.size14Medium.copyWith(
-              color: AppColors.textBody,
-            ),
-            children: [
-              TextSpan(
-                text: '$currentLength',
-                style: AppTextStyles.size14Bold.copyWith(
-                  color: AppColors.textBody,
-                ),
-              ),
-              TextSpan(text: '/$maxLength'),
-            ],
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/memo/presentation/providers/memo_write_controller.dart
+++ b/lib/features/memo/presentation/providers/memo_write_controller.dart
@@ -1,0 +1,68 @@
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_list_provider.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_write_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const String memoWriteSubmitFailureMessage = '메모 저장에 실패했어요';
+
+final memoWriteControllerProvider = NotifierProvider.autoDispose
+    .family<MemoWriteController, MemoWriteState, String>(
+      MemoWriteController.new,
+    );
+
+class MemoWriteController extends Notifier<MemoWriteState> {
+  MemoWriteController(this.plantId);
+
+  final String plantId;
+
+  @override
+  MemoWriteState build() {
+    return MemoWriteState.initial(plantId);
+  }
+
+  void updateContent(String content) {
+    state = state.copyWith(
+      content: content,
+      submitStatus: MemoWriteSubmitStatus.idle,
+      clearErrorMessage: true,
+    );
+  }
+
+  void selectPhoto() {
+    state = state.copyWith(hasPhoto: true);
+  }
+
+  void removePhoto() {
+    state = state.copyWith(hasPhoto: false);
+  }
+
+  bool submit() {
+    if (!state.canSubmit) {
+      return false;
+    }
+
+    state = state.copyWith(
+      submitStatus: MemoWriteSubmitStatus.submitting,
+      clearErrorMessage: true,
+    );
+
+    try {
+      ref
+          .read(memoListProvider.notifier)
+          .addMemo(
+            plantId: plantId,
+            content: state.content.trim(),
+            hasPhoto: state.hasPhoto,
+          );
+      state = state.copyWith(submitStatus: MemoWriteSubmitStatus.success);
+
+      return true;
+    } catch (_) {
+      state = state.copyWith(
+        submitStatus: MemoWriteSubmitStatus.failure,
+        errorMessage: memoWriteSubmitFailureMessage,
+      );
+
+      return false;
+    }
+  }
+}

--- a/lib/features/memo/presentation/providers/memo_write_state.dart
+++ b/lib/features/memo/presentation/providers/memo_write_state.dart
@@ -1,0 +1,50 @@
+const int memoWriteMaxContentLength = 200;
+const int memoWriteMaxPhotoCount = 1;
+
+enum MemoWriteSubmitStatus { idle, submitting, success, failure }
+
+class MemoWriteState {
+  const MemoWriteState({
+    required this.plantId,
+    required this.content,
+    required this.hasPhoto,
+    required this.submitStatus,
+    this.errorMessage,
+  });
+
+  const MemoWriteState.initial(String plantId)
+    : this(
+        plantId: plantId,
+        content: '',
+        hasPhoto: false,
+        submitStatus: MemoWriteSubmitStatus.idle,
+      );
+
+  final String plantId;
+  final String content;
+  final bool hasPhoto;
+  final MemoWriteSubmitStatus submitStatus;
+  final String? errorMessage;
+
+  bool get isSubmitting => submitStatus == MemoWriteSubmitStatus.submitting;
+
+  bool get canSubmit => content.trim().isNotEmpty && !isSubmitting;
+
+  MemoWriteState copyWith({
+    String? content,
+    bool? hasPhoto,
+    MemoWriteSubmitStatus? submitStatus,
+    String? errorMessage,
+    bool clearErrorMessage = false,
+  }) {
+    return MemoWriteState(
+      plantId: plantId,
+      content: content ?? this.content,
+      hasPhoto: hasPhoto ?? this.hasPhoto,
+      submitStatus: submitStatus ?? this.submitStatus,
+      errorMessage: clearErrorMessage
+          ? null
+          : errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/memo/presentation/widgets/memo_content_field.dart
+++ b/lib/features/memo/presentation/widgets/memo_content_field.dart
@@ -1,0 +1,104 @@
+import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
+import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class MemoContentField extends StatefulWidget {
+  const MemoContentField({
+    required this.content,
+    required this.maxLength,
+    required this.onChanged,
+    super.key,
+  });
+
+  final String content;
+  final int maxLength;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<MemoContentField> createState() => _MemoContentFieldState();
+}
+
+class _MemoContentFieldState extends State<MemoContentField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.content);
+  }
+
+  @override
+  void didUpdateWidget(covariant MemoContentField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.content != _controller.text) {
+      _controller.value = TextEditingValue(
+        text: widget.content,
+        selection: TextSelection.collapsed(offset: widget.content.length),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentLength = widget.content.characters.length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        DecoratedBox(
+          decoration: const BoxDecoration(
+            border: Border(bottom: BorderSide(color: AppColors.borderDefault)),
+          ),
+          child: TextField(
+            controller: _controller,
+            maxLength: widget.maxLength,
+            minLines: 1,
+            maxLines: 6,
+            keyboardType: TextInputType.multiline,
+            onChanged: widget.onChanged,
+            style: AppTextStyles.size16Medium.copyWith(
+              color: AppColors.textStrong,
+            ),
+            decoration: InputDecoration(
+              hintText: '메모 내용을 입력해 주세요',
+              hintStyle: AppTextStyles.size18Medium.copyWith(
+                color: AppColors.textDisabled,
+              ),
+              counterText: '',
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: AppSpacing.x16,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.x8),
+        RichText(
+          text: TextSpan(
+            style: AppTextStyles.size14Medium.copyWith(
+              color: AppColors.textBody,
+            ),
+            children: [
+              TextSpan(
+                text: '$currentLength',
+                style: AppTextStyles.size14Bold.copyWith(
+                  color: AppColors.textBody,
+                ),
+              ),
+              TextSpan(text: '/${widget.maxLength}'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/memo/presentation/providers/memo_write_controller_test.dart
+++ b/test/features/memo/presentation/providers/memo_write_controller_test.dart
@@ -1,0 +1,98 @@
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_list_provider.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_write_controller.dart';
+import 'package:commonplant_frontend/features/memo/presentation/providers/memo_write_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('메모 내용에 따라 canSubmit을 계산한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = memoWriteControllerProvider('plant-1');
+    final controller = container.read(provider.notifier);
+
+    expect(container.read(provider).canSubmit, isFalse);
+
+    controller.updateContent('   ');
+    expect(container.read(provider).canSubmit, isFalse);
+
+    controller.updateContent('오늘도 맑음');
+    expect(container.read(provider).content, '오늘도 맑음');
+    expect(container.read(provider).canSubmit, isTrue);
+  });
+
+  test('메모 사진을 선택하고 제거한다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = memoWriteControllerProvider('plant-1');
+    final controller = container.read(provider.notifier);
+
+    controller.selectPhoto();
+    expect(container.read(provider).hasPhoto, isTrue);
+
+    controller.removePhoto();
+    expect(container.read(provider).hasPhoto, isFalse);
+  });
+
+  test('제출 시 메모를 추가하고 submitting과 success 상태를 거친다', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = memoWriteControllerProvider('new-plant');
+    final statuses = <MemoWriteSubmitStatus>[];
+    final subscription = container.listen(
+      provider,
+      (previous, next) => statuses.add(next.submitStatus),
+    );
+    addTearDown(subscription.close);
+    final controller = container.read(provider.notifier);
+
+    controller.updateContent('  새 잎이 올라왔다  ');
+    controller.selectPhoto();
+
+    expect(controller.submit(), isTrue);
+    expect(
+      statuses,
+      containsAllInOrder([
+        MemoWriteSubmitStatus.submitting,
+        MemoWriteSubmitStatus.success,
+      ]),
+    );
+
+    final memo = container.read(memoItemsProvider('new-plant')).single;
+    expect(memo.content, '새 잎이 올라왔다');
+    expect(memo.imageAsset, isNotNull);
+  });
+
+  test('메모 추가가 실패하면 failure 상태와 메시지를 제공한다', () {
+    final container = ProviderContainer(
+      overrides: [memoListProvider.overrideWith(_ThrowingMemoListNotifier.new)],
+    );
+    addTearDown(container.dispose);
+    final provider = memoWriteControllerProvider('plant-1');
+    final controller = container.read(provider.notifier);
+
+    controller.updateContent('저장할 메모');
+
+    expect(controller.submit(), isFalse);
+    expect(
+      container.read(provider).submitStatus,
+      MemoWriteSubmitStatus.failure,
+    );
+    expect(
+      container.read(provider).errorMessage,
+      memoWriteSubmitFailureMessage,
+    );
+    expect(container.read(provider).canSubmit, isTrue);
+  });
+}
+
+class _ThrowingMemoListNotifier extends MemoListNotifier {
+  @override
+  MemoItem addMemo({
+    required String plantId,
+    required String content,
+    bool hasPhoto = false,
+  }) {
+    throw StateError('save failed');
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #174
- Parent: #165
- 3차 계획 문서: `docs/code-readability-refactoring-round-3-plan.md`

## 구현 범위

- `MemoWritePage`를 `ConsumerWidget`으로 전환
- content, photo, canSubmit, submit status를 `MemoWriteState`로 통합
- `plantId`별 auto-dispose family `MemoWriteController` 추가
- `memoListProvider.addMemo` 호출을 Controller로 이동
- `TextEditingController`를 `MemoContentField` leaf 위젯으로 분리
- content/photo/submit 상태 Controller 테스트 추가

## 주요 변경사항

- page의 `setState`, mutable field, `TextEditingController`, memo list 직접 변경을 제거했습니다.
- Controller가 `idle → submitting → success/failure` 제출 상태를 명시적으로 관리합니다.
- page는 성공 시 memo list 이동, 실패 시 Snackbar 표시만 담당합니다.
- 현재 local memo 생성과 사진 포함 동작은 유지했습니다.
- feature route/page StatefulWidget 수가 4개에서 3개로 감소했습니다.

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- 관련 Controller/page/list 테스트 11개
- `fvm flutter test` 전체 205개

모든 검증을 통과했습니다.

## 리뷰 포인트

- `MemoWriteState`의 draft와 submit status 경계가 읽기 쉬운지
- `MemoContentField`에만 `TextEditingController`를 남긴 lifecycle 경계가 적절한지
- 기존 메모 작성 후 목록 이동 및 사진 첨부 동작이 유지되는지

## 문서 반영

- 3차 계획과 상태관리 가이드에 이미 정의된 form state/leaf lifecycle 기준을 적용해 별도 문서 변경은 없습니다.

## Breaking change

- 없음
