### PR TITLE
[Task] Place/Plant Repository 계약 정리

### DIFF
--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Flutter, Dart, Riverpod, go_router, flutter_test
 
-**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-10 Task 7까지 병합됐고, Task 8 구현과 전체 검증을 완료해 PR #187에서 리뷰 중이다.
+**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-10 Task 8까지 병합됐고, Task 9 구현과 전체 검증을 완료해 PR #189에서 리뷰 중이다.
 
 ---
 
@@ -586,15 +586,15 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 - [x] `features/**/pages`에 화면 상태 변경 목적의 `setState`가 없다.
 - [x] StatefulWidget은 shared 또는 lifecycle leaf widget에만 남는다.
 - [x] `FormSubmitController` 기반 ChangeNotifier 혼용이 제거된다.
-- [ ] 검색, 선택, 폼 draft, 제출 상태가 Riverpod Controller test로 검증된다.
+- [x] 검색, 선택, 폼 draft, 제출 상태가 Riverpod Controller test로 검증된다.
 - [x] Provider 공개 타입에서 `FixtureData` 이름이 제거된다.
 - [x] fixture가 widget 파일에 정의된 item model을 import하지 않는다.
-- [ ] feature 간 presentation Provider 직접 의존이 줄어든다.
-- [ ] page가 `useRemoteApiProvider`, request DTO, repository 구현을 직접 알지 않는다.
+- [x] feature 간 presentation Provider 직접 의존이 줄어든다.
+- [x] page가 `useRemoteApiProvider`, request DTO, repository 구현을 직접 알지 않는다.
 - [ ] 사용처 없는 Phase 0 위젯이 제거된다.
 - [ ] router test가 책임별로 분리된다.
 - [ ] README와 상태관리/테스트/shared widget 문서가 실제 구조를 반영한다.
-- [ ] 전체 `fvm flutter test`가 통과한다.
+- [x] 전체 `fvm flutter test`가 통과한다.
 
 ## 이슈와 PR 기록
 
@@ -610,8 +610,8 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 6. Place form state 통합 | #178 | #179 | Done |
 | Task 1~6 중간 검증 | #180 | #181 | Done |
 | Task 7. Plant form state와 Provider 소유권 정리 | #182 | #183 | Done |
-| Task 8. Place/Plant detail ViewData 경계 정리 | #184 | #187 | In Review |
-| Task 9. Repository 계약과 local/remote 경계 정리 | 시작 시 생성 | - | Pending |
+| Task 8. Place/Plant detail ViewData 경계 정리 | #184 | #187 | Done |
+| Task 9. Repository 계약과 local/remote 경계 정리 | #188 | #189 | In Review |
 | Task 10. 미사용 Phase 0 구조 정리 | 시작 시 생성 | - | Pending |
 | Task 11. Router/test helper 가독성 정리 | 시작 시 생성 | - | Pending |
 
@@ -641,5 +641,8 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 8 | `73cac15` | Place 상세 ViewData와 item model을 정의하고 remote summary 합성을 view mapper로 분리 | Place 상세 대상 test 15개 |
 | Task 8 | `d2e618b` | Plant 상세 ViewData와 memo item model을 정의하고 remote detail 합성을 view mapper로 분리 | Plant 상세 대상 test 14개 |
 | Task 8 | - | `FixtureData` 공개 타입과 detail fixture의 widget 역의존 제거를 구조 감사하고 작업 이력 갱신 | 대상 test 29개, format, analyze, 전체 test 218개 |
+| Task 9 | `1dbe513` | Place repository domain 계약, data 구현체, feature 의존 조립 경계를 분리하고 테스트 fake의 Dio 의존 제거 | Place 대상 test 71개, analyze |
+| Task 9 | `689e1ef` | Plant repository domain 계약, data 구현체, feature 의존 조립 경계를 분리하고 테스트 fake의 Dio 의존 제거 | Plant 대상 test 63개, analyze |
+| Task 9 | - | Place/Plant presentation의 data 계층 의존과 concrete fake 상속을 구조 감사하고 Task 8·9 상태 및 작업 이력 갱신 | 구조 감사, format, analyze, 전체 test 218개 |
 
 Task 6부터는 구현 커밋을 책임별로 나누고 각 커밋을 별도 행으로 기록한다. 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/lib/features/place/data/datasources/place_remote_data_source.dart
+++ b/lib/features/place/data/datasources/place_remote_data_source.dart
@@ -4,11 +4,30 @@ import 'package:commonplant_frontend/core/network/api_exception.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:dio/dio.dart';
 
