### PR TITLE
Refactor: Plant form state 통합 #182

### DIFF
--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Flutter, Dart, Riverpod, go_router, flutter_test
 
-**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다.
+**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-05 Task 7 구현과 전체 검증을 완료하고 PR #183에서 리뷰 중이다.
 
 ---
 
@@ -608,8 +608,12 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 4. Memo write state 전환 | #174 | #175 | Done |
 | Task 5. Profile setup state 통합 | #176 | #177 | Done |
 | Task 6. Place form state 통합 | #178 | #179 | Done |
-| Task 1~6 중간 검증 | #180 | #181 | In Review |
-| Task 7~11 | 각 Task 시작 시 생성 | - | Pending |
+| Task 1~6 중간 검증 | #180 | #181 | Done |
+| Task 7. Plant form state와 Provider 소유권 정리 | #182 | #183 | In Review |
+| Task 8. Place/Plant detail ViewData 경계 정리 | 시작 시 생성 | - | Pending |
+| Task 9. Repository 계약과 local/remote 경계 정리 | 시작 시 생성 | - | Pending |
+| Task 10. 미사용 Phase 0 구조 정리 | 시작 시 생성 | - | Pending |
+| Task 11. Router/test helper 가독성 정리 | 시작 시 생성 | - | Pending |
 
 각 Task 이슈를 만들 때 #165를 parent issue로 연결하고, Project 10의 category는 대상 domain을 우선한다. 여러 domain을 함께 다루는 공통 구조와 문서 Task는 `Story`로 지정한다.
 
@@ -629,5 +633,10 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 6 | `ab2f014` | Place form page를 `ConsumerWidget`으로 전환하고 이름 입력 제어를 leaf widget으로 이동 | Place form 대상 test 15개 |
 | Task 6 | `4c7fe75` | Place form controller test의 중복 import 정리 | `fvm flutter analyze`, 전체 test 212개 |
 | 중간 검증 | `5a6e2d0` | 구조 감사, 회귀 테스트, 플랫폼 빌드 검증 기준과 Task 1~6 결과 문서화 | 대상 test 83개, 전체 test 212개, analyze, iOS/Android debug build |
+| Task 7 | `96b5af7` | Plant 폼 생성·수정 상태 모델과 제출 가능 여부 계산 테스트 추가 | Plant form state test 5개 |
+| Task 7 | `42c26a9` | 사용자 장소 조회 facade와 Plant 등록 장소 Provider의 feature 소유권 분리 | Place/Plant Provider 및 폼 대상 test 16개 |
+| Task 7 | `1888adc` | Plant 폼 조회·선택·생성·수정·제출 상태를 family Controller로 통합 | Plant form controller/page test 11개 |
+| Task 7 | `64e9208` | Plant form page를 `ConsumerWidget`으로 전환하고 이름 입력 제어를 leaf widget으로 이동 | Plant 폼 및 router 대상 test 39개 |
+| Task 7 | `7c7093c` | Provider facade와 Controller test의 불필요한 import 정리 | format, analyze, 전체 test 218개 |
 
 Task 6부터는 구현 커밋을 책임별로 나누고 각 커밋을 별도 행으로 기록한다. 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/lib/features/place/place_feature_provider.dart
