### PR TITLE
Docs: 리팩토링 중간 검증 기준 #180

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ lib/
 | [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md) | 사람이 읽기 쉬운 코드로 개선하기 위한 파일 분해, 우선순위, PR 단위, 리뷰 기준 |
 | [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md) | 1차 완료 후 남은 Place 중심 대형 화면, 라우팅 파라미터, detail action, mapper 경계 개선 계획 |
 | [코드 가독성 리팩토링 3차 계획](docs/code-readability-refactoring-round-3-plan.md) | Riverpod-first 화면 상태, ViewData, feature/repository 경계를 정리하는 실행 계획 |
+| [코드 가독성 리팩토링 검증 기준](docs/code-readability-refactoring-validation.md) | 리팩토링 구조 감사, 회귀 테스트, 플랫폼 빌드, 실제 기기/API smoke 판정 기준과 검증 기록 |
 | [API Swagger 연계 참고 문서](docs/api-swagger-reference.md) | 서버 Swagger 변경사항, API 계층 반영 가능 항목, 백엔드 확인 필요 항목 |
 | [백엔드 API 확인 질문 목록](docs/backend-api-open-questions.md) | Swagger와 API 계층 기준으로 분리한 백엔드 확인 질문 목록 |
 | [후속 결정 체크리스트](docs/follow-up-decision-checklist.md) | 계획된 작업 완료 후 새 이슈로 분리할 결정/확인 항목 목록 |

--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -608,7 +608,7 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 4. Memo write state 전환 | #174 | #175 | Done |
 | Task 5. Profile setup state 통합 | #176 | #177 | Done |
 | Task 6. Place form state 통합 | #178 | #179 | Done |
-| Task 1~6 중간 검증 | #180 | - | In Progress |
+| Task 1~6 중간 검증 | #180 | #181 | In Review |
 | Task 7~11 | 각 Task 시작 시 생성 | - | Pending |
 
 각 Task 이슈를 만들 때 #165를 parent issue로 연결하고, Project 10의 category는 대상 domain을 우선한다. 여러 domain을 함께 다루는 공통 구조와 문서 Task는 `Story`로 지정한다.
@@ -628,5 +628,6 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 6 | `4117715` | Place 폼 draft, 조회, 제출 상태를 family Controller로 통합 | Place form controller/page test 8개 |
 | Task 6 | `ab2f014` | Place form page를 `ConsumerWidget`으로 전환하고 이름 입력 제어를 leaf widget으로 이동 | Place form 대상 test 15개 |
 | Task 6 | `4c7fe75` | Place form controller test의 중복 import 정리 | `fvm flutter analyze`, 전체 test 212개 |
+| 중간 검증 | `5a6e2d0` | 구조 감사, 회귀 테스트, 플랫폼 빌드 검증 기준과 Task 1~6 결과 문서화 | 대상 test 83개, 전체 test 212개, analyze, iOS/Android debug build |
 
 Task 6부터는 구현 커밋을 책임별로 나누고 각 커밋을 별도 행으로 기록한다. 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -560,6 +560,8 @@ fvm flutter test
 
 Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행한 뒤 전체 test를 실행한다.
 
+여러 Task가 연속 병합된 중간 지점과 라운드 완료 전에는 [코드 가독성 리팩토링 검증 기준](code-readability-refactoring-validation.md)에 따라 구조 감사, 대상 회귀 테스트, 전체 품질 게이트, 플랫폼 빌드를 함께 실행한다.
+
 ## 리뷰 체크리스트
 
 - [ ] route page가 `ConsumerWidget`인가?
@@ -605,7 +607,8 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 3. Place friend/invitation state 전환 | #172 | #173 | Done |
 | Task 4. Memo write state 전환 | #174 | #175 | Done |
 | Task 5. Profile setup state 통합 | #176 | #177 | Done |
-| Task 6. Place form state 통합 | #178 | #179 | In Review |
+| Task 6. Place form state 통합 | #178 | #179 | Done |
+| Task 1~6 중간 검증 | #180 | - | In Progress |
 | Task 7~11 | 각 Task 시작 시 생성 | - | Pending |
 
 각 Task 이슈를 만들 때 #165를 parent issue로 연결하고, Project 10의 category는 대상 domain을 우선한다. 여러 domain을 함께 다루는 공통 구조와 문서 Task는 `Story`로 지정한다.

