### PR TITLE
Refactor: Place/Plant 상세 ViewData 정리 #184

### DIFF
--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Flutter, Dart, Riverpod, go_router, flutter_test
 
-**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-07 Task 7까지 병합됐고, Task 8은 로컬 구현과 전체 검증을 완료했으나 GitHub 저장소 쓰기 권한 403으로 push와 PR 생성이 대기 중이다.
+**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-10 Task 7까지 병합됐고, Task 8 구현과 전체 검증을 완료해 PR #187에서 리뷰 중이다.
 
 ---
 
@@ -610,7 +610,7 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 6. Place form state 통합 | #178 | #179 | Done |
 | Task 1~6 중간 검증 | #180 | #181 | Done |
 | Task 7. Plant form state와 Provider 소유권 정리 | #182 | #183 | Done |
-| Task 8. Place/Plant detail ViewData 경계 정리 | #184 | - | In Progress (push blocked) |
+| Task 8. Place/Plant detail ViewData 경계 정리 | #184 | #187 | In Review |
 | Task 9. Repository 계약과 local/remote 경계 정리 | 시작 시 생성 | - | Pending |
 | Task 10. 미사용 Phase 0 구조 정리 | 시작 시 생성 | - | Pending |
 | Task 11. Router/test helper 가독성 정리 | 시작 시 생성 | - | Pending |

--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Flutter, Dart, Riverpod, go_router, flutter_test
 
-**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-05 Task 7 구현과 전체 검증을 완료하고 PR #183에서 리뷰 중이다.
+**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-07 Task 7까지 병합됐고, Task 8은 로컬 구현과 전체 검증을 완료했으나 GitHub 저장소 쓰기 권한 403으로 push와 PR 생성이 대기 중이다.
 
 ---
 
@@ -582,13 +582,13 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 
 3차 라운드는 아래 조건을 만족하면 완료로 본다.
 
-- [ ] feature route/page의 StatefulWidget 11개가 `ConsumerWidget`으로 전환된다.
-- [ ] `features/**/pages`에 화면 상태 변경 목적의 `setState`가 없다.
-- [ ] StatefulWidget은 shared 또는 lifecycle leaf widget에만 남는다.
-- [ ] `FormSubmitController` 기반 ChangeNotifier 혼용이 제거된다.
+- [x] feature route/page의 StatefulWidget 11개가 `ConsumerWidget`으로 전환된다.
+- [x] `features/**/pages`에 화면 상태 변경 목적의 `setState`가 없다.
+- [x] StatefulWidget은 shared 또는 lifecycle leaf widget에만 남는다.
+- [x] `FormSubmitController` 기반 ChangeNotifier 혼용이 제거된다.
 - [ ] 검색, 선택, 폼 draft, 제출 상태가 Riverpod Controller test로 검증된다.
-- [ ] Provider 공개 타입에서 `FixtureData` 이름이 제거된다.
-- [ ] fixture가 widget 파일에 정의된 item model을 import하지 않는다.
+- [x] Provider 공개 타입에서 `FixtureData` 이름이 제거된다.
+- [x] fixture가 widget 파일에 정의된 item model을 import하지 않는다.
 - [ ] feature 간 presentation Provider 직접 의존이 줄어든다.
 - [ ] page가 `useRemoteApiProvider`, request DTO, repository 구현을 직접 알지 않는다.
 - [ ] 사용처 없는 Phase 0 위젯이 제거된다.
@@ -609,8 +609,8 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 5. Profile setup state 통합 | #176 | #177 | Done |
 | Task 6. Place form state 통합 | #178 | #179 | Done |
 | Task 1~6 중간 검증 | #180 | #181 | Done |