+++ b/lib/features/place/place_feature_provider.dart
@@ -1,6 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/place/place_feature_provider.dart
+++ b/lib/features/place/place_feature_provider.dart
@@ -1,13 +1,10 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-export 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
-
-final plantRegistrationPlaceProvider = FutureProvider<List<PlaceSummary>>((
-  ref,
-) {
+final userPlaceSummariesProvider = FutureProvider<List<PlaceSummary>>((ref) {
   if (ref.watch(useRemoteApiProvider)) {
     return ref.watch(placeRepositoryProvider).fetchUserPlaces();
   }

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -1,8 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -43,7 +43,7 @@ class PlaceExitController extends Notifier<FormSubmitState> {
       await ref.read(placeRepositoryProvider).deletePlace(placeId);
       ref.invalidate(placeDetailProvider(placeId));
       ref.invalidate(remotePlaceListProvider);
-      ref.invalidate(plantRegistrationPlaceProvider);
+      ref.invalidate(userPlaceSummariesProvider);
       state = const FormSubmitState.idle();
 
       return const PlaceExitResult.home();

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -1,11 +1,11 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_state.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -165,7 +165,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
           );
       ref.invalidate(placeDetailProvider(placeId));
       ref.invalidate(remotePlaceListProvider);
-      ref.invalidate(plantRegistrationPlaceProvider);
+      ref.invalidate(userPlaceSummariesProvider);
     } else {
       ref
           .read(placeListProvider.notifier)

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,16 +1,13 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
-import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
-import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_state.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_form_scaffold.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class PlantFormPage extends ConsumerStatefulWidget {
+class PlantFormPage extends ConsumerWidget {
   const PlantFormPage({
     super.key,
     this.plantId,
@@ -22,176 +19,69 @@ class PlantFormPage extends ConsumerStatefulWidget {
   final String? placeId;
   final String? initialPlantName;
 
-  bool get isEdit => plantId != null;
+  PlantFormArgs get _args => PlantFormArgs(
+    plantId: plantId,
+    placeId: placeId,
+    initialPlantName: initialPlantName,
+  );
 
   @override
-  ConsumerState<PlantFormPage> createState() => _PlantFormPageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formState = ref.watch(plantFormControllerProvider(_args));
 
-class _PlantFormPageState extends ConsumerState<PlantFormPage> {
-  late final TextEditingController _nameController;
-  late final String _selectedPlantName;
-  String? _selectedPlaceId;
-  String _initialEditPlantName = plantFormDefaultEditName;
-  bool _hasAppliedEditInfo = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedPlantName = _normalizedInitialPlantName();
-    _nameController = TextEditingController(
-      text: widget.isEdit ? plantFormDefaultEditName : '',
-    );
-    _selectedPlaceId = widget.isEdit
-        ? null
-        : plantRegistrationPlaceFallbacks.first.id;
-  }
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (widget.isEdit) {
-      return _buildEditRoute();
-    }
-
-    final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
-    final registrationPlaces = remotePlaces.value ?? const [];
-    final isSubmitting = ref
-        .watch(legacyPlantFormControllerProvider)
-        .isSubmitting;
-    final places = registrationPlaces.isEmpty
-        ? plantRegistrationPlaceFallbacks
-        : registrationPlaces;
-    final selectedPlaceId = _effectiveSelectedPlaceId(places);
-
-    return PlantCreateScaffold(
-      places: places,
-      selectedPlaceId: selectedPlaceId,
-      wateringDate: '2023. 01. 30',
-      isSubmitting: isSubmitting,
-      onPlaceSelected: (place) => setState(() => _selectedPlaceId = place.id),
-      onCancel: _cancelCreate,
-      onSubmit: () => _submitCreate(),
-    );
-  }
-
-  Widget _buildEditRoute() {
-    final plantId = widget.plantId!;
-    final editInfo = ref.watch(plantFormEditInfoProvider(plantId));
-
-    return editInfo.when(
-      data: (info) {
-        if (info == null) {
-          return const PlantStateScaffold(
-            title: '식물 수정',
-            statusTitle: '식물 수정 정보를 찾을 수 없어요',
-            message: '다시 식물 상세에서 수정해 주세요',
-          );
-        }
-
-        _applyEditInfo(info);
-
-        return _buildEditScaffold();
-      },
-      error: (error, stackTrace) => PlantStateScaffold(
-        title: '식물 수정',
-        statusTitle: '식물 수정 정보를 불러오지 못했어요',
-        message: '잠시 후 다시 시도해 주세요',
-        actionLabel: '다시 시도',
-        onAction: () => invalidatePlantFormEditInfo(ref, plantId),
-      ),
-      loading: () => const PlantStateScaffold(
+    return switch (formState.loadStatus) {
+      PlantFormLoadStatus.loading => const PlantStateScaffold(
         title: '식물 수정',
         statusTitle: '식물 수정 정보를 불러오고 있어요',
         message: '식물 이름과 사진 정보를 준비하고 있어요',
         isLoading: true,
       ),
-    );
+      PlantFormLoadStatus.failure => PlantStateScaffold(
+        title: '식물 수정',
+        statusTitle: '식물 수정 정보를 불러오지 못했어요',
+        message: '잠시 후 다시 시도해 주세요',
+        actionLabel: '다시 시도',
+        onAction: () =>
+            ref.read(plantFormControllerProvider(_args).notifier).retryLoad(),
+      ),
+      PlantFormLoadStatus.notFound => const PlantStateScaffold(
+        title: '식물 수정',
+        statusTitle: '식물 수정 정보를 찾을 수 없어요',
+        message: '다시 식물 상세에서 수정해 주세요',
+      ),
+      PlantFormLoadStatus.ready => _buildForm(context, ref, formState),
+    };
   }
 
-  Widget _buildEditScaffold() {
-    final isSubmitting = ref
-        .watch(legacyPlantFormControllerProvider)
-        .isSubmitting;
-    final trimmedName = _nameController.text.trim();
-    final canSubmit =
-        trimmedName.isNotEmpty &&
-        trimmedName != _initialEditPlantName &&
-        !isSubmitting;
+  Widget _buildForm(
+    BuildContext context,
+    WidgetRef ref,
+    PlantFormState formState,
+  ) {
+    final controller = ref.read(plantFormControllerProvider(_args).notifier);
+
+    if (!formState.isEdit) {
+      return PlantCreateScaffold(
+        places: formState.places,
+        selectedPlaceId: formState.selectedPlaceId,
+        wateringDate: '2023. 01. 30',
+        isSubmitting: formState.isSubmitting,
+        onPlaceSelected: controller.selectPlace,
+        onCancel: () => _cancelCreate(context),
+        onSubmit: () => _submit(context, ref),
+      );
+    }
 
     return PlantEditScaffold(
-      nameController: _nameController,
-      canSubmit: canSubmit,
-      isSubmitting: isSubmitting,
-      onChanged: (_) => setState(() {}),
-      onSubmit: () => _submitEdit(),
+      name: formState.currentName,
+      canSubmit: formState.canSubmit,
+      isSubmitting: formState.isSubmitting,
+      onChanged: controller.updateName,
+      onSubmit: () => _submit(context, ref),
     );
   }
 
-  void _applyEditInfo(PlantEditInfo info) {
-    if (_hasAppliedEditInfo) {
-      return;
-    }
-
-    final name = info.name.trim();
-
-    _initialEditPlantName = name;
-    _nameController.text = name;
-    _nameController.selection = TextSelection.collapsed(offset: name.length);
-    _hasAppliedEditInfo = true;
-  }
-
-  String _normalizedInitialPlantName() {
-    final plantName = widget.initialPlantName?.trim();
-
-    if (plantName == null || plantName.isEmpty) {
-      return '몬스테라 델리오사';
-    }
-
-    return plantName;
-  }
-
-  PlantRegistrationPlace? get _selectedPlace {
-    final remotePlaces = ref.read(plantRegistrationPlaceProvider).value;
-    final places = remotePlaces ?? const [];
-    final effectivePlaces = places.isEmpty
-        ? plantRegistrationPlaceFallbacks
-        : places;
-    final selectedPlaceId = _selectedPlaceId;
-
-    if (selectedPlaceId == null) {
-      return null;
-    }
-
-    for (final place in effectivePlaces) {
-      if (place.id == selectedPlaceId) {
-        return place;
-      }
-    }
-
-    return effectivePlaces.isEmpty ? null : effectivePlaces.first;
-  }
-
-  String? _effectiveSelectedPlaceId(List<PlantRegistrationPlace> places) {
-    final selectedPlaceId = _selectedPlaceId;
-
-    if (selectedPlaceId != null) {
-      for (final place in places) {
-        if (place.id == selectedPlaceId) {
-          return selectedPlaceId;
-        }
-      }
-    }
-
-    return places.isEmpty ? null : places.first.id;
-  }
-
-  void _cancelCreate() {
+  void _cancelCreate(BuildContext context) {
     if (context.canPop()) {
       context.pop();
       return;
@@ -200,84 +90,36 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     context.go(AppRoutePaths.home);
   }
 
-  Future<void> _submitCreate() async {
-    if (ref.read(legacyPlantFormControllerProvider).isSubmitting) {
+  Future<void> _submit(BuildContext context, WidgetRef ref) async {
+    final provider = plantFormControllerProvider(_args);
+    final result = await ref.read(provider.notifier).submit();
+
+    if (!context.mounted) {
       return;
     }
 
-    final selectedPlace = _selectedPlace;
+    switch (result?.destination) {
+      case PlantFormSubmitDestination.home:
+        context.go(AppRoutePaths.home);
+      case PlantFormSubmitDestination.plantDetail:
+        final plantId = result?.plantId;
 
-    if (selectedPlace == null) {
-      return;
+        if (plantId != null) {
+          context.go(
+            AppRoutePaths.plantDetailLocation(
+              plantId,
+              placeId: result?.placeId,
+            ),
+          );
+        }
+      case null:
+        final errorMessage = ref.read(provider).submitErrorMessage;
+
+        if (errorMessage != null) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(errorMessage)));
+        }
     }
-
-    final result = await ref
-        .read(legacyPlantFormControllerProvider.notifier)
-        .submit(
-          PlantFormSubmitInput.create(
-            plantName: _selectedPlantName,
-            placeId: selectedPlace.id,
-            placeName: selectedPlace.name,
-          ),
-        );
-
-    if (!mounted) {
-      return;
-    }
-
-    if (result?.destination == PlantFormSubmitDestination.home) {
-      context.go(AppRoutePaths.home);
-      return;
-    }
-
-    _showSubmitErrorSnackBar();
-  }
-
-  Future<void> _submitEdit() async {
-    if (ref.read(legacyPlantFormControllerProvider).isSubmitting) {
-      return;
-    }
-
-    final name = _nameController.text.trim();
-    final result = await ref
-        .read(legacyPlantFormControllerProvider.notifier)
-        .submit(
-          PlantFormSubmitInput.update(
-            plantId: widget.plantId!,
-            plantName: name,
-            placeId: widget.placeId,
-          ),
-        );
-
-    if (!mounted) {
-      return;
-    }
-
-    if (result?.destination == PlantFormSubmitDestination.plantDetail &&
-        result?.plantId != null) {
-      context.go(
-        AppRoutePaths.plantDetailLocation(
-          result!.plantId!,
-          placeId: result.placeId,
-        ),
-      );
-      return;
-    }
-
-    _showSubmitErrorSnackBar();
-  }
-
-  void _showSubmitErrorSnackBar() {
-    final errorMessage = ref
-        .read(legacyPlantFormControllerProvider)
-        .errorMessage;
-
-    if (!mounted || errorMessage == null) {
-      return;
-    }
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(errorMessage)));
   }
 }

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -61,7 +61,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
     final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
     final registrationPlaces = remotePlaces.value ?? const [];
-    final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
+    final isSubmitting = ref
+        .watch(legacyPlantFormControllerProvider)
+        .isSubmitting;
     final places = registrationPlaces.isEmpty
         ? plantRegistrationPlaceFallbacks
         : registrationPlaces;
@@ -113,7 +115,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Widget _buildEditScaffold() {
-    final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
+    final isSubmitting = ref
+        .watch(legacyPlantFormControllerProvider)
+        .isSubmitting;
     final trimmedName = _nameController.text.trim();
     final canSubmit =
         trimmedName.isNotEmpty &&
@@ -197,7 +201,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Future<void> _submitCreate() async {
-    if (ref.read(plantFormControllerProvider).isSubmitting) {
+    if (ref.read(legacyPlantFormControllerProvider).isSubmitting) {
       return;
     }
 
@@ -208,7 +212,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     }
 
     final result = await ref
-        .read(plantFormControllerProvider.notifier)
+        .read(legacyPlantFormControllerProvider.notifier)
         .submit(
           PlantFormSubmitInput.create(
             plantName: _selectedPlantName,
@@ -230,13 +234,13 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   Future<void> _submitEdit() async {
-    if (ref.read(plantFormControllerProvider).isSubmitting) {
+    if (ref.read(legacyPlantFormControllerProvider).isSubmitting) {
       return;
     }
 
     final name = _nameController.text.trim();
     final result = await ref
-        .read(plantFormControllerProvider.notifier)
+        .read(legacyPlantFormControllerProvider.notifier)
         .submit(
           PlantFormSubmitInput.update(
             plantId: widget.plantId!,
@@ -264,7 +268,9 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
   }
 
   void _showSubmitErrorSnackBar() {
-    final errorMessage = ref.read(plantFormControllerProvider).errorMessage;
+    final errorMessage = ref
+        .read(legacyPlantFormControllerProvider)
+        .errorMessage;
 
     if (!mounted || errorMessage == null) {
       return;

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -1,10 +1,9 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_form_scaffold.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_state_view.dart';
 import 'package:flutter/material.dart';
@@ -61,9 +60,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     }
 
     final remotePlaces = ref.watch(plantRegistrationPlaceProvider);
-    final registrationPlaces = _registrationPlacesFromSummaries(
-      remotePlaces.value ?? const [],
-    );
+    final registrationPlaces = remotePlaces.value ?? const [];
     final isSubmitting = ref.watch(plantFormControllerProvider).isSubmitting;
     final places = registrationPlaces.isEmpty
         ? plantRegistrationPlaceFallbacks
@@ -157,7 +154,7 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
 
   PlantRegistrationPlace? get _selectedPlace {
     final remotePlaces = ref.read(plantRegistrationPlaceProvider).value;
-    final places = _registrationPlacesFromSummaries(remotePlaces ?? const []);
+    final places = remotePlaces ?? const [];
     final effectivePlaces = places.isEmpty
         ? plantRegistrationPlaceFallbacks
         : places;
@@ -276,18 +273,5 @@ class _PlantFormPageState extends ConsumerState<PlantFormPage> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(errorMessage)));
-  }
-
-  List<PlantRegistrationPlace> _registrationPlacesFromSummaries(
-    List<PlaceSummary> summaries,
-  ) {
-    return [
-      for (final place in summaries)
-        PlantRegistrationPlace(
-          id: place.id,
-          name: place.name,
-          imageAsset: AppImageAssets.placeEditLivingRoom,
-        ),
-    ];
   }
 }

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -1,13 +1,23 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_state.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final plantFormControllerProvider =
-    NotifierProvider<PlantFormController, FormSubmitState>(
+final plantFormControllerProvider = NotifierProvider.autoDispose
+    .family<PlantFormController, PlantFormState, PlantFormArgs>(
       PlantFormController.new,
+    );
+
+final legacyPlantFormControllerProvider =
+    NotifierProvider<LegacyPlantFormController, FormSubmitState>(
+      LegacyPlantFormController.new,
     );
 
 enum PlantFormSubmitDestination { home, plantDetail }
@@ -36,6 +46,175 @@ class PlantFormSubmitResult {
   final String? placeId;
 }
 
+class PlantFormController extends Notifier<PlantFormState> {
+  PlantFormController(this.args);
+
+  final PlantFormArgs args;
+
+  @override
+  PlantFormState build() {
+    final plantId = args.plantId;
+
+    if (plantId != null) {
+      return ref
+          .watch(plantFormEditInfoProvider(plantId))
+          .when(
+            data: (info) {
+              if (info == null) {
+                return PlantFormState.notFound(
+                  plantId: plantId,
+                  placeId: args.placeId,
+                );
+              }
+
+              return PlantFormState.edit(
+                plantId: plantId,
+                placeId: args.placeId,
+                name: info.name.trim(),
+              );
+            },
+            error: (error, stackTrace) => PlantFormState.failure(
+              plantId: plantId,
+              placeId: args.placeId,
+              message: '식물 수정 정보를 불러오지 못했어요',
+            ),
+            loading: () => PlantFormState.loadingEdit(
+              plantId: plantId,
+              placeId: args.placeId,
+            ),
+          );
+    }
+
+    ref.listen(plantRegistrationPlaceProvider, (previous, next) {
+      final places = _effectivePlaces(next.value ?? const []);
+      final selectedPlaceId = _effectiveSelectedPlaceId(
+        places,
+        state.selectedPlaceId,
+      );
+
+      state = state.copyWith(places: places, selectedPlaceId: selectedPlaceId);
+    });
+
+    return PlantFormState.create(
+      plantName: _normalizedInitialPlantName(args.initialPlantName),
+      places: _effectivePlaces(
+        ref.read(plantRegistrationPlaceProvider).value ?? const [],
+      ),
+    );
+  }
+
+  void updateName(String name) {
+    if (state.loadStatus != PlantFormLoadStatus.ready) {
+      return;
+    }
+
+    state = state.copyWith(
+      currentName: name,
+      submitState: const FormSubmitState.idle(),
+    );
+  }
+
+  void selectPlace(PlantRegistrationPlace place) {
+    if (state.isEdit || !state.places.any((item) => item.id == place.id)) {
+      return;
+    }
+
+    state = state.copyWith(
+      selectedPlaceId: place.id,
+      submitState: const FormSubmitState.idle(),
+    );
+  }
+
+  void retryLoad() {
+    final plantId = args.plantId;
+
+    if (plantId == null) {
+      return;
+    }
+
+    ref.invalidate(remotePlantEditInfoProvider(plantId));
+    ref.invalidate(remotePlantFormEditInfoProvider(plantId));
+  }
+
+  Future<PlantFormSubmitResult?> submit() async {
+    if (!state.canSubmit) {
+      return null;
+    }
+
+    final isEdit = state.isEdit;
+    state = state.copyWith(submitState: const FormSubmitState.submitting());
+
+    try {
+      final result = isEdit ? await _update() : await _create();
+      state = state.copyWith(submitState: const FormSubmitState.idle());
+
+      return result;
+    } catch (_) {
+      state = state.copyWith(
+        submitState: FormSubmitState.failure(
+          isEdit ? '식물 수정에 실패했어요' : '식물 등록에 실패했어요',
+        ),
+      );
+
+      return null;
+    }
+  }
+
+  Future<PlantFormSubmitResult> _create() async {
+    final plantName = state.currentName.trim();
+    final selectedPlace = state.selectedPlace!;
+
+    if (ref.read(useRemoteApiProvider)) {
+      await ref
+          .read(plantRepositoryProvider)
+          .createPlant(
+            CreatePlantRequest(
+              placeCode: selectedPlace.id,
+              nickname: plantName,
+              scientificNameKo: plantName,
+            ),
+          );
+      ref.invalidate(remotePlantListProvider);
+    }
+
+    ref
+        .read(plantListProvider.notifier)
+        .addPlant(
+          name: plantName,
+          placeId: selectedPlace.id,
+          placeName: selectedPlace.name,
+        );
+
+    return const PlantFormSubmitResult.home();
+  }
+
+  Future<PlantFormSubmitResult> _update() async {
+    final plantId = state.plantId!;
+    final plantName = state.currentName.trim();
+    final placeId = state.placeId;
+
+    if (ref.read(useRemoteApiProvider) && placeId != null) {
+      await ref
+          .read(plantRepositoryProvider)
+          .updatePlant(
+            plantId: plantId,
+            placeCode: placeId,
+            request: UpdatePlantRequest(nickname: plantName),
+          );
+      ref.invalidate(remotePlantListProvider);
+    }
+
+    ref
+        .read(plantListProvider.notifier)
+        .updatePlant(id: plantId, name: plantName);
+
+    return PlantFormSubmitResult.plantDetail(
+      plantId: plantId,
+      placeId: placeId,
+    );
+  }
+}
+
 class PlantFormSubmitInput {
   const PlantFormSubmitInput.create({
     required this.plantName,
@@ -57,7 +236,7 @@ class PlantFormSubmitInput {
   bool get isEdit => plantId != null;
 }
 
-class PlantFormController extends Notifier<FormSubmitState> {
+class LegacyPlantFormController extends Notifier<FormSubmitState> {
   @override
   FormSubmitState build() {
     return const FormSubmitState.idle();
@@ -134,4 +313,32 @@ class PlantFormController extends Notifier<FormSubmitState> {
       placeId: placeId,
     );
   }
+}
+
+List<PlantRegistrationPlace> _effectivePlaces(
+  List<PlantRegistrationPlace> places,
+) {
+  return places.isEmpty ? plantRegistrationPlaceFallbacks : places;
+}
+
+String? _effectiveSelectedPlaceId(
+  List<PlantRegistrationPlace> places,
+  String? selectedPlaceId,
+) {
+  if (selectedPlaceId != null &&
+      places.any((place) => place.id == selectedPlaceId)) {
+    return selectedPlaceId;
+  }
+
+  return places.isEmpty ? null : places.first.id;
+}
+
+String _normalizedInitialPlantName(String? initialPlantName) {
+  final plantName = initialPlantName?.trim();
+
+  if (plantName == null || plantName.isEmpty) {
+    return '몬스테라 델리오사';
+  }
+
+  return plantName;
 }

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -15,11 +15,6 @@ final plantFormControllerProvider = NotifierProvider.autoDispose
       PlantFormController.new,
     );
 
-final legacyPlantFormControllerProvider =
-    NotifierProvider<LegacyPlantFormController, FormSubmitState>(
-      LegacyPlantFormController.new,
-    );
-
 enum PlantFormSubmitDestination { home, plantDetail }
 
 class PlantFormSubmitResult {
@@ -192,106 +187,6 @@ class PlantFormController extends Notifier<PlantFormState> {
     final plantId = state.plantId!;
     final plantName = state.currentName.trim();
     final placeId = state.placeId;
-
-    if (ref.read(useRemoteApiProvider) && placeId != null) {
-      await ref
-          .read(plantRepositoryProvider)
-          .updatePlant(
-            plantId: plantId,
-            placeCode: placeId,
-            request: UpdatePlantRequest(nickname: plantName),
-          );
-      ref.invalidate(remotePlantListProvider);
-    }
-
-    ref
-        .read(plantListProvider.notifier)
-        .updatePlant(id: plantId, name: plantName);
-
-    return PlantFormSubmitResult.plantDetail(
-      plantId: plantId,
-      placeId: placeId,
-    );
-  }
-}
-
-class PlantFormSubmitInput {
-  const PlantFormSubmitInput.create({
-    required this.plantName,
-    required this.placeId,
-    required this.placeName,
-  }) : plantId = null;
-
-  const PlantFormSubmitInput.update({
-    required this.plantId,
-    required this.plantName,
-    this.placeId,
-  }) : placeName = null;
-
-  final String? plantId;
-  final String plantName;
-  final String? placeId;
-  final String? placeName;
-
-  bool get isEdit => plantId != null;
-}
-
-class LegacyPlantFormController extends Notifier<FormSubmitState> {
-  @override
-  FormSubmitState build() {
-    return const FormSubmitState.idle();
-  }
-
-  Future<PlantFormSubmitResult?> submit(PlantFormSubmitInput input) async {
-    if (state.isSubmitting) {
-      return null;
-    }
-
-    state = const FormSubmitState.submitting();
-
-    try {
-      final result = input.isEdit ? await _update(input) : await _create(input);
-      state = const FormSubmitState.idle();
-
-      return result;
-    } catch (_) {
-      state = FormSubmitState.failure(
-        input.isEdit ? '식물 수정에 실패했어요' : '식물 등록에 실패했어요',
-      );
-
-      return null;
-    }
-  }
-
-  Future<PlantFormSubmitResult> _create(PlantFormSubmitInput input) async {
-    final plantName = input.plantName.trim();
-    final placeId = input.placeId!;
-    final placeName = input.placeName!;
-
-    if (ref.read(useRemoteApiProvider)) {
-      await ref
-          .read(plantRepositoryProvider)
-          .createPlant(
-            CreatePlantRequest(
-              placeCode: placeId,
-              nickname: plantName,
-              scientificNameKo: plantName,
-            ),
-          );
-      ref.invalidate(remotePlantListProvider);
-    }
-
-    ref
-        .read(plantListProvider.notifier)
-        .addPlant(name: plantName, placeId: placeId, placeName: placeName);
-
-    return const PlantFormSubmitResult.home();
-  }
-
-  Future<PlantFormSubmitResult> _update(PlantFormSubmitInput input) async {
-    final plantId = input.plantId!;
-    final plantName = input.plantName.trim();
-    final placeId = input.placeId;
 
     if (ref.read(useRemoteApiProvider) && placeId != null) {
       await ref

--- a/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
@@ -28,11 +28,6 @@ final remotePlantFormEditInfoProvider =
       return info;
     }, retry: (retryCount, error) => null);
 
-void invalidatePlantFormEditInfo(WidgetRef ref, String plantId) {
-  ref.invalidate(remotePlantEditInfoProvider(plantId));
-  ref.invalidate(remotePlantFormEditInfoProvider(plantId));
-}
-
 final remotePlantEditInfoProvider =
     FutureProvider.family<PlantEditInfo, String>(
       (ref, plantId) => ref

--- a/lib/features/plant/presentation/providers/plant_form_state.dart
+++ b/lib/features/plant/presentation/providers/plant_form_state.dart
@@ -1,0 +1,191 @@
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
+
+enum PlantFormMode { create, edit }
+
+enum PlantFormLoadStatus { loading, ready, notFound, failure }
+
+class PlantFormArgs {
+  const PlantFormArgs({this.plantId, this.placeId, this.initialPlantName});
+
+  final String? plantId;
+  final String? placeId;
+  final String? initialPlantName;
+
+  bool get isEdit => plantId != null;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PlantFormArgs &&
+        other.plantId == plantId &&
+        other.placeId == placeId &&
+        other.initialPlantName == initialPlantName;
+  }
+
+  @override
+  int get hashCode => Object.hash(plantId, placeId, initialPlantName);
+}
+
+class PlantFormState {
+  const PlantFormState({
+    required this.plantId,
+    required this.placeId,
+    required this.mode,
+    required this.initialName,
+    required this.currentName,
+    required this.places,
+    required this.selectedPlaceId,
+    required this.loadStatus,
+    required this.submitState,
+    this.loadErrorMessage,
+  });
+
+  PlantFormState.create({
+    required String plantName,
+    required List<PlantRegistrationPlace> places,
+  }) : this(
+         plantId: null,
+         placeId: null,
+         mode: PlantFormMode.create,
+         initialName: plantName,
+         currentName: plantName,
+         places: List.unmodifiable(places),
+         selectedPlaceId: places.isEmpty ? null : places.first.id,
+         loadStatus: PlantFormLoadStatus.ready,
+         submitState: const FormSubmitState.idle(),
+       );
+
+  const PlantFormState.loadingEdit({
+    required String plantId,
+    required String? placeId,
+  }) : this(
+         plantId: plantId,
+         placeId: placeId,
+         mode: PlantFormMode.edit,
+         initialName: '',
+         currentName: '',
+         places: const [],
+         selectedPlaceId: null,
+         loadStatus: PlantFormLoadStatus.loading,
+         submitState: const FormSubmitState.idle(),
+       );
+
+  const PlantFormState.edit({
+    required String plantId,
+    required String? placeId,
+    required String name,
+  }) : this(
+         plantId: plantId,
+         placeId: placeId,
+         mode: PlantFormMode.edit,
+         initialName: name,
+         currentName: name,
+         places: const [],
+         selectedPlaceId: null,
+         loadStatus: PlantFormLoadStatus.ready,
+         submitState: const FormSubmitState.idle(),
+       );
+
+  const PlantFormState.notFound({
+    required String plantId,
+    required String? placeId,
+  }) : this(
+         plantId: plantId,
+         placeId: placeId,
+         mode: PlantFormMode.edit,
+         initialName: '',
+         currentName: '',
+         places: const [],
+         selectedPlaceId: null,
+         loadStatus: PlantFormLoadStatus.notFound,
+         submitState: const FormSubmitState.idle(),
+       );
+
+  const PlantFormState.failure({
+    required String plantId,
+    required String? placeId,
+    required String message,
+  }) : this(
+         plantId: plantId,
+         placeId: placeId,
+         mode: PlantFormMode.edit,
+         initialName: '',
+         currentName: '',
+         places: const [],
+         selectedPlaceId: null,
+         loadStatus: PlantFormLoadStatus.failure,
+         submitState: const FormSubmitState.idle(),
+         loadErrorMessage: message,
+       );
+
+  final String? plantId;
+  final String? placeId;
+  final PlantFormMode mode;
+  final String initialName;
+  final String currentName;
+  final List<PlantRegistrationPlace> places;
+  final String? selectedPlaceId;
+  final PlantFormLoadStatus loadStatus;
+  final FormSubmitState submitState;
+  final String? loadErrorMessage;
+
+  bool get isEdit => mode == PlantFormMode.edit;
+
+  bool get isSubmitting => submitState.isSubmitting;
+
+  String? get submitErrorMessage => submitState.errorMessage;
+
+  bool get hasChanges => currentName.trim() != initialName;
+
+  PlantRegistrationPlace? get selectedPlace {
+    final selectedPlaceId = this.selectedPlaceId;
+
+    if (selectedPlaceId == null) {
+      return null;
+    }
+
+    for (final place in places) {
+      if (place.id == selectedPlaceId) {
+        return place;
+      }
+    }
+
+    return null;
+  }
+
+  bool get canSubmit {
+    if (loadStatus != PlantFormLoadStatus.ready || isSubmitting) {
+      return false;
+    }
+
+    if (currentName.trim().isEmpty) {
+      return false;
+    }
+
+    return isEdit ? hasChanges : selectedPlace != null;
+  }
+
+  PlantFormState copyWith({
+    String? currentName,
+    List<PlantRegistrationPlace>? places,
+    Object? selectedPlaceId = _unset,
+    FormSubmitState? submitState,
+  }) {
+    return PlantFormState(
+      plantId: plantId,
+      placeId: placeId,
+      mode: mode,
+      initialName: initialName,
+      currentName: currentName ?? this.currentName,
+      places: places == null ? this.places : List.unmodifiable(places),
+      selectedPlaceId: identical(selectedPlaceId, _unset)
+          ? this.selectedPlaceId
+          : selectedPlaceId as String?,
+      loadStatus: loadStatus,
+      submitState: submitState ?? this.submitState,
+      loadErrorMessage: loadErrorMessage,
+    );
+  }
+}
+
+const Object _unset = Object();

--- a/lib/features/plant/presentation/providers/plant_registration_place_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_registration_place_provider.dart
@@ -1,0 +1,18 @@
+import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
+import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantRegistrationPlaceProvider =
+    FutureProvider.autoDispose<List<PlantRegistrationPlace>>((ref) async {
+      final summaries = await ref.watch(userPlaceSummariesProvider.future);
+
+      return List.unmodifiable([
+        for (final place in summaries)
+          PlantRegistrationPlace(
+            id: place.id,
+            name: place.name,
+            imageAsset: AppImageAssets.placeEditLivingRoom,
+          ),
+      ]);
+    });

--- a/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
+++ b/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
@@ -4,16 +4,16 @@ import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_edit_photo_button.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_form_bottom_actions.dart';
+import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_name_field.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_place_picker.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_watering_date_field.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_scaffold.dart';
-import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
 import 'package:flutter/material.dart';
 
 class PlantEditScaffold extends StatelessWidget {
   const PlantEditScaffold({
-    required this.nameController,
+    required this.name,
     required this.canSubmit,
     required this.isSubmitting,
     required this.onChanged,
@@ -21,7 +21,7 @@ class PlantEditScaffold extends StatelessWidget {
     super.key,
   });
 
-  final TextEditingController nameController;
+  final String name;
   final bool canSubmit;
   final bool isSubmitting;
   final ValueChanged<String> onChanged;
@@ -56,12 +56,7 @@ class PlantEditScaffold extends StatelessWidget {
                     children: [
                       const PlantEditPhotoButton(),
                       const SizedBox(height: AppSpacing.x32),
-                      CommonTextField(
-                        controller: nameController,
-                        maxLength: 10,
-                        forceFocusedDecoration: true,
-                        onChanged: onChanged,
-                      ),
+                      PlantNameField(name: name, onChanged: onChanged),
                     ],
                   ),
                 ),

--- a/lib/features/plant/presentation/widgets/plant_name_field.dart
+++ b/lib/features/plant/presentation/widgets/plant_name_field.dart
@@ -1,0 +1,56 @@
+import 'package:commonplant_frontend/shared/widgets/common_text_field.dart';
+import 'package:flutter/material.dart';
+
+class PlantNameField extends StatefulWidget {
+  const PlantNameField({
+    super.key,
+    required this.name,
+    required this.onChanged,
+  });
+
+  final String name;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<PlantNameField> createState() => _PlantNameFieldState();
+}
+
+class _PlantNameFieldState extends State<PlantNameField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.name);
+  }
+
+  @override
+  void didUpdateWidget(covariant PlantNameField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.name == _controller.text) {
+      return;
+    }
+
+    _controller.value = TextEditingValue(
+      text: widget.name,
+      selection: TextSelection.collapsed(offset: widget.name.length),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CommonTextField(
+      controller: _controller,
+      maxLength: 10,
+      forceFocusedDecoration: true,
+      onChanged: widget.onChanged,
+    );
+  }
+}

--- a/test/features/place/place_feature_provider_test.dart
+++ b/test/features/place/place_feature_provider_test.dart
@@ -1,13 +1,14 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
-import 'package:commonplant_frontend/features/place/presentation/providers/plant_registration_place_provider.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('plantRegistrationPlaceProvider', () {
+  group('userPlaceSummariesProvider', () {
     test('remote mode는 소속 장소 조회를 repository에 위임한다', () async {
       final repository = _StaticPlaceRepository([
         const PlaceSummary(id: 'place-1', name: '거실'),
@@ -21,9 +22,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final places = await container.read(
-        plantRegistrationPlaceProvider.future,
-      );
+      final places = await container.read(userPlaceSummariesProvider.future);
 
       expect([for (final place in places) place.name], ['거실', '작업실']);
       expect(repository.fetchUserPlacesCalls, 1);

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -2,8 +2,13 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_state.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,53 +16,62 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlantFormController', () {
-    test('local 식물 생성은 목록에 추가하고 홈 이동 결과를 반환한다', () async {
+    test('local 식물 생성은 선택 장소와 plant draft를 목록에 저장한다', () async {
       final container = ProviderContainer();
+      const args = PlantFormArgs(initialPlantName: ' 몬스테라 ');
+      final subscription = container.listen(
+        plantFormControllerProvider(args),
+        (previous, next) {},
+      );
 
+      addTearDown(subscription.close);
       addTearDown(container.dispose);
 
-      final result = await container
-          .read(plantFormControllerProvider.notifier)
-          .submit(
-            const PlantFormSubmitInput.create(
-              plantName: '  몬스테라  ',
-              placeId: 'place-1',
-              placeName: '거실',
-            ),
-          );
+      final controller = container.read(
+        plantFormControllerProvider(args).notifier,
+      );
+      controller.selectPlace(plantRegistrationPlaceFallbacks[1]);
+
+      final result = await controller.submit();
       final plants = container.read(plantListProvider);
 
       expect(result?.destination, PlantFormSubmitDestination.home);
       expect(
-        container.read(plantFormControllerProvider),
+        container.read(plantFormControllerProvider(args)).submitState,
         const FormSubmitState.idle(),
       );
       expect(plants, hasLength(1));
       expect(plants.single.name, '몬스테라');
-      expect(plants.single.placeId, 'place-1');
-      expect(plants.single.placeName, '거실');
+      expect(plants.single.placeId, 'place-2');
+      expect(plants.single.placeName, '낫 스윗 회사_가든');
     });
 
-    test('remote 식물 생성은 repository를 호출하고 local 목록도 갱신한다', () async {
+    test('remote 식물 생성은 Provider 장소를 사용해 repository를 호출한다', () async {
       final repository = _RecordingPlantRepository();
       final container = ProviderContainer(
         overrides: [
           useRemoteApiProvider.overrideWithValue(true),
           plantRepositoryProvider.overrideWithValue(repository),
+          plantRegistrationPlaceProvider.overrideWith(
+            (ref) => [plantRegistrationPlaceFallbacks.first],
+          ),
         ],
       );
+      const args = PlantFormArgs(initialPlantName: '몬스테라');
+      final subscription = container.listen(
+        plantFormControllerProvider(args),
+        (previous, next) {},
+      );
 
+      addTearDown(subscription.close);
       addTearDown(container.dispose);
 
+      await container.read(plantRegistrationPlaceProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
       final result = await container
-          .read(plantFormControllerProvider.notifier)
-          .submit(
-            const PlantFormSubmitInput.create(
-              plantName: '몬스테라',
-              placeId: 'place-1',
-              placeName: '거실',
-            ),
-          );
+          .read(plantFormControllerProvider(args).notifier)
+          .submit();
       final plants = container.read(plantListProvider);
 
       expect(result?.destination, PlantFormSubmitDestination.home);
@@ -70,7 +84,7 @@ void main() {
       expect(plants.single.name, '몬스테라');
     });
 
-    test('local 식물 수정은 목록 값을 갱신하고 상세 이동 결과를 반환한다', () async {
+    test('local 식물 수정은 조회 초기값과 변경한 이름을 목록에 반영한다', () async {
       final container = ProviderContainer();
 
       addTearDown(container.dispose);
@@ -78,16 +92,24 @@ void main() {
       final plant = container
           .read(plantListProvider.notifier)
           .addPlant(name: '몬테', placeId: 'place-1', placeName: '거실');
+      final args = PlantFormArgs(plantId: plant.id, placeId: 'place-1');
+      final subscription = container.listen(
+        plantFormControllerProvider(args),
+        (previous, next) {},
+      );
+      addTearDown(subscription.close);
 
-      final result = await container
-          .read(plantFormControllerProvider.notifier)
-          .submit(
-            PlantFormSubmitInput.update(
-              plantId: plant.id,
-              plantName: '몬테라',
-              placeId: 'place-1',
-            ),
-          );
+      final initialState = container.read(plantFormControllerProvider(args));
+      final controller = container.read(
+        plantFormControllerProvider(args).notifier,
+      );
+
+      expect(initialState.loadStatus, PlantFormLoadStatus.ready);
+      expect(initialState.currentName, '몬테');
+      expect(initialState.canSubmit, isFalse);
+
+      controller.updateName('몬테라');
+      final result = await controller.submit();
       final plants = container.read(plantListProvider);
 
       expect(result?.destination, PlantFormSubmitDestination.plantDetail);
@@ -96,7 +118,7 @@ void main() {
       expect(plants.single.name, '몬테라');
     });
 
-    test('remote 식물 수정은 repository를 호출하고 상세 이동 결과를 반환한다', () async {
+    test('remote 식물 수정은 조회값을 draft로 사용하고 repository를 호출한다', () async {
       final repository = _RecordingPlantRepository();
       final container = ProviderContainer(
         overrides: [
@@ -104,28 +126,33 @@ void main() {
           plantRepositoryProvider.overrideWithValue(repository),
         ],
       );
+      const args = PlantFormArgs(plantId: 'plant-1', placeId: 'place-1');
+      final subscription = container.listen(
+        plantFormControllerProvider(args),
+        (previous, next) {},
+      );
 
+      addTearDown(subscription.close);
       addTearDown(container.dispose);
 
-      final result = await container
-          .read(plantFormControllerProvider.notifier)
-          .submit(
-            const PlantFormSubmitInput.update(
-              plantId: 'plant-1',
-              plantName: '몬테라',
-              placeId: 'place-1',
-            ),
-          );
+      await container.read(remotePlantFormEditInfoProvider('plant-1').future);
+      await Future<void>.delayed(Duration.zero);
+
+      final initialState = container.read(plantFormControllerProvider(args));
+      final controller = container.read(
+        plantFormControllerProvider(args).notifier,
+      );
+
+      expect(initialState.currentName, '몬테');
+
+      controller.updateName('몬테라');
+      final result = await controller.submit();
 
       expect(result?.destination, PlantFormSubmitDestination.plantDetail);
       expect(repository.updateCalls, 1);
       expect(repository.latestUpdatePlantId, 'plant-1');
       expect(repository.latestUpdatePlaceCode, 'place-1');
       expect(repository.latestUpdateRequest?.toJson(), {'nickname': '몬테라'});
-      expect(
-        container.read(plantFormControllerProvider),
-        const FormSubmitState.idle(),
-      );
     });
   });
 }
@@ -139,6 +166,11 @@ class _RecordingPlantRepository extends PlantRepository {
   String? latestUpdatePlaceCode;
   CreatePlantRequest? latestCreateRequest;
   UpdatePlantRequest? latestUpdateRequest;
+
+  @override
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
+    return const PlantEditInfo(name: '몬테');
+  }
 
   @override
   Future<void> createPlant(

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -2,7 +2,6 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';

--- a/test/features/plant/presentation/providers/plant_form_state_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_state_test.dart
@@ -1,0 +1,80 @@
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_state.dart';
+import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const places = [
+    PlantRegistrationPlace(id: 'place-1', name: '거실', imageAsset: 'living'),
+    PlantRegistrationPlace(id: 'place-2', name: '작업실', imageAsset: 'work'),
+  ];
+
+  group('PlantFormState', () {
+    test('생성 상태는 첫 장소를 선택하고 제출할 수 있다', () {
+      final state = PlantFormState.create(plantName: '몬스테라', places: places);
+
+      expect(state.isEdit, isFalse);
+      expect(state.selectedPlace?.id, 'place-1');
+      expect(state.canSubmit, isTrue);
+    });
+
+    test('생성 상태는 장소가 없거나 제출 중이면 제출할 수 없다', () {
+      final emptyState = PlantFormState.create(
+        plantName: '몬스테라',
+        places: const [],
+      );
+      final submittingState = PlantFormState.create(
+        plantName: '몬스테라',
+        places: places,
+      ).copyWith(submitState: const FormSubmitState.submitting());
+
+      expect(emptyState.canSubmit, isFalse);
+      expect(submittingState.canSubmit, isFalse);
+    });
+
+    test('수정 상태는 이름이 달라진 경우에만 제출할 수 있다', () {
+      const state = PlantFormState.edit(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+        name: '몬테',
+      );
+
+      expect(state.isEdit, isTrue);
+      expect(state.hasChanges, isFalse);
+      expect(state.canSubmit, isFalse);
+      expect(state.copyWith(currentName: '몬테라').canSubmit, isTrue);
+    });
+
+    test('로딩과 조회 실패 상태는 제출할 수 없다', () {
+      const loadingState = PlantFormState.loadingEdit(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+      );
+      const failureState = PlantFormState.failure(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+        message: '조회 실패',
+      );
+
+      expect(loadingState.canSubmit, isFalse);
+      expect(failureState.canSubmit, isFalse);
+      expect(failureState.loadErrorMessage, '조회 실패');
+    });
+
+    test('route 인자가 같으면 family Provider key도 같다', () {
+      const first = PlantFormArgs(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+        initialPlantName: '몬스테라',
+      );
+      const second = PlantFormArgs(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+        initialPlantName: '몬스테라',
+      );
+
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+    });
+  });
+}

--- a/test/features/plant/presentation/providers/plant_registration_place_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_registration_place_provider_test.dart
@@ -1,0 +1,26 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('사용자 장소를 Plant 등록 장소 모델로 변환한다', () async {
+    final container = ProviderContainer(
+      overrides: [
+        userPlaceSummariesProvider.overrideWith(
+          (ref) => [
+            const PlaceSummary(id: 'place-1', name: '거실'),
+            const PlaceSummary(id: 'place-2', name: '작업실'),
+          ],
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final places = await container.read(plantRegistrationPlaceProvider.future);
+
+    expect([for (final place in places) place.id], ['place-1', 'place-2']);
+    expect([for (final place in places) place.name], ['거실', '작업실']);
+  });
+}


### PR DESCRIPTION
## 작업 내용
- Plant 폼의 생성/수정 상태와 제출 가능 여부를 `PlantFormState`로 통합했습니다.
- 장소 목록 Provider의 소유권을 Place/Plant 도메인 경계에 맞게 재배치했습니다.
- 생성/수정 조회, 입력, 제출을 family Controller 한 곳에서 관리하도록 정리했습니다.
- `PlantFormPage`를 `ConsumerWidget`으로 전환하고 텍스트 컨트롤러는 leaf widget으로 격리했습니다.
- 상태 계산, Provider 매핑, 로컬/원격 제출 회귀 테스트를 보강했습니다.

## 영향
- 화면이 직접 관리하던 폼 상태와 비동기 분기를 제거해 Plant 폼의 상태 흐름과 테스트 경계를 명확히 했습니다.
- 사용자에게 보이는 등록/수정 동작과 라우팅은 유지됩니다.

## 검증
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test` (218개 통과)
- Plant 폼 및 라우터 대상 테스트 39개 통과

Closes #182