--- a/docs/code-readability-refactoring-validation.md
+++ b/docs/code-readability-refactoring-validation.md
@@ -1,0 +1,122 @@
+# Code Readability Refactoring Validation
+
+이 문서는 코드 가독성 리팩토링이 파일 이동이나 테스트 통과에 그치지 않고, 계획한 상태 소유권과 의존 경계를 실제로 유지하는지 반복해서 검증하기 위한 기준이다.
+
+## 검증 시점
+
+아래 시점에 검증을 실행하고 결과를 기록한다.
+
+1. 여러 상태관리 Task가 연속 병합된 중간 지점
+2. repository 또는 feature 의존 경계를 변경한 뒤
+3. 각 리팩토링 라운드를 완료하기 전
+
+3차 라운드는 Task 1~6 병합 후 첫 중간 검증을 실행한다. 다음 검증은 Task 9 완료 후, 최종 검증은 Task 11 완료 후 실행한다.
+
+## 검증 단계
+
+### 1. GitHub와 문서 상태
+
+- 대상 이슈가 닫히고 PR이 병합됐는지 확인한다.
+- PR quality check가 통과했는지 확인한다.
+- Project 10의 status, category, priority가 현재 상태와 일치하는지 확인한다.
+- 계획 문서의 이슈/PR 상태와 실제 GitHub 상태가 일치하는지 확인한다.
+
+### 2. 구조 감사
+
+완료된 Task의 완료 조건을 기준으로 아래 항목을 확인한다.
+
+- route page가 `ConsumerWidget`으로 전환됐는가?
+- 완료된 page에 화면 동작 목적의 `setState`와 mutable field가 남아 있지 않은가?
+- `StatefulWidget`은 controller, focus, animation 같은 Flutter 생명주기 객체를 소유하는 leaf widget에만 남아 있는가?
+- page가 `useRemoteApiProvider`, request DTO, repository 구현을 직접 참조하지 않는가?
+- Provider가 `BuildContext`, widget, navigation, dialog, snackbar를 알지 않는가?
+- form/search/selection 상태가 이름 있는 State와 `autoDispose` Controller로 관리되는가?
+- Controller의 상태 전이가 unit test로 고정돼 있는가?
+- 아직 시작하지 않은 Task의 잔여 항목을 완료 Task의 실패로 잘못 분류하지 않았는가?
+
+구조 검색은 아래 명령을 기본으로 사용하고, 결과를 해당 Task 범위와 대조한다.
+
+```bash
+rg -n "ConsumerStatefulWidget|StatefulWidget|setState\\(" lib/features/*/presentation/pages
+rg -n "useRemoteApiProvider|data/dtos|data/repositories" lib/features/*/presentation/pages
+rg -n "TextEditingController|FocusNode|BuildContext|Navigator|ScaffoldMessenger" lib/features/*/presentation/providers
+rg -n "FormSubmitController|ChangeNotifierProvider|ChangeNotifier" lib test
+```
+
+### 3. 대상 회귀 테스트
+
+각 완료 Task의 page, State, Controller test를 먼저 실행한다. 실패하면 전체 테스트로 범위를 넓히기 전에 해당 Task의 상태 전이와 사용자 동작을 확인한다.
+
+검증 대상:
+
+- 초기 렌더링과 loading/empty/error 분기
+- 입력에 따른 `canSubmit`, `hasChanges`, 검색 결과
+- 선택, 해제, 삭제, 수락 상태 전이
+- local/remote repository 분기
+- 성공 후 navigation과 실패 feedback
+
+### 4. 저장소 전체 품질 게이트
+
+```bash
+fvm dart format --output=none --set-exit-if-changed .
+fvm flutter analyze
+fvm flutter test
+```
+
+### 5. 플랫폼 빌드
+
+테스트 타깃 밖의 Android/iOS 앱 설정과 플러그인 컴파일 회귀를 확인한다.
+
+```bash
+fvm flutter build ios --debug --no-codesign
+fvm flutter build apk --debug
+```
+
+빌드 산출물은 검증 용도로만 사용하고 저장소에 커밋하지 않는다.
+
+### 6. 실제 기기와 원격 API smoke
+
+실제 API를 사용하는 사용자 흐름은 staging API, 테스트 계정, seed/cleanup 정책이 준비된 뒤 별도로 검증한다. 준비 전에는 unit/widget test의 Provider override와 debug build 통과를 코드 수준 판정 기준으로 사용한다.
+
+우선 smoke 대상:
+
+- 프로필 설정과 약관 동의
+- 장소 생성·수정과 친구 선택
+- 식물 검색·등록·수정
+- 메모 작성·삭제
+
+## 판정 기준
+
+| 판정 | 기준 |
+| --- | --- |
+| Code-level Pass | 구조 감사, 대상 회귀 테스트, 전체 품질 게이트, 지원 플랫폼 debug build가 모두 통과한다. |
+| Smoke Pending | Code-level Pass지만 staging API 또는 실제 기기 사용자 흐름을 실행하지 않았다. 차단 조건을 함께 기록한다. |
+| Fail | 완료 Task의 구조 조건 위반, 테스트 실패, analyze 실패, 지원 플랫폼 build 실패 중 하나 이상이 있다. |
+
+실제 기기/API smoke가 준비되지 않았다는 이유만으로 코드 수준 검증을 실패로 판정하지 않는다. 대신 검증 범위를 숨기지 않고 `Smoke Pending`으로 명시한다.
+
+## 검증 기록
+
+### 2026-08-05: 3차 Task 1~6 중간 검증
+
+대상 기준점: `develop`의 PR #169, #171, #173, #175, #177, #179 병합 상태
+
+| 구분 | 결과 |
+| --- | --- |
+| GitHub | 대상 PR 6개 병합, 마지막 PR #179 quality check 통과, 이슈 #178과 PR #179 Project status `Done` |
+| Route page | Task 1~6 대상 page 10개 모두 `ConsumerWidget` |
+| 잔여 Stateful page | `PlantFormPage` 1개, `setState` 2개이며 미착수 Task 7 범위와 일치 |
+| Page 의존 경계 | feature page의 `useRemoteApiProvider`, request DTO, repository 직접 참조 0건 |
+| Provider UI 의존 | presentation Provider의 controller/focus/context/navigation 직접 참조 0건 |
+| 상태관리 혼용 | `FormSubmitController`, `ChangeNotifierProvider`, `ChangeNotifier` 0건 |
+| 대상 회귀 테스트 | Task 1~6 관련 21개 test file, 83개 test 통과 |
+| Format | 233개 file 검사, 변경 필요 0건 |
+| Analyze | `No issues found` |
+| 전체 테스트 | 212개 test 통과 |
+| iOS debug build | `build/ios/iphoneos/Runner.app` 생성 성공 |
+| Android debug build | `build/app/outputs/flutter-apk/app-debug.apk` 생성 성공 |
+| 실제 기기/API smoke | staging API, 테스트 계정, 데이터 정리 정책 미확정으로 미실행 |
+
+**판정:** `Code-level Pass / Smoke Pending`
+
+Task 1~6의 상태 소유권 이동과 기존 사용자 동작에서 회귀는 발견되지 않았다. 다음 구현 범위는 계획대로 Task 7이며, 실제 기기/API smoke는 [테스트 작성 기준](testing-guide.md)의 integration test 준비 조건이 충족된 뒤 실행한다.


### PR DESCRIPTION
## 관련 이슈
- Closes #180
- Parent #165

## 변경 사항
- 코드 가독성 리팩토링의 반복 가능한 검증 절차를 추가했습니다.
- 구조 감사, 대상 회귀 테스트, 전체 품질 게이트, iOS/Android debug build, 실제 기기/API smoke를 구분했습니다.
- 3차 Task 1~6의 중간 검증 결과를 수치와 판정으로 기록했습니다.
- Task 6 상태를 실제 병합 결과인 `Done`으로 갱신했습니다.

## 검증 결과
- Task 1~6 대상 21개 test file, 83개 test 통과
- 전체 212개 test 통과
- format 233개 file 변경 필요 없음
- `fvm flutter analyze`: No issues found
- iOS debug build 성공
- Android debug APK build 성공
- 구조 감사에서 완료 Task 회귀 0건

## 판정
- `Code-level Pass / Smoke Pending`
- staging API, 테스트 계정, 데이터 정리 정책이 준비되지 않아 실제 기기/API smoke는 미실행

## 검증
- `git diff --check`