### PR TITLE
[Epic] 코드 가독성 리팩토링 3차 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 ## 진행해야 할 작업 내역
 
 기존 [남은 작업 진행 계획](docs/remaining-work-plan.md)의 0~15번 항목은 2026-06-28 기준 모두 완료되었습니다.
-완료된 항목은 작업 기록 보존용으로 남기고, 코드 가독성 리팩토링 1차 라운드는 [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md)의 Task 1~7 기준으로 완료되었습니다. 2차 라운드도 2026-08-04에 [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md)의 Task 1~8 기준으로 완료되었습니다. 3차 라운드는 Task 1~10이 병합됐고, 마지막 Task 11의 구현과 코드 수준 검증을 완료해 [#193](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/193)에서 검토 중입니다.
+완료된 항목은 작업 기록 보존용으로 남기고, 코드 가독성 리팩토링 1차 라운드는 [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md)의 Task 1~7 기준으로 완료되었습니다. 2차 라운드도 2026-08-04에 [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md)의 Task 1~8 기준으로 완료되었습니다. 3차 라운드는 2026-08-12에 [코드 가독성 리팩토링 3차 계획](docs/code-readability-refactoring-round-3-plan.md)의 Task 1~11과 코드 수준 검증을 완료했습니다.
 
 이후 새 작업은 아래 기준으로 범위를 다시 정합니다.
 
 - 후속 결정/확인 항목은 [후속 결정 체크리스트](docs/follow-up-decision-checklist.md)를 기준으로 새 이슈로 분리합니다.
 - 구조 개선 후보는 [lib 구조 리팩토링 개선 방향](docs/lib-refactoring-direction.md)의 남은 진단 항목을 기준으로 재평가합니다.
-- 3차 가독성 리팩토링은 마지막 PR 병합 후 계획 문서와 Project 상태를 `Done`으로 닫습니다.
+- 가독성 리팩토링 1~3차 완료 후 새 범위는 기존 계획을 연장하지 않고 별도 이슈나 Epic으로 분리합니다.
 - 새 작업도 `이슈 생성 -> Project 10 등록 -> develop 기반 브랜치 생성 -> 작업 -> 검증 -> 커밋/푸시 -> PR 생성` 순서로 진행합니다.
 
 우선순위:
@@ -218,5 +218,5 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 1. [x] 기존 남은 작업 계획 0~15번 완료 상태를 확인합니다.
 2. [x] 코드 가독성 리팩토링 1차 라운드의 상위 범위와 완료 기준을 문서화합니다.
 3. [x] 코드 가독성 리팩토링 2차 라운드 Task 1~8을 완료합니다.
-4. [ ] 코드 가독성 리팩토링 3차 Task 11 PR을 검토하고 병합합니다.
+4. [x] 코드 가독성 리팩토링 3차 Task 1~11과 최종 코드 수준 검증을 완료합니다.
 5. [ ] 백엔드 확인, 테스트, 릴리즈처럼 결정이 필요한 항목을 개별 이슈로 분리합니다.

--- a/docs/code-readability-refactoring-round-3-plan.md
+++ b/docs/code-readability-refactoring-round-3-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Flutter, Dart, Riverpod, go_router, flutter_test
 
-**Status:** 2026-08-04 `develop` 기준 계획 수립. 상위 Epic은 #165, 계획 문서 Task는 #166이다. 2026-08-12 Task 9까지 병합됐고, Task 10 구현과 전체 검증을 완료해 PR #191에서 리뷰 중이다.
+**Status:** 2026-08-12 Task 1~11과 최종 코드 수준 검증을 완료했다. 상위 Epic은 #165이며 마지막 구현 PR #193까지 `develop`에 병합됐다.
 
 ---
 
@@ -600,7 +600,7 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 
 | Task | 이슈 | PR | 상태 |
 | --- | --- | --- | --- |
-| 3차 상위 Epic | #165 | - | In Progress |
+| 3차 상위 Epic | #165 | - | Done |
 | 3차 계획 문서화 | #166 | #167 | Done |
 | Task 1. Detail route page stateless 전환 | #168 | #169 | Done |
 | Task 2. Search 화면 state Controller 전환 | #170 | #171 | Done |
@@ -613,7 +613,7 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 8. Place/Plant detail ViewData 경계 정리 | #184 | #187 | Done |
 | Task 9. Repository 계약과 local/remote 경계 정리 | #188 | #189 | Done |
 | Task 10. 미사용 Phase 0 구조 정리 | #190 | #191 | Done |
-| Task 11. Router/test helper 가독성 정리 | #192 | #193 | In Review |
+| Task 11. Router/test helper 가독성 정리 | #192 | #193 | Done |
 
 각 Task 이슈를 만들 때 #165를 parent issue로 연결하고, Project 10의 category는 대상 domain을 우선한다. 여러 domain을 함께 다루는 공통 구조와 문서 Task는 `Story`로 지정한다.
 
@@ -650,6 +650,6 @@ Controller가 추가된 Task는 대상 controller test를 먼저 단독 실행�
 | Task 11 | `ac0b159` | route 계약·진입 테스트와 production/page 테스트 앱 조립 helper 분리 | router 및 Place/Plant detail test 30개 |
 | Task 11 | `90bbc38` | 가입 흐름과 Place 흐름 router test를 책임별 파일로 분리 | router test 17개 |
 | Task 11 | `015b120` | 남은 Plant/Memo 흐름 테스트 파일의 책임을 이름에 명시 | router test 17개 |
-| Task 11 | - | README, 테스트 기준, 3차 작업 이력과 최종 검증 결과 갱신 | 구조 감사, format, analyze, 전체 test 218개, iOS/Android debug build |
+| Task 11 | `8d91bf5` | README, 테스트 기준, 3차 작업 이력과 최종 검증 결과 갱신 | 구조 감사, format, analyze, 전체 test 218개, iOS/Android debug build |
 
 Task 6부터는 구현 커밋을 책임별로 나누고 각 커밋을 별도 행으로 기록한다. 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/code-readability-refactoring-validation.md
+++ b/docs/code-readability-refactoring-validation.md
@@ -123,11 +123,11 @@ Task 1~6의 상태 소유권 이동과 기존 사용자 동작에서 회귀는 �
 
 ### 2026-08-12: 3차 Task 1~11 최종 검증
 
-대상 기준점: `develop`의 PR #191 병합 상태와 Task 11 PR #193의 구현 커밋 `015b120`
+대상 기준점: `develop`의 Task 11 PR #193 병합 커밋 `fbad0e5`
 
 | 구분 | 결과 |
 | --- | --- |
-| GitHub | Task 1~10 PR 병합, Task 10 이슈/PR Project status `Done`, Task 11 이슈 #192와 PR #193 `In Review` |
+| GitHub | Task 1~11 PR 병합, 하위 이슈 13개 종료, Task 11 이슈 #192와 PR #193 Project status `Done`, quality check 2개 통과 |
 | Route page | `features/**/pages`의 `StatefulWidget`, `ConsumerStatefulWidget`, 화면 동작 목적 `setState` 0건 |
 | Page 의존 경계 | feature page의 `useRemoteApiProvider`, request DTO, repository 직접 참조 0건 |
 | Provider UI 의존 | presentation Provider의 controller/focus/context/navigation 직접 참조 0건 |
@@ -144,4 +144,4 @@ Task 1~6의 상태 소유권 이동과 기존 사용자 동작에서 회귀는 �
 
 **판정:** `Code-level Pass / Smoke Pending`
 
-3차 Task 1~11의 상태 소유권, 의존 방향, 테스트 책임 분리에서 코드 수준 회귀는 발견되지 않았다. PR #193 병합 후 3차 Epic과 문서 상태를 `Done`으로 닫고, 실제 기기/API smoke는 [테스트 작성 기준](testing-guide.md)의 integration test 준비 조건이 충족된 뒤 별도 이슈로 진행한다.
+3차 Task 1~11의 상태 소유권, 의존 방향, 테스트 책임 분리에서 코드 수준 회귀는 발견되지 않았다. 3차 라운드는 코드 수준에서 완료했으며, 실제 기기/API smoke는 [테스트 작성 기준](testing-guide.md)의 integration test 준비 조건이 충족된 뒤 별도 이슈로 진행한다.


### PR DESCRIPTION
## 요약

- PR #193 병합에 맞춰 README의 3차 가독성 리팩토링 상태를 완료로 갱신했습니다.
- 3차 계획의 Epic과 Task 11 상태를 `Done`으로 정리했습니다.
- 최종 검증 기준점을 병합 커밋 `fbad0e5`로 확정하고 GitHub 완료 상태를 기록했습니다.

## 완료 근거

- Task 1~11 관련 하위 이슈 13개 종료
- 마지막 구현 PR #193 병합 및 quality check 2건 통과
- 최종 검증 `Code-level Pass / Smoke Pending`

## 검증

- `git diff --check`
- GitHub Actions quality check 2건 통과

Closes #165