-| Task 7. Plant form state와 Provider 소유권 정리 | #182 | #183 | In Review |
-| Task 8. Place/Plant detail ViewData 경계 정리 | 시작 시 생성 | - | Pending |
+| Task 7. Plant form state와 Provider 소유권 정리 | #182 | #183 | Done |
+| Task 8. Place/Plant detail ViewData 경계 정리 | #184 | - | In Progress (push blocked) |
 | Task 9. Repository 계약과 local/remote 경계 정리 | 시작 시 생성 | - | Pending |
 | Task 10. 미사용 Phase 0 구조 정리 | 시작 시 생성 | - | Pending |
 | Task 11. Router/test helper 가독성 정리 | 시작 시 생성 | - | Pending |
@@ -638,5 +638,8 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 7 | `1888adc` | Plant 폼 조회·선택·생성·수정·제출 상태를 family Controller로 통합 | Plant form controller/page test 11개 |
 | Task 7 | `64e9208` | Plant form page를 `ConsumerWidget`으로 전환하고 이름 입력 제어를 leaf widget으로 이동 | Plant 폼 및 router 대상 test 39개 |
 | Task 7 | `7c7093c` | Provider facade와 Controller test의 불필요한 import 정리 | format, analyze, 전체 test 218개 |
+| Task 8 | `73cac15` | Place 상세 ViewData와 item model을 정의하고 remote summary 합성을 view mapper로 분리 | Place 상세 대상 test 15개 |
+| Task 8 | `d2e618b` | Plant 상세 ViewData와 memo item model을 정의하고 remote detail 합성을 view mapper로 분리 | Plant 상세 대상 test 14개 |
+| Task 8 | - | `FixtureData` 공개 타입과 detail fixture의 widget 역의존 제거를 구조 감사하고 작업 이력 갱신 | 대상 test 29개, format, analyze, 전체 test 218개 |
 
 Task 6부터는 구현 커밋을 책임별로 나누고 각 커밋을 별도 행으로 기록한다. 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/lib/features/place/presentation/fixtures/place_detail_fixture.dart
+++ b/lib/features/place/presentation/fixtures/place_detail_fixture.dart
@@ -1,48 +1,14 @@
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
-import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_header.dart';
-import 'package:commonplant_frontend/features/place/presentation/widgets/place_plant_list.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 
-class PlaceDetailFixtureData {
-  const PlaceDetailFixtureData({
-    required this.role,
-    required this.name,
-    required this.address,
-    required this.sunlightLabel,
-    required this.humidityLabel,
-    required this.friends,
-    required this.plants,
-  });
-
-  final PlaceDetailRole role;
-  final String name;
-  final String address;
-  final String sunlightLabel;
-  final String humidityLabel;
-  final List<PlaceDetailFriendItem> friends;
-  final List<PlaceDetailPlantItem> plants;
-
-  PlaceDetailFixtureData applySummary(PlaceSummary summary) {
-    return PlaceDetailFixtureData(
-      role: role,
-      name: summary.name,
-      address: summary.address ?? address,
-      sunlightLabel: sunlightLabel,
-      humidityLabel: humidityLabel,
-      friends: friends,
-      plants: plants,
-    );
-  }
-}
-
-PlaceDetailFixtureData placeDetailFixture(
+PlaceDetailViewData placeDetailFixture(
   String placeId, {
   PlaceDetailRole? role,
 }) {
   final effectiveRole = role ?? _roleFromPlaceId(placeId);
 
-  return PlaceDetailFixtureData(
+  return PlaceDetailViewData(
     role: effectiveRole,
     name: '스윗 홈_거실',
     address: '서울시 노원구 광운로 20',

--- a/lib/features/place/presentation/mappers/place_detail_view_mapper.dart
+++ b/lib/features/place/presentation/mappers/place_detail_view_mapper.dart
@@ -1,0 +1,21 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
+
+PlaceDetailViewData? mapPlaceSummaryToDetailViewData({
+  required PlaceDetailViewData fallback,
+  required PlaceSummary summary,
+}) {
+  if (summary.name.trim().isEmpty) {
+    return null;
+  }
+
+  return PlaceDetailViewData(
+    role: fallback.role,
+    name: summary.name,
+    address: summary.address ?? fallback.address,
+    sunlightLabel: fallback.sunlightLabel,
+    humidityLabel: fallback.humidityLabel,
+    friends: fallback.friends,
+    plants: fallback.plants,
+  );
+}

--- a/lib/features/place/presentation/models/place_detail_view_data.dart
+++ b/lib/features/place/presentation/models/place_detail_view_data.dart
@@ -1,0 +1,60 @@
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
+
+class PlaceDetailViewData {
+  const PlaceDetailViewData({
+    required this.role,
+    required this.name,
+    required this.address,
+    required this.sunlightLabel,
+    required this.humidityLabel,
+    required this.friends,
+    required this.plants,
+  });
+
+  final PlaceDetailRole role;
+  final String name;
+  final String address;
+  final String sunlightLabel;
+  final String humidityLabel;
+  final List<PlaceDetailFriendItem> friends;
+  final List<PlaceDetailPlantItem> plants;
+}
+
+class PlaceDetailFriendItem {
+  const PlaceDetailFriendItem({
+    required this.id,
+    required this.name,
+    this.imageAsset,
+    this.isOwner = false,
+  });
+
+  final String id;
+  final String name;
+  final String? imageAsset;
+  final bool isOwner;
+
+  PlaceFriendProfile toProfile() {
+    return PlaceFriendProfile(id: id, name: name, imageAsset: imageAsset);
+  }
+}
+
+class PlaceDetailPlantItem {
+  const PlaceDetailPlantItem({
+    required this.id,
+    required this.name,
+    required this.species,
+    required this.description,
+    required this.dDayLabel,
+    required this.dateLabel,
+    this.canWater = false,
+  });
+
+  final String id;
+  final String name;
+  final String species;
+  final String description;
+  final String dDayLabel;
+  final String dateLabel;
+  final bool canWater;
+}

--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -6,8 +6,8 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_view_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_fab.dart';
@@ -119,7 +119,7 @@ class PlaceDetailPage extends ConsumerWidget {
   Widget _buildScaffold(
     BuildContext context,
     WidgetRef ref,
-    PlaceDetailFixtureData detail,
+    PlaceDetailViewData detail,
   ) {
     return CommonScaffold(
       title: 'My place',

--- a/lib/features/place/presentation/providers/place_detail_view_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_view_provider.dart
@@ -1,17 +1,18 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/mappers/place_detail_view_mapper.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef PlaceDetailViewRequest = ({String placeId, PlaceDetailRole? role});
 
 final placeDetailViewProvider =
-    Provider.family<
-      AsyncValue<PlaceDetailFixtureData?>,
-      PlaceDetailViewRequest
-    >((ref, request) {
+    Provider.family<AsyncValue<PlaceDetailViewData?>, PlaceDetailViewRequest>((
+      ref,
+      request,
+    ) {
       if (!ref.watch(useRemoteApiProvider)) {
         return AsyncData(ref.watch(placeLocalDetailViewProvider(request)));
       }
@@ -20,7 +21,7 @@ final placeDetailViewProvider =
     });
 
 final placeLocalDetailViewProvider =
-    Provider.family<PlaceDetailFixtureData, PlaceDetailViewRequest>((
+    Provider.family<PlaceDetailViewData, PlaceDetailViewRequest>((
       ref,
       request,
     ) {
@@ -28,31 +29,20 @@ final placeLocalDetailViewProvider =
     });
 
 final placeRemoteDetailViewProvider =
-    FutureProvider.family<PlaceDetailFixtureData?, PlaceDetailViewRequest>((
+    FutureProvider.family<PlaceDetailViewData?, PlaceDetailViewRequest>((
       ref,
       request,
     ) async {
-      final fixture = ref.watch(placeLocalDetailViewProvider(request));
+      final fallback = ref.watch(placeLocalDetailViewProvider(request));
       final summary = await ref.watch(
         placeDetailProvider(request.placeId).future,
       );
 
-      return applyRemotePlaceSummaryToFixture(
-        fixture: fixture,
+      return mapPlaceSummaryToDetailViewData(
+        fallback: fallback,
         summary: summary,
       );
     }, retry: (retryCount, error) => null);
-
-PlaceDetailFixtureData? applyRemotePlaceSummaryToFixture({
-  required PlaceDetailFixtureData fixture,
-  required PlaceSummary summary,
-}) {
-  if (summary.name.trim().isEmpty) {
-    return null;
-  }
-
-  return fixture.applySummary(summary);
-}
 
 void invalidatePlaceDetailView(WidgetRef ref, PlaceDetailViewRequest request) {
   ref.invalidate(placeDetailProvider(request.placeId));

--- a/lib/features/place/presentation/widgets/place_detail_header.dart
+++ b/lib/features/place/presentation/widgets/place_detail_header.dart
@@ -5,29 +5,12 @@ import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_friend_profile.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_friend_avatar.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
-class PlaceDetailFriendItem {
-  const PlaceDetailFriendItem({
-    required this.id,
-    required this.name,
-    this.imageAsset,
-    this.isOwner = false,
-  });
-
-  final String id;
-  final String name;
-  final String? imageAsset;
-  final bool isOwner;
-
-  PlaceFriendProfile toProfile() {
-    return PlaceFriendProfile(id: id, name: name, imageAsset: imageAsset);
-  }
-}
 
 class PlaceDetailHeader extends StatelessWidget {
   const PlaceDetailHeader({

--- a/lib/features/place/presentation/widgets/place_plant_list.dart
+++ b/lib/features/place/presentation/widgets/place_plant_list.dart
@@ -3,30 +3,11 @@ import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 import 'package:commonplant_frontend/shared/widgets/common_plant_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_watering_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
-class PlaceDetailPlantItem {
-  const PlaceDetailPlantItem({
-    required this.id,
-    required this.name,
-    required this.species,
-    required this.description,
-    required this.dDayLabel,
-    required this.dateLabel,
-    this.canWater = false,
-  });
-
-  final String id;
-  final String name;
-  final String species;
-  final String description;
-  final String dDayLabel;
-  final String dateLabel;
-  final bool canWater;
-}
 
 class PlacePlantList extends StatelessWidget {
   const PlacePlantList({

--- a/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
+++ b/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
@@ -1,50 +1,8 @@
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
-import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_memo_preview_section.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 
-class PlantDetailFixtureData {
-  const PlantDetailFixtureData({
-    required this.placeCode,
-    required this.placeName,
-    required this.name,
-    required this.species,
-    required this.daysTogether,
-    required this.dDayLabel,
-    required this.startDate,
-    required this.lastWateredDate,
-    required this.wateringCycleLabel,
-    required this.memos,
-  });
-
-  final String? placeCode;
-  final String placeName;
-  final String name;
-  final String species;
-  final int daysTogether;
-  final String dDayLabel;
-  final String startDate;
-  final String lastWateredDate;
-  final String wateringCycleLabel;
-  final List<PlantDetailMemoItem> memos;
-
-  PlantDetailFixtureData applyRemote(PlantDetail detail) {
-    return PlantDetailFixtureData(
-      placeCode: detail.placeId ?? placeCode,
-      placeName: detail.placeName ?? placeName,
-      name: detail.name,
-      species: detail.species ?? species,
-      daysTogether: daysTogether,
-      dDayLabel: dDayLabel,
-      startDate: startDate,
-      lastWateredDate: detail.lastWateredDate ?? lastWateredDate,
-      wateringCycleLabel: wateringCycleLabel,
-      memos: memos,
-    );
-  }
-}
-
-PlantDetailFixtureData plantDetailFixture({String? placeCode}) {
-  return PlantDetailFixtureData(
+PlantDetailViewData plantDetailFixture({String? placeCode}) {
+  return PlantDetailViewData(
     placeCode: placeCode,
     placeName: '스윗홈_거실',
     name: '몬테',

--- a/lib/features/plant/presentation/mappers/plant_detail_view_mapper.dart
+++ b/lib/features/plant/presentation/mappers/plant_detail_view_mapper.dart
@@ -1,0 +1,24 @@
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
+
+PlantDetailViewData? mapPlantDetailToViewData({
+  required PlantDetailViewData fallback,
+  required PlantDetail detail,
+}) {
+  if (detail.name.trim().isEmpty) {
+    return null;
+  }
+
+  return PlantDetailViewData(
+    placeCode: detail.placeId ?? fallback.placeCode,
+    placeName: detail.placeName ?? fallback.placeName,
+    name: detail.name,
+    species: detail.species ?? fallback.species,
+    daysTogether: fallback.daysTogether,
+    dDayLabel: fallback.dDayLabel,
+    startDate: fallback.startDate,
+    lastWateredDate: detail.lastWateredDate ?? fallback.lastWateredDate,
+    wateringCycleLabel: fallback.wateringCycleLabel,
+    memos: fallback.memos,
+  );
+}

--- a/lib/features/plant/presentation/models/plant_detail_view_data.dart
+++ b/lib/features/plant/presentation/models/plant_detail_view_data.dart
@@ -1,0 +1,41 @@
+class PlantDetailViewData {
+  const PlantDetailViewData({
+    required this.placeCode,
+    required this.placeName,
+    required this.name,
+    required this.species,
+    required this.daysTogether,
+    required this.dDayLabel,
+    required this.startDate,
+    required this.lastWateredDate,
+    required this.wateringCycleLabel,
+    required this.memos,
+  });
+
+  final String? placeCode;
+  final String placeName;
+  final String name;
+  final String species;
+  final int daysTogether;
+  final String dDayLabel;
+  final String startDate;
+  final String lastWateredDate;
+  final String wateringCycleLabel;
+  final List<PlantDetailMemoItem> memos;
+}
+
+class PlantDetailMemoItem {
+  const PlantDetailMemoItem({
+    required this.author,
+    required this.content,
+    required this.dateLabel,
+    this.avatarAsset,
+    this.thumbnailAsset,
+  });
+
+  final String author;
+  final String content;
+  final String dateLabel;
+  final String? avatarAsset;
+  final String? thumbnailAsset;
+}

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
-import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_care_summary.dart';
@@ -115,7 +115,7 @@ class PlantDetailPage extends ConsumerWidget {
   Widget _buildScaffold(
     BuildContext context,
     WidgetRef ref,
-    PlantDetailFixtureData detail,
+    PlantDetailViewData detail,
   ) {
     return CommonScaffold(
       title: 'My plant',

--- a/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
@@ -1,16 +1,17 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/mappers/plant_detail_view_mapper.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef PlantDetailViewRequest = ({String plantId, String? placeCode});
 
 final plantDetailViewProvider =
-    Provider.family<
-      AsyncValue<PlantDetailFixtureData?>,
-      PlantDetailViewRequest
-    >((ref, request) {
+    Provider.family<AsyncValue<PlantDetailViewData?>, PlantDetailViewRequest>((
+      ref,
+      request,
+    ) {
       if (!ref.watch(useRemoteApiProvider)) {
         return AsyncData(ref.watch(plantLocalDetailViewProvider(request)));
       }
@@ -19,7 +20,7 @@ final plantDetailViewProvider =
     });
 
 final plantLocalDetailViewProvider =
-    Provider.family<PlantDetailFixtureData, PlantDetailViewRequest>((
+    Provider.family<PlantDetailViewData, PlantDetailViewRequest>((
       ref,
       request,
     ) {
@@ -27,28 +28,17 @@ final plantLocalDetailViewProvider =
     });
 
 final plantRemoteDetailViewProvider =
-    FutureProvider.family<PlantDetailFixtureData?, PlantDetailViewRequest>((
+    FutureProvider.family<PlantDetailViewData?, PlantDetailViewRequest>((
       ref,
       request,
     ) async {
-      final fixture = ref.watch(plantLocalDetailViewProvider(request));
+      final fallback = ref.watch(plantLocalDetailViewProvider(request));
       final detail = await ref.watch(
         remotePlantDetailProvider(request.plantId).future,
       );
 
-      return applyRemotePlantDetailToFixture(fixture: fixture, detail: detail);
+      return mapPlantDetailToViewData(fallback: fallback, detail: detail);
     }, retry: (retryCount, error) => null);
-
-PlantDetailFixtureData? applyRemotePlantDetailToFixture({
-  required PlantDetailFixtureData fixture,
-  required PlantDetail detail,
-}) {
-  if (detail.name.trim().isEmpty) {
-    return null;
-  }
-
-  return fixture.applyRemote(detail);
-}
 
 void invalidatePlantDetailView(WidgetRef ref, PlantDetailViewRequest request) {
   ref.invalidate(remotePlantDetailProvider(request.plantId));

--- a/lib/features/plant/presentation/widgets/plant_memo_preview_section.dart
+++ b/lib/features/plant/presentation/widgets/plant_memo_preview_section.dart
@@ -4,28 +4,13 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_content_width.dart';
 import 'package:commonplant_frontend/shared/widgets/common_button.dart';
 import 'package:commonplant_frontend/shared/widgets/common_memo_card.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
-class PlantDetailMemoItem {
-  const PlantDetailMemoItem({
-    required this.author,
-    required this.content,
-    required this.dateLabel,
-    this.avatarAsset,
-    this.thumbnailAsset,
-  });
-
-  final String author;
-  final String content;
-  final String dateLabel;
-  final String? avatarAsset;
-  final String? thumbnailAsset;
-}
 
 class MemoPreviewSection extends StatelessWidget {
   const MemoPreviewSection({

--- a/test/features/place/presentation/fixtures/place_detail_fixture_test.dart
+++ b/test/features/place/presentation/fixtures/place_detail_fixture_test.dart
@@ -1,4 +1,3 @@
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,23 +22,6 @@ void main() {
       expect(leaderDetail.plants, hasLength(4));
       expect(leaderDetail.plants.first.canWater, isTrue);
       expect(memberDetail.role, PlaceDetailRole.member);
-    });
-
-    test('remote summary를 적용해도 fixture 보조 정보는 유지한다', () {
-      final detail = placeDetailFixture('place-1').applySummary(
-        const PlaceSummary(
-          id: 'remote-place',
-          name: '옥상 정원',
-          address: '서울시 성북구',
-        ),
-      );
-
-      expect(detail.name, '옥상 정원');
-      expect(detail.address, '서울시 성북구');
-      expect(detail.sunlightLabel, '9.3 / 5');
-      expect(detail.humidityLabel, '69%');
-      expect(detail.friends, hasLength(3));
-      expect(detail.plants, hasLength(4));
     });
   });
 }

--- a/test/features/place/presentation/mappers/place_detail_view_mapper_test.dart
+++ b/test/features/place/presentation/mappers/place_detail_view_mapper_test.dart
@@ -1,0 +1,24 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/presentation/mappers/place_detail_view_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('remote summary를 ViewData에 적용하고 fallback 보조 정보는 유지한다', () {
+    final detail = mapPlaceSummaryToDetailViewData(
+      fallback: placeDetailFixture('place-1'),
+      summary: const PlaceSummary(
+        id: 'remote-place',
+        name: '옥상 정원',
+        address: '서울시 성북구',
+      ),
+    );
+
+    expect(detail?.name, '옥상 정원');
+    expect(detail?.address, '서울시 성북구');
+    expect(detail?.sunlightLabel, '9.3 / 5');
+    expect(detail?.humidityLabel, '69%');
+    expect(detail?.friends, hasLength(3));
+    expect(detail?.plants, hasLength(4));
+  });
+}

--- a/test/features/place/presentation/widgets/place_detail_widgets_test.dart
+++ b/test/features/place/presentation/widgets/place_detail_widgets_test.dart
@@ -1,3 +1,4 @@
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_fab.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_detail_header.dart';
 import 'package:commonplant_frontend/features/place/presentation/widgets/place_plant_list.dart';

--- a/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
+++ b/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
@@ -1,4 +1,3 @@
-import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,26 +14,6 @@ void main() {
       expect(detail.wateringCycleLabel, '10 Day');
       expect(detail.memos, hasLength(4));
       expect(detail.memos.first.author, '커먼플랜트');
-    });
-
-    test('remote detail을 적용할 때 없는 값은 fallback을 유지한다', () {
-      final detail = plantDetailFixture(placeCode: 'fallback-place')
-          .applyRemote(
-            const PlantDetail(
-              id: 'plant-remote',
-              name: '필로덴드론',
-              placeName: '거실 정원',
-              lastWateredDate: '2026.05.25',
-            ),
-          );
-
-      expect(detail.placeCode, 'fallback-place');
-      expect(detail.placeName, '거실 정원');
-      expect(detail.name, '필로덴드론');
-      expect(detail.species, 'Monstera deliciosa');
-      expect(detail.lastWateredDate, '2026.05.25');
-      expect(detail.dDayLabel, 'D-3');
-      expect(detail.memos, hasLength(4));
     });
   });
 }

--- a/test/features/plant/presentation/mappers/plant_detail_view_mapper_test.dart
+++ b/test/features/plant/presentation/mappers/plant_detail_view_mapper_test.dart
@@ -1,0 +1,26 @@
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
+import 'package:commonplant_frontend/features/plant/presentation/mappers/plant_detail_view_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('remote detail을 ViewData에 적용하고 없는 값은 fallback을 유지한다', () {
+    final detail = mapPlantDetailToViewData(
+      fallback: plantDetailFixture(placeCode: 'fallback-place'),
+      detail: const PlantDetail(
+        id: 'plant-remote',
+        name: '필로덴드론',
+        placeName: '거실 정원',
+        lastWateredDate: '2026.05.25',
+      ),
+    );
+
+    expect(detail?.placeCode, 'fallback-place');
+    expect(detail?.placeName, '거실 정원');
+    expect(detail?.name, '필로덴드론');
+    expect(detail?.species, 'Monstera deliciosa');
+    expect(detail?.lastWateredDate, '2026.05.25');
+    expect(detail?.dDayLabel, 'D-3');
+    expect(detail?.memos, hasLength(4));
+  });
+}

--- a/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
+++ b/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
@@ -1,3 +1,4 @@
+import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_care_summary.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_content_width.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_hero.dart';


### PR DESCRIPTION
## 관련 이슈
- Closes #184
- Parent: #165

## 작업 내용
- `PlaceDetailViewData`, `PlantDetailViewData`를 presentation model로 추가했습니다.
- Place friend/plant item과 Plant memo item model을 widget 파일 밖으로 이동했습니다.
- detail fixture는 local ViewData 생성만 담당하도록 정리했습니다.
- remote entity와 fallback ViewData 합성을 Place/Plant 전용 view mapper로 분리했습니다.
- Provider 공개 타입에서 `FixtureData`를 제거했습니다.

## 영향
- fixture, Provider, widget 사이의 역의존이 제거되어 상세 화면의 데이터 흐름을 타입 이름으로 추적할 수 있습니다.
- Place/Plant 상세 화면의 local/remote 표시와 loading/empty/error 동작은 유지됩니다.

## 커밋
- `73cac15` Place 상세 ViewData 및 mapper 분리
- `d2e618b` Plant 상세 ViewData 및 mapper 분리
- `2dbb302` Task 8 작업 이력과 검증 결과 문서화
- `e14e691` 계획 문서에 PR #187과 In Review 상태 반영

## 검증
- Place/Plant 상세 대상 테스트 29개 통과
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test` 전체 218개 통과
- Provider 공개 타입의 `FixtureData` 0건
- detail fixture의 widget import 0건

## Breaking change
- 없음