-class PlaceRemoteDataSource {
-  const PlaceRemoteDataSource(this._dio);
+abstract interface class PlaceRemoteDataSource {
+  Future<Object?> getMyGarden();
+
+  Future<Object?> getUserPlaces();
+
+  Future<Object?> getPlace(String code);
+
+  Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image});
+
+  Future<void> updatePlace({
+    required String code,
+    required UpdatePlaceRequest request,
+    MultipartFile? image,
+  });
+
+  Future<void> deletePlace(String code);
+}
+
+class DioPlaceRemoteDataSource implements PlaceRemoteDataSource {
+  const DioPlaceRemoteDataSource(this._dio);
 
   final Dio _dio;
 
+  @override
   Future<Object?> getMyGarden() async {
     try {
       final response = await _dio.get<Object?>('/place/myGarden');
@@ -19,6 +38,7 @@ class PlaceRemoteDataSource {
     }
   }
 
+  @override
   Future<Object?> getUserPlaces() async {
     try {
       final response = await _dio.get<Object?>('/place/user');
@@ -29,6 +49,7 @@ class PlaceRemoteDataSource {
     }
   }
 
+  @override
   Future<Object?> getPlace(String code) async {
     try {
       final response = await _dio.get<Object?>('/place/$code');
@@ -39,6 +60,7 @@ class PlaceRemoteDataSource {
     }
   }
 
+  @override
   Future<void> createPlace(
     CreatePlaceRequest request, {
     MultipartFile? image,
@@ -59,6 +81,7 @@ class PlaceRemoteDataSource {
     }
   }
 
+  @override
   Future<void> updatePlace({
     required String code,
     required UpdatePlaceRequest request,
@@ -80,6 +103,7 @@ class PlaceRemoteDataSource {
     }
   }
 
+  @override
   Future<void> deletePlace(String code) async {
     try {
       await _dio.delete<Object?>('/place/delete/$code');

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -1,51 +1,61 @@
-import 'package:commonplant_frontend/core/network/api_client.dart';
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final placeRemoteDataSourceProvider = Provider<PlaceRemoteDataSource>((ref) {
-  return PlaceRemoteDataSource(ref.watch(dioProvider));
-});
-
-final placeRepositoryProvider = Provider<PlaceRepository>((ref) {
-  return PlaceRepository(ref.watch(placeRemoteDataSourceProvider));
-});
-
-class PlaceRepository {
-  const PlaceRepository(this._remoteDataSource);
+class PlaceRepositoryImpl implements PlaceRepository {
+  const PlaceRepositoryImpl(this._remoteDataSource);
 
   final PlaceRemoteDataSource _remoteDataSource;
 
+  @override
   Future<List<PlaceSummary>> fetchMyGardenPlaces() async {
     final data = await _remoteDataSource.getMyGarden();
 
     return placeSummariesFromResponse(data);
   }
 
+  @override
   Future<List<PlaceSummary>> fetchUserPlaces() async {
     final data = await _remoteDataSource.getUserPlaces();
 
     return placeSummariesFromResponse(data);
   }
 
+  @override
   Future<PlaceSummary> fetchPlace(String code) async {
     final data = await _remoteDataSource.getPlace(code);
 
     return placeSummaryFromResponse(data, fallbackId: code);
   }
 
-  Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image}) {
+  @override
+  Future<void> createPlace({
+    required String name,
+    required String address,
+    MultipartFile? image,
+  }) {
+    final request = CreatePlaceRequest(name: name, address: address);
+
     return _remoteDataSource.createPlace(request, image: image);
   }
 
+  @override
   Future<void> updatePlace({
     required String code,
-    required UpdatePlaceRequest request,
+    required String name,
+    required String address,
+    String? imageKey,
     MultipartFile? image,
   }) {
+    final request = UpdatePlaceRequest(
+      name: name,
+      address: address,
+      imageKey: imageKey,
+    );
+
     return _remoteDataSource.updatePlace(
       code: code,
       request: request,
@@ -53,6 +63,7 @@ class PlaceRepository {
     );
   }
 
+  @override
   Future<void> deletePlace(String code) {
     return _remoteDataSource.deletePlace(code);
   }

--- a/lib/features/place/domain/repositories/place_repository.dart
+++ b/lib/features/place/domain/repositories/place_repository.dart
@@ -1,0 +1,20 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+
+abstract interface class PlaceRepository {
+  Future<List<PlaceSummary>> fetchMyGardenPlaces();
+
+  Future<List<PlaceSummary>> fetchUserPlaces();
+
+  Future<PlaceSummary> fetchPlace(String code);
+
+  Future<void> createPlace({required String name, required String address});
+
+  Future<void> updatePlace({
+    required String code,
+    required String name,
+    required String address,
+    String? imageKey,
+  });
+
+  Future<void> deletePlace(String code);
+}

--- a/lib/features/place/place_feature_provider.dart
+++ b/lib/features/place/place_feature_provider.dart
@@ -1,5 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/place/place_repository_provider.dart
+++ b/lib/features/place/place_repository_provider.dart
@@ -1,0 +1,13 @@
+import 'package:commonplant_frontend/core/network/api_client.dart';
+import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
+import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final placeRemoteDataSourceProvider = Provider<PlaceRemoteDataSource>((ref) {
+  return DioPlaceRemoteDataSource(ref.watch(dioProvider));
+});
+
+final placeRepositoryProvider = Provider<PlaceRepository>((ref) {
+  return PlaceRepositoryImpl(ref.watch(placeRemoteDataSourceProvider));
+});

--- a/lib/features/place/presentation/providers/place_detail_remote_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_remote_provider.dart
@@ -1,5 +1,5 @@
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final placeDetailProvider = FutureProvider.family<PlaceSummary, String>(

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -1,7 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_state.dart';
@@ -136,9 +135,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
 
       await ref
           .read(placeRepositoryProvider)
-          .createPlace(
-            CreatePlaceRequest(name: name, address: requiredAddress),
-          );
+          .createPlace(name: name, address: requiredAddress);
       ref.invalidate(remotePlaceListProvider);
     } else {
       ref
@@ -159,10 +156,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
 
       await ref
           .read(placeRepositoryProvider)
-          .updatePlace(
-            code: placeId,
-            request: UpdatePlaceRequest(name: name, address: requiredAddress),
-          );
+          .updatePlace(code: placeId, name: name, address: requiredAddress);
       ref.invalidate(placeDetailProvider(placeId));
       ref.invalidate(remotePlaceListProvider);
       ref.invalidate(userPlaceSummariesProvider);

--- a/lib/features/place/presentation/providers/place_list_provider.dart
+++ b/lib/features/place/presentation/providers/place_list_provider.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';

--- a/lib/features/plant/data/datasources/plant_remote_data_source.dart
+++ b/lib/features/plant/data/datasources/plant_remote_data_source.dart
@@ -4,11 +4,34 @@ import 'package:commonplant_frontend/core/network/api_exception.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:dio/dio.dart';
 
-class PlantRemoteDataSource {
-  const PlantRemoteDataSource(this._dio);
+abstract interface class PlantRemoteDataSource {
+  Future<Object?> getPlants({int page = 0, int size = 20});
+
+  Future<void> createPlant(CreatePlantRequest request, {MultipartFile? image});
+
+  Future<Object?> getPlant({required String plantId});
+
+  Future<Object?> getPlantEditInfo({required String plantId});
+
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    required UpdatePlantRequest request,
+    MultipartFile? image,
+  });
+
+  Future<void> deletePlant({
+    required String plantId,
+    required String placeCode,
+  });
+}
+
+class DioPlantRemoteDataSource implements PlantRemoteDataSource {
+  const DioPlantRemoteDataSource(this._dio);
 
   final Dio _dio;
 
+  @override
   Future<Object?> getPlants({int page = 0, int size = 20}) async {
     try {
       final response = await _dio.get<Object?>(
@@ -22,6 +45,7 @@ class PlantRemoteDataSource {
     }
   }
 
+  @override
   Future<void> createPlant(
     CreatePlantRequest request, {
     MultipartFile? image,
@@ -42,6 +66,7 @@ class PlantRemoteDataSource {
     }
   }
 
+  @override
   Future<Object?> getPlant({required String plantId}) async {
     try {
       final response = await _dio.get<Object?>('/plants/$plantId');
@@ -52,6 +77,7 @@ class PlantRemoteDataSource {
     }
   }
 
+  @override
   Future<Object?> getPlantEditInfo({required String plantId}) async {
     try {
       final response = await _dio.get<Object?>('/plants/$plantId/edit');
@@ -62,6 +88,7 @@ class PlantRemoteDataSource {
     }
   }
 
+  @override
   Future<void> updatePlant({
     required String plantId,
     required String placeCode,
@@ -85,6 +112,7 @@ class PlantRemoteDataSource {
     }
   }
 
+  @override
   Future<void> deletePlant({
     required String plantId,
     required String placeCode,

--- a/lib/features/plant/data/repositories/plant_repository.dart
+++ b/lib/features/plant/data/repositories/plant_repository.dart
@@ -1,53 +1,74 @@
-import 'package:commonplant_frontend/core/network/api_client.dart';
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
 import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
 import 'package:commonplant_frontend/features/plant/data/mappers/plant_mapper.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final plantRemoteDataSourceProvider = Provider<PlantRemoteDataSource>((ref) {
-  return PlantRemoteDataSource(ref.watch(dioProvider));
-});
-
-final plantRepositoryProvider = Provider<PlantRepository>((ref) {
-  return PlantRepository(ref.watch(plantRemoteDataSourceProvider));
-});
-
-class PlantRepository {
-  const PlantRepository(this._remoteDataSource);
+class PlantRepositoryImpl implements PlantRepository {
+  const PlantRepositoryImpl(this._remoteDataSource);
 
   final PlantRemoteDataSource _remoteDataSource;
 
+  @override
   Future<List<PlantSummary>> fetchPlants({int page = 0, int size = 20}) async {
     final data = await _remoteDataSource.getPlants(page: page, size: size);
 
     return plantSummariesFromResponse(data);
   }
 
-  Future<void> createPlant(CreatePlantRequest request, {MultipartFile? image}) {
+  @override
+  Future<void> createPlant({
+    required String placeCode,
+    required String nickname,
+    String? scientificNameKo,
+    String? scientificNameEn,
+    String? lastWateredDate,
+    String? description,
+    MultipartFile? image,
+  }) {
+    final request = CreatePlantRequest(
+      placeCode: placeCode,
+      nickname: nickname,
+      scientificNameKo: scientificNameKo,
+      scientificNameEn: scientificNameEn,
+      lastWateredDate: lastWateredDate,
+      description: description,
+    );
+
     return _remoteDataSource.createPlant(request, image: image);
   }
 
+  @override
   Future<PlantDetail> fetchPlant({required String plantId}) async {
     final data = await _remoteDataSource.getPlant(plantId: plantId);
 
     return plantDetailFromResponse(data, fallbackId: plantId);
   }
 
+  @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
     final data = await _remoteDataSource.getPlantEditInfo(plantId: plantId);
 
     return plantEditInfoFromResponse(data);
   }
 
+  @override
   Future<void> updatePlant({
     required String plantId,
     required String placeCode,
-    required UpdatePlantRequest request,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
     MultipartFile? image,
   }) {
+    final request = UpdatePlantRequest(
+      imageKey: imageKey,
+      nickname: nickname,
+      lastWateredDate: lastWateredDate,
+    );
+
     return _remoteDataSource.updatePlant(
       plantId: plantId,
       placeCode: placeCode,
@@ -56,6 +77,7 @@ class PlantRepository {
     );
   }
 
+  @override
   Future<void> deletePlant({
     required String plantId,
     required String placeCode,

--- a/lib/features/plant/domain/repositories/plant_repository.dart
+++ b/lib/features/plant/domain/repositories/plant_repository.dart
@@ -1,0 +1,32 @@
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+
+abstract interface class PlantRepository {
+  Future<List<PlantSummary>> fetchPlants({int page = 0, int size = 20});
+
+  Future<void> createPlant({
+    required String placeCode,
+    required String nickname,
+    String? scientificNameKo,
+    String? scientificNameEn,
+    String? lastWateredDate,
+    String? description,
+  });
+
+  Future<PlantDetail> fetchPlant({required String plantId});
+
+  Future<PlantEditInfo> fetchPlantEditInfo({required String plantId});
+
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
+  });
+
+  Future<void> deletePlant({
+    required String plantId,
+    required String placeCode,
+  });
+}

--- a/lib/features/plant/plant_repository_provider.dart
+++ b/lib/features/plant/plant_repository_provider.dart
@@ -1,0 +1,13 @@
+import 'package:commonplant_frontend/core/network/api_client.dart';
+import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
+import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final plantRemoteDataSourceProvider = Provider<PlantRemoteDataSource>((ref) {
+  return DioPlantRemoteDataSource(ref.watch(dioProvider));
+});
+
+final plantRepositoryProvider = Provider<PlantRepository>((ref) {
+  return PlantRepositoryImpl(ref.watch(plantRemoteDataSourceProvider));
+});

--- a/lib/features/plant/presentation/providers/plant_delete_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_delete_controller.dart
@@ -1,5 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';

--- a/lib/features/plant/presentation/providers/plant_detail_remote_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_remote_provider.dart
@@ -1,5 +1,5 @@
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final remotePlantDetailProvider = FutureProvider.family<PlantDetail, String>(

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -1,6 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/models/plant_registration_place.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
@@ -163,11 +162,9 @@ class PlantFormController extends Notifier<PlantFormState> {
       await ref
           .read(plantRepositoryProvider)
           .createPlant(
-            CreatePlantRequest(
-              placeCode: selectedPlace.id,
-              nickname: plantName,
-              scientificNameKo: plantName,
-            ),
+            placeCode: selectedPlace.id,
+            nickname: plantName,
+            scientificNameKo: plantName,
           );
       ref.invalidate(remotePlantListProvider);
     }
@@ -194,7 +191,7 @@ class PlantFormController extends Notifier<PlantFormState> {
           .updatePlant(
             plantId: plantId,
             placeCode: placeId,
-            request: UpdatePlantRequest(nickname: plantName),
+            nickname: plantName,
           );
       ref.invalidate(remotePlantListProvider);
     }

--- a/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_form_edit_provider.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart'

--- a/lib/features/plant/presentation/providers/plant_list_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_list_provider.dart
@@ -1,6 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'package:commonplant_frontend/features/plant/domain/entities/plant_summary.dart';

--- a/test/features/place/data/datasources/place_remote_data_source_test.dart
+++ b/test/features/place/data/datasources/place_remote_data_source_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('PlaceRemoteDataSource', () {
     test('장소 수정은 multipart PUT /place/update/{code}로 요청한다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlaceRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlaceRemoteDataSource(_dioWith(adapter));
 
       await dataSource.updatePlace(
         code: 'Abc123',
@@ -30,7 +30,7 @@ void main() {
 
     test('장소 생성은 optional image part를 multipart에 포함한다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlaceRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlaceRemoteDataSource(_dioWith(adapter));
 
       await dataSource.createPlace(
         const CreatePlaceRequest(name: '정원', address: '서울특별시'),
@@ -46,7 +46,7 @@ void main() {
 
     test('장소 수정은 optional image part를 multipart에 포함한다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlaceRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlaceRemoteDataSource(_dioWith(adapter));
 
       await dataSource.updatePlace(
         code: 'Abc123',

--- a/test/features/place/data/repositories/place_repository_test.dart
+++ b/test/features/place/data/repositories/place_repository_test.dart
@@ -8,23 +8,28 @@ void main() {
   group('PlaceRepository', () {
     test('장소 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlaceRemoteDataSource();
-      final repository = PlaceRepository(dataSource);
+      final repository = PlaceRepositoryImpl(dataSource);
       final image = MultipartFile.fromString(
         'image-bytes',
         filename: 'place.png',
       );
 
       await repository.createPlace(
-        const CreatePlaceRequest(name: '거실', address: '서울시 성북구'),
+        name: '거실',
+        address: '서울시 성북구',
         image: image,
       );
 
       expect(dataSource.latestCreateImage, same(image));
+      expect(dataSource.latestCreateRequest?.toJson(), {
+        'name': '거실',
+        'address': '서울시 성북구',
+      });
     });
 
     test('장소 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlaceRemoteDataSource();
-      final repository = PlaceRepository(dataSource);
+      final repository = PlaceRepositoryImpl(dataSource);
       final image = MultipartFile.fromString(
         'image-bytes',
         filename: 'place.png',
@@ -32,18 +37,24 @@ void main() {
 
       await repository.updatePlace(
         code: 'place-1',
-        request: const UpdatePlaceRequest(name: '거실', address: '서울시 성북구'),
+        name: '거실',
+        address: '서울시 성북구',
         image: image,
       );
 
       expect(dataSource.latestUpdateImage, same(image));
+      expect(dataSource.latestUpdateRequest?.toJson(), {
+        'name': '거실',
+        'address': '서울시 성북구',
+      });
     });
   });
 }
 
-class _ImagePlaceRemoteDataSource extends PlaceRemoteDataSource {
-  _ImagePlaceRemoteDataSource() : super(Dio());
-
+class _ImagePlaceRemoteDataSource extends Fake
+    implements PlaceRemoteDataSource {
+  CreatePlaceRequest? latestCreateRequest;
+  UpdatePlaceRequest? latestUpdateRequest;
   MultipartFile? latestCreateImage;
   MultipartFile? latestUpdateImage;
 
@@ -52,6 +63,7 @@ class _ImagePlaceRemoteDataSource extends PlaceRemoteDataSource {
     CreatePlaceRequest request, {
     MultipartFile? image,
   }) async {
+    latestCreateRequest = request;
     latestCreateImage = image;
   }
 
@@ -61,6 +73,7 @@ class _ImagePlaceRemoteDataSource extends PlaceRemoteDataSource {
     required UpdatePlaceRequest request,
     MultipartFile? image,
   }) async {
+    latestUpdateRequest = request;
     latestUpdateImage = image;
   }
 }

--- a/test/features/place/place_feature_provider_test.dart
+++ b/test/features/place/place_feature_provider_test.dart
@@ -1,9 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_feature_provider.dart';
-import 'package:dio/dio.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -30,8 +29,8 @@ void main() {
   });
 }
 
-class _StaticPlaceRepository extends PlaceRepository {
-  _StaticPlaceRepository(this.places) : super(PlaceRemoteDataSource(Dio()));
+class _StaticPlaceRepository extends Fake implements PlaceRepository {
+  _StaticPlaceRepository(this.places);
 
   final List<PlaceSummary> places;
   int fetchUserPlacesCalls = 0;

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_detail_page.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -179,9 +178,7 @@ Widget _remotePlaceDetailApp(PlaceRepository repository) {
   );
 }
 
-class _PendingPlaceRepository extends PlaceRepository {
-  _PendingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _PendingPlaceRepository extends Fake implements PlaceRepository {
   final Completer<PlaceSummary> _completer = Completer<PlaceSummary>();
 
   @override
@@ -190,8 +187,8 @@ class _PendingPlaceRepository extends PlaceRepository {
   }
 }
 
-class _StaticPlaceRepository extends PlaceRepository {
-  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _StaticPlaceRepository extends Fake implements PlaceRepository {
+  _StaticPlaceRepository(this.summary);
 
   final PlaceSummary summary;
 
@@ -201,9 +198,7 @@ class _StaticPlaceRepository extends PlaceRepository {
   }
 }
 
-class _RetryPlaceRepository extends PlaceRepository {
-  _RetryPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _RetryPlaceRepository extends Fake implements PlaceRepository {
   int fetchCalls = 0;
 
   @override
@@ -222,8 +217,8 @@ class _RetryPlaceRepository extends PlaceRepository {
   }
 }
 
-class _DeletablePlaceRepository extends PlaceRepository {
-  _DeletablePlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _DeletablePlaceRepository extends Fake implements PlaceRepository {
+  _DeletablePlaceRepository(this.summary);
 
   final PlaceSummary summary;
   int deleteCalls = 0;

--- a/test/features/place/presentation/pages/place_form_page_test.dart
+++ b/test/features/place/presentation/pages/place_form_page_test.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_form_page.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -96,10 +94,8 @@ void main() {
 
     expect(repository.updateCalls, 1);
     expect(repository.latestUpdateCode, 'place-1');
-    expect(repository.latestUpdateRequest?.toJson(), {
-      'name': '루프탑 정원',
-      'address': '서울시 성북구',
-    });
+    expect(repository.latestUpdateName, '루프탑 정원');
+    expect(repository.latestUpdateAddress, '서울시 성북구');
     expect(find.text('홈'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
@@ -127,26 +123,25 @@ Widget _remotePlaceEditApp(PlaceRepository repository) {
   );
 }
 
-class _PendingPlaceRepository extends PlaceRepository {
-  _PendingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _PendingPlaceRepository extends Fake implements PlaceRepository {
   final Completer<void> _completer = Completer<void>();
   int createCalls = 0;
 
   @override
-  Future<void> createPlace(CreatePlaceRequest request, {MultipartFile? image}) {
+  Future<void> createPlace({required String name, required String address}) {
     createCalls++;
     return _completer.future;
   }
 }
 
-class _EditablePlaceRepository extends PlaceRepository {
-  _EditablePlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _EditablePlaceRepository extends Fake implements PlaceRepository {
+  _EditablePlaceRepository(this.summary);
 
   final PlaceSummary summary;
   int updateCalls = 0;
   String? latestUpdateCode;
-  UpdatePlaceRequest? latestUpdateRequest;
+  String? latestUpdateName;
+  String? latestUpdateAddress;
 
   @override
   Future<PlaceSummary> fetchPlace(String code) async {
@@ -156,11 +151,13 @@ class _EditablePlaceRepository extends PlaceRepository {
   @override
   Future<void> updatePlace({
     required String code,
-    required UpdatePlaceRequest request,
-    MultipartFile? image,
+    required String name,
+    required String address,
+    String? imageKey,
   }) async {
     updateCalls++;
     latestUpdateCode = code;
-    latestUpdateRequest = request;
+    latestUpdateName = name;
+    latestUpdateAddress = address;
   }
 }

--- a/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
@@ -1,8 +1,7 @@
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -29,8 +28,8 @@ void main() {
   });
 }
 
-class _StaticPlaceRepository extends PlaceRepository {
-  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _StaticPlaceRepository extends Fake implements PlaceRepository {
+  _StaticPlaceRepository(this.summary);
 
   final PlaceSummary summary;
   String? lastCode;

--- a/test/features/place/presentation/providers/place_detail_view_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_view_provider_test.dart
@@ -1,10 +1,9 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_view_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -78,8 +77,8 @@ void main() {
   });
 }
 
-class _StaticPlaceRepository extends PlaceRepository {
-  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _StaticPlaceRepository extends Fake implements PlaceRepository {
+  _StaticPlaceRepository(this.summary);
 
   final PlaceSummary summary;
   int fetchCalls = 0;

--- a/test/features/place/presentation/providers/place_exit_controller_test.dart
+++ b/test/features/place/presentation/providers/place_exit_controller_test.dart
@@ -1,9 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_exit_controller.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -78,9 +77,7 @@ void main() {
   });
 }
 
-class _RecordingPlaceRepository extends PlaceRepository {
-  _RecordingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _RecordingPlaceRepository extends Fake implements PlaceRepository {
   int deleteCalls = 0;
   String? latestDeleteCode;
 
@@ -91,9 +88,7 @@ class _RecordingPlaceRepository extends PlaceRepository {
   }
 }
 
-class _FailingPlaceRepository extends PlaceRepository {
-  _FailingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _FailingPlaceRepository extends Fake implements PlaceRepository {
   int deleteCalls = 0;
 
   @override

--- a/test/features/place/presentation/providers/place_form_controller_test.dart
+++ b/test/features/place/presentation/providers/place_form_controller_test.dart
@@ -1,13 +1,11 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_state.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_list_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -141,22 +139,20 @@ void main() {
       expect(result?.destination, PlaceFormSubmitDestination.home);
       expect(repository.updateCalls, 1);
       expect(repository.latestUpdateCode, 'place-1');
-      expect(repository.latestUpdateRequest?.toJson(), {
-        'name': '루프탑',
-        'address': '서울시 성북구',
-      });
+      expect(repository.latestUpdateName, '루프탑');
+      expect(repository.latestUpdateAddress, '서울시 성북구');
     });
   });
 }
 
-class _RecordingPlaceRepository extends PlaceRepository {
-  _RecordingPlaceRepository() : super(PlaceRemoteDataSource(Dio()));
-
+class _RecordingPlaceRepository extends Fake implements PlaceRepository {
   int createCalls = 0;
   int updateCalls = 0;
   String? latestUpdateCode;
-  CreatePlaceRequest? latestCreateRequest;
-  UpdatePlaceRequest? latestUpdateRequest;
+  String? latestCreateName;
+  String? latestCreateAddress;
+  String? latestUpdateName;
+  String? latestUpdateAddress;
 
   @override
   Future<PlaceSummary> fetchPlace(String code) async {
@@ -164,22 +160,25 @@ class _RecordingPlaceRepository extends PlaceRepository {
   }
 
   @override
-  Future<void> createPlace(
-    CreatePlaceRequest request, {
-    MultipartFile? image,
+  Future<void> createPlace({
+    required String name,
+    required String address,
   }) async {
     createCalls++;
-    latestCreateRequest = request;
+    latestCreateName = name;
+    latestCreateAddress = address;
   }
 
   @override
   Future<void> updatePlace({
     required String code,
-    required UpdatePlaceRequest request,
-    MultipartFile? image,
+    required String name,
+    required String address,
+    String? imageKey,
   }) async {
     updateCalls++;
     latestUpdateCode = code;
-    latestUpdateRequest = request;
+    latestUpdateName = name;
+    latestUpdateAddress = address;
   }
 }

--- a/test/features/place/presentation/providers/place_form_edit_provider_test.dart
+++ b/test/features/place/presentation/providers/place_form_edit_provider_test.dart
@@ -1,9 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
-import 'package:commonplant_frontend/features/place/data/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
+import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_form_edit_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -71,8 +70,8 @@ void main() {
   });
 }
 
-class _StaticPlaceRepository extends PlaceRepository {
-  _StaticPlaceRepository(this.summary) : super(PlaceRemoteDataSource(Dio()));
+class _StaticPlaceRepository extends Fake implements PlaceRepository {
+  _StaticPlaceRepository(this.summary);
 
   final PlaceSummary summary;
   int fetchCalls = 0;

--- a/test/features/plant/data/datasources/plant_remote_data_source_test.dart
+++ b/test/features/plant/data/datasources/plant_remote_data_source_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('PlantRemoteDataSource', () {
     test('식물 상세 조회는 place query 없이 plantId path만 보낸다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.getPlant(plantId: '1');
 
@@ -19,7 +19,7 @@ void main() {
 
     test('식물 수정 정보 조회는 place query 없이 plantId path만 보낸다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.getPlantEditInfo(plantId: '1');
 
@@ -29,7 +29,7 @@ void main() {
 
     test('식물 수정은 placeCode query를 보낸다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.updatePlant(
         plantId: '1',
@@ -43,7 +43,7 @@ void main() {
 
     test('식물 생성은 optional image part를 multipart에 포함한다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.createPlant(
         const CreatePlantRequest(placeCode: 'Abc123', nickname: '몬스테라'),
@@ -59,7 +59,7 @@ void main() {
 
     test('식물 수정은 optional image part를 multipart에 포함한다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.updatePlant(
         plantId: '1',
@@ -77,7 +77,7 @@ void main() {
 
     test('식물 삭제는 placeCode query를 보낸다', () async {
       final adapter = _CapturingAdapter();
-      final dataSource = PlantRemoteDataSource(_dioWith(adapter));
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
 
       await dataSource.deletePlant(plantId: '1', placeCode: 'Abc123');
 

--- a/test/features/plant/data/repositories/plant_repository_test.dart
+++ b/test/features/plant/data/repositories/plant_repository_test.dart
@@ -8,23 +8,28 @@ void main() {
   group('PlantRepository', () {
     test('식물 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlantRemoteDataSource();
-      final repository = PlantRepository(dataSource);
+      final repository = PlantRepositoryImpl(dataSource);
       final image = MultipartFile.fromString(
         'image-bytes',
         filename: 'plant.png',
       );
 
       await repository.createPlant(
-        const CreatePlantRequest(placeCode: 'place-1', nickname: '몬스테라'),
+        placeCode: 'place-1',
+        nickname: '몬스테라',
         image: image,
       );
 
       expect(dataSource.latestCreateImage, same(image));
+      expect(dataSource.latestCreateRequest?.toJson(), {
+        'placeCode': 'place-1',
+        'nickname': '몬스테라',
+      });
     });
 
     test('식물 수정은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlantRemoteDataSource();
-      final repository = PlantRepository(dataSource);
+      final repository = PlantRepositoryImpl(dataSource);
       final image = MultipartFile.fromString(
         'image-bytes',
         filename: 'plant.png',
@@ -33,18 +38,20 @@ void main() {
       await repository.updatePlant(
         plantId: 'plant-1',
         placeCode: 'place-1',
-        request: const UpdatePlantRequest(nickname: '몬스테라'),
+        nickname: '몬스테라',
         image: image,
       );
 
       expect(dataSource.latestUpdateImage, same(image));
+      expect(dataSource.latestUpdateRequest?.toJson(), {'nickname': '몬스테라'});
     });
   });
 }
 
-class _ImagePlantRemoteDataSource extends PlantRemoteDataSource {
-  _ImagePlantRemoteDataSource() : super(Dio());
-
+class _ImagePlantRemoteDataSource extends Fake
+    implements PlantRemoteDataSource {
+  CreatePlantRequest? latestCreateRequest;
+  UpdatePlantRequest? latestUpdateRequest;
   MultipartFile? latestCreateImage;
   MultipartFile? latestUpdateImage;
 
@@ -53,6 +60,7 @@ class _ImagePlantRemoteDataSource extends PlantRemoteDataSource {
     CreatePlantRequest request, {
     MultipartFile? image,
   }) async {
+    latestCreateRequest = request;
     latestCreateImage = image;
   }
 
@@ -63,6 +71,7 @@ class _ImagePlantRemoteDataSource extends PlantRemoteDataSource {
     required UpdatePlantRequest request,
     MultipartFile? image,
   }) async {
+    latestUpdateRequest = request;
     latestUpdateImage = image;
   }
 }

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_detail_page.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -190,9 +189,7 @@ Widget _remotePlantDetailApp(PlantRepository repository) {
   );
 }
 
-class _PendingPlantRepository extends PlantRepository {
-  _PendingPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _PendingPlantRepository extends Fake implements PlantRepository {
   final Completer<PlantDetail> _detailCompleter = Completer<PlantDetail>();
 
   @override
@@ -201,9 +198,8 @@ class _PendingPlantRepository extends PlantRepository {
   }
 }
 
-class _StaticPlantRepository extends PlantRepository {
-  _StaticPlantRepository({required this.detail})
-    : super(PlantRemoteDataSource(Dio()));
+class _StaticPlantRepository extends Fake implements PlantRepository {
+  _StaticPlantRepository({required this.detail});
 
   final PlantDetail detail;
 
@@ -213,9 +209,7 @@ class _StaticPlantRepository extends PlantRepository {
   }
 }
 
-class _RetryPlantRepository extends PlantRepository {
-  _RetryPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _RetryPlantRepository extends Fake implements PlantRepository {
   int detailFetchCalls = 0;
 
   @override
@@ -236,8 +230,8 @@ class _RetryPlantRepository extends PlantRepository {
   }
 }
 
-class _DeletablePlantRepository extends PlantRepository {
-  _DeletablePlantRepository(this.detail) : super(PlantRemoteDataSource(Dio()));
+class _DeletablePlantRepository extends Fake implements PlantRepository {
+  _DeletablePlantRepository(this.detail);
 
   final PlantDetail detail;
   int deleteCalls = 0;

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -173,9 +171,7 @@ void main() {
   });
 }
 
-class _PendingPlantRepository extends PlantRepository {
-  _PendingPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _PendingPlantRepository extends Fake implements PlantRepository {
   final Completer<void> _completer = Completer<void>();
   int updateCalls = 0;
 
@@ -183,8 +179,9 @@ class _PendingPlantRepository extends PlantRepository {
   Future<void> updatePlant({
     required String plantId,
     required String placeCode,
-    required UpdatePlantRequest request,
-    MultipartFile? image,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
   }) {
     updateCalls++;
     return _completer.future;
@@ -196,17 +193,16 @@ class _PendingPlantRepository extends PlantRepository {
   }
 }
 
-class _FailingPlantUpdateRepository extends PlantRepository {
-  _FailingPlantUpdateRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _FailingPlantUpdateRepository extends Fake implements PlantRepository {
   int updateCalls = 0;
 
   @override
   Future<void> updatePlant({
     required String plantId,
     required String placeCode,
-    required UpdatePlantRequest request,
-    MultipartFile? image,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
   }) async {
     updateCalls++;
     throw StateError('raw failure');
@@ -218,9 +214,7 @@ class _FailingPlantUpdateRepository extends PlantRepository {
   }
 }
 
-class _PendingEditInfoPlantRepository extends PlantRepository {
-  _PendingEditInfoPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _PendingEditInfoPlantRepository extends Fake implements PlantRepository {
   final Completer<PlantEditInfo> _completer = Completer<PlantEditInfo>();
 
   @override
@@ -229,9 +223,8 @@ class _PendingEditInfoPlantRepository extends PlantRepository {
   }
 }
 
-class _StaticEditInfoPlantRepository extends PlantRepository {
-  _StaticEditInfoPlantRepository(this.editInfo)
-    : super(PlantRemoteDataSource(Dio()));
+class _StaticEditInfoPlantRepository extends Fake implements PlantRepository {
+  _StaticEditInfoPlantRepository(this.editInfo);
 
   final PlantEditInfo editInfo;
 
@@ -241,9 +234,7 @@ class _StaticEditInfoPlantRepository extends PlantRepository {
   }
 }
 
-class _RetryEditInfoPlantRepository extends PlantRepository {
-  _RetryEditInfoPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _RetryEditInfoPlantRepository extends Fake implements PlantRepository {
   int editInfoFetchCalls = 0;
 
   @override

--- a/test/features/plant/presentation/providers/plant_delete_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_delete_controller_test.dart
@@ -1,9 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_delete_controller.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -105,9 +104,7 @@ void main() {
   });
 }
 
-class _RecordingPlantRepository extends PlantRepository {
-  _RecordingPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _RecordingPlantRepository extends Fake implements PlantRepository {
   int deleteCalls = 0;
   String? latestDeletedPlantId;
   String? latestDeletedPlaceCode;
@@ -123,9 +120,7 @@ class _RecordingPlantRepository extends PlantRepository {
   }
 }
 
-class _FailingPlantRepository extends PlantRepository {
-  _FailingPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _FailingPlantRepository extends Fake implements PlantRepository {
   int deleteCalls = 0;
 
   @override

--- a/test/features/plant/presentation/providers/plant_detail_remote_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_remote_provider_test.dart
@@ -1,8 +1,7 @@
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_remote_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -28,8 +27,8 @@ void main() {
   });
 }
 
-class _StaticPlantRepository extends PlantRepository {
-  _StaticPlantRepository(this.detail) : super(PlantRemoteDataSource(Dio()));
+class _StaticPlantRepository extends Fake implements PlantRepository {
+  _StaticPlantRepository(this.detail);
 
   final PlantDetail detail;
   String? lastPlantId;

--- a/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
@@ -1,9 +1,8 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -80,8 +79,8 @@ void main() {
   });
 }
 
-class _StaticPlantRepository extends PlantRepository {
-  _StaticPlantRepository(this.detail) : super(PlantRemoteDataSource(Dio()));
+class _StaticPlantRepository extends Fake implements PlantRepository {
+  _StaticPlantRepository(this.detail);
 
   final PlantDetail detail;
   int fetchCalls = 0;

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -1,7 +1,6 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/dtos/plant_requests.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
@@ -9,7 +8,6 @@ import 'package:commonplant_frontend/features/plant/presentation/providers/plant
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_list_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -75,11 +73,9 @@ void main() {
 
       expect(result?.destination, PlantFormSubmitDestination.home);
       expect(repository.createCalls, 1);
-      expect(repository.latestCreateRequest?.toJson(), {
-        'placeCode': 'place-1',
-        'nickname': '몬스테라',
-        'scientificNameKo': '몬스테라',
-      });
+      expect(repository.latestCreatePlaceCode, 'place-1');
+      expect(repository.latestCreateNickname, '몬스테라');
+      expect(repository.latestCreateScientificNameKo, '몬스테라');
       expect(plants.single.name, '몬스테라');
     });
 
@@ -151,20 +147,20 @@ void main() {
       expect(repository.updateCalls, 1);
       expect(repository.latestUpdatePlantId, 'plant-1');
       expect(repository.latestUpdatePlaceCode, 'place-1');
-      expect(repository.latestUpdateRequest?.toJson(), {'nickname': '몬테라'});
+      expect(repository.latestUpdateNickname, '몬테라');
     });
   });
 }
 
-class _RecordingPlantRepository extends PlantRepository {
-  _RecordingPlantRepository() : super(PlantRemoteDataSource(Dio()));
-
+class _RecordingPlantRepository extends Fake implements PlantRepository {
   int createCalls = 0;
   int updateCalls = 0;
   String? latestUpdatePlantId;
   String? latestUpdatePlaceCode;
-  CreatePlantRequest? latestCreateRequest;
-  UpdatePlantRequest? latestUpdateRequest;
+  String? latestCreatePlaceCode;
+  String? latestCreateNickname;
+  String? latestCreateScientificNameKo;
+  String? latestUpdateNickname;
 
   @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
@@ -172,24 +168,31 @@ class _RecordingPlantRepository extends PlantRepository {
   }
 
   @override
-  Future<void> createPlant(
-    CreatePlantRequest request, {
-    MultipartFile? image,
+  Future<void> createPlant({
+    required String placeCode,
+    required String nickname,
+    String? scientificNameKo,
+    String? scientificNameEn,
+    String? lastWateredDate,
+    String? description,
   }) async {
     createCalls++;
-    latestCreateRequest = request;
+    latestCreatePlaceCode = placeCode;
+    latestCreateNickname = nickname;
+    latestCreateScientificNameKo = scientificNameKo;
   }
 
   @override
   Future<void> updatePlant({
     required String plantId,
     required String placeCode,
-    required UpdatePlantRequest request,
-    MultipartFile? image,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
   }) async {
     updateCalls++;
     latestUpdatePlantId = plantId;
     latestUpdatePlaceCode = placeCode;
-    latestUpdateRequest = request;
+    latestUpdateNickname = nickname;
   }
 }

--- a/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
@@ -1,8 +1,7 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
-import 'package:commonplant_frontend/features/plant/data/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
+import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_edit_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -83,8 +82,8 @@ void main() {
   });
 }
 
-class _StaticPlantRepository extends PlantRepository {
-  _StaticPlantRepository(this.editInfo) : super(PlantRemoteDataSource(Dio()));
+class _StaticPlantRepository extends Fake implements PlantRepository {
+  _StaticPlantRepository(this.editInfo);
 
   final PlantEditInfo editInfo;
   int fetchCalls = 0;


### PR DESCRIPTION
## 작업 내용
- Place/Plant repository interface를 domain 계층으로 분리했습니다.
- data repository 구현체가 request DTO 생성과 datasource mapping을 담당하게 했습니다.
- repository/datasource Riverpod 조립을 feature 루트 Provider로 이동했습니다.
- Place/Plant presentation의 concrete repository와 request DTO import를 제거했습니다.
- controller/page 테스트 fake를 순수 domain repository 구현으로 전환해 실제 Dio 의존을 제거했습니다.

## 커밋
- `1dbe513` Place Repository 계약 분리
- `689e1ef` Plant Repository 계약 분리
- `3d3114f` Task 8·9 상태 및 작업 이력 기록

## 검증
- Place 테스트 71개 통과
- Plant 테스트 63개 통과
- presentation data repository/DTO import 구조 감사 통과
- concrete repository 상속 및 실제 Dio datasource fake 구조 감사 통과
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test` 218개 통과

Closes #188
