### PR TITLE
Docs: QA 디바이스 기준 정리 #195

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ test/
 | [상태관리 Provider 작성 기준](docs/state-management-guide.md) | Riverpod Provider 선택, 파일 배치, async 상태 처리 기준 |
 | [폼 검증 및 에러 메시지 작성 기준](docs/form-validation-error-guide.md) | 입력 검증 위치, helper/error 메시지, 서버 에러 처리 기준 |
 | [테스트 작성 기준](docs/testing-guide.md) | unit/widget test 작성 기준, 실행 명령, CI/pre-commit 연계 |
+| [품질·테스트 후속 작업 계획](docs/quality-testing-follow-up-plan.md) | QA 필수 viewport, golden/integration test 도입 순서, Ready/Blocked 경계 |
 | [lib 구조 리팩토링 개선 방향](docs/lib-refactoring-direction.md) | `lib` 구조, Riverpod, 라우팅, feature 경계 리팩토링 진단과 단계별 개선안 |
 | [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md) | 사람이 읽기 쉬운 코드로 개선하기 위한 파일 분해, 우선순위, PR 단위, 리뷰 기준 |
 | [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md) | 1차 완료 후 남은 Place 중심 대형 화면, 라우팅 파라미터, detail action, mapper 경계 개선 계획 |

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -13,8 +13,8 @@
 
 | 체크 | ID | 결정 항목 | 출처 | 다음 액션 | 상태 |
 | --- | --- | --- | --- | --- | --- |
-| [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | `320×568`, `375×812`, `430×932` 자동 검증 viewport와 Android/iOS 수동 QA profile을 적용한다. | Decided |
-| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | `375×812` pilot을 기준으로 대상 화면, DPR, baseline 갱신 규칙을 별도 이슈에서 확정한다. | Ready |
+| [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | Compact width `320×640`, Short height `375×667`, Reference `375×812`, Wide `430×932`와 Android/iOS 수동 QA profile을 적용한다. 확인된 compact overflow는 별도 Bug 이슈로 수정한다. | Decided |
+| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | compact 적용 gap 수정 후 `OnboardingPage`의 `375×812` pilot으로 대상 화면, DPR, baseline 갱신 규칙을 별도 이슈에서 확정한다. | Open |
 | [ ] | TEST-02 | integration test 실행 환경과 workflow 연결 방식 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | API 비사용 smoke/runner는 로컬 범위로 분리하고 staging URL, 테스트 계정, seed/cleanup이 필요한 remote workflow는 보류한다. | Blocked |
 
 ## 릴리즈와 환경

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -13,9 +13,9 @@
 
 | 체크 | ID | 결정 항목 | 출처 | 다음 액션 | 상태 |
 | --- | --- | --- | --- | --- | --- |
-| [ ] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md` | QA 기준 디바이스와 화면 폭을 정리한다. | Open |
-| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md` | QA 디바이스 목록 확정 후 full-screen golden 범위를 정한다. | Open |
-| [ ] | TEST-02 | integration test 실행 환경과 workflow 연결 방식 | `docs/testing-guide.md` | staging API, 테스트 계정, runner 준비 여부를 확인한다. | Open |
+| [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | `320×568`, `375×812`, `430×932` 자동 검증 viewport와 Android/iOS 수동 QA profile을 적용한다. | Decided |
+| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | `375×812` pilot을 기준으로 대상 화면, DPR, baseline 갱신 규칙을 별도 이슈에서 확정한다. | Ready |
+| [ ] | TEST-02 | integration test 실행 환경과 workflow 연결 방식 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | API 비사용 smoke/runner는 로컬 범위로 분리하고 staging URL, 테스트 계정, seed/cleanup이 필요한 remote workflow는 보류한다. | Blocked |
 
 ## 릴리즈와 환경
 

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -16,7 +16,7 @@
 | --- | --- | --- |
 | 기준 브랜치 | `develop@f001561` | 코드 가독성 리팩토링 3차 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
-| Widget test viewport | 일부 화면 테스트가 `375×812`, DPR 1을 파일별로 직접 설정 | 공통 QA profile/helper는 없음 |
+| Widget test viewport | 일부 화면 테스트가 `320×640`, `375×812`, `430×812`, DPR 1을 파일별로 직접 설정 | 공통 QA profile/helper는 없음 |
 | Golden test | test, baseline image, 공통 font loader 없음 | TEST-01에서 첫 도입 범위 결정 필요 |
 | Font/asset | Pretendard 4종과 앱 asset이 저장소 및 `pubspec.yaml`에 등록됨 | Golden 재현성의 기본 조건 충족 |
 | Integration test | SDK 의존성, `integration_test/`, 실행 script 없음 | 로컬 smoke scaffold부터 별도 도입 가능 |
@@ -29,11 +29,12 @@
 | 순서 | ID | 범위 | 선행 조건 | 현재 상태 |
 | --- | --- | --- | --- | --- |
 | 1 | QA-01 | QA 필수 디바이스와 viewport 기준 확정 | 없음 | Decided (#195) |
-| 2 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | QA-01 | Ready |
-| 3 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 로컬 실행 환경 검토 | 없음. 우선순위상 TEST-01 다음 | Ready |
-| 4 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
+| 2 | QA-01 적용 후속 | compact-width overflow 수정과 viewport 회귀 테스트 추가 | QA-01 | Ready. 별도 Bug 이슈 필요 |
+| 3 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | QA-01 적용 후속 | Open. 선행 작업 완료 후 Ready |
+| 4 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 로컬 실행 환경 검토 | 없음. 우선순위상 TEST-01 다음 | Ready |
+| 5 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
 
-TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
+TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
 
 ## QA-01 필수 기준
 
@@ -43,14 +44,44 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 
 | Profile | Logical viewport | 용도 | 적용 기준 |
 | --- | --- | --- | --- |
-| Compact | `320×568` | 작은 휴대폰의 가로 overflow와 짧은 세로 공간 확인 | form, 긴 문구, 가로 배치, 하단 CTA가 있는 화면 |
+| Compact width | `320×640` | 작은 휴대폰의 가로 overflow 확인 | form, 긴 문구, 가로 배치가 있는 화면 |
+| Short height | `375×667` | 짧은 세로 공간과 하단 CTA 확인 | 키보드, 하단 CTA, 고정 세로 배치가 있는 화면 |
 | Reference | `375×812` | Figma와 현재 `AppSizes` 기준 회귀 확인 | 모든 신규 화면의 기본 widget test |
 | Wide | `430×932` | 넓고 긴 휴대폰에서 정렬, 최대 너비, 여백 확인 | grid, card list, 좌우 정렬 변화가 있는 화면 |
 
-- `320` logical pixel은 Android의 small phone 기준을 하한 회귀 폭으로 사용한다.
+- `320` logical pixel은 Android의 small phone 기준을 하한 회귀 폭으로 사용하고, 기존 낮은 높이 화면 테스트와 일치하는 `320×640`으로 관리한다.
+- `375×667`은 폭과 높이 위험을 한 profile에 섞지 않고 짧은 높이 회귀를 독립적으로 확인할 때 사용한다.
 - `375×812`는 디자인 비교와 향후 full-screen golden의 기본 후보 크기다.
-- 세 프로필을 모든 테스트에 기계적으로 반복하지 않는다. Reference는 기본으로 사용하고 Compact/Wide는 레이아웃 위험이 있는 화면에 추가한다.
+- 네 profile을 모든 테스트에 기계적으로 반복하지 않는다. Reference는 기본으로 사용하고 Compact width, Short height, Wide는 레이아웃 위험이 있는 화면에 추가한다.
 - DPR 차이는 layout 검증 기준과 분리한다. Golden baseline의 DPR은 TEST-01에서 확정한다.
+
+### 2026-08-13 viewport 검증 결과
+
+임시 진단 테스트로 route-level 화면 18개를 8개 viewport에서 초기 렌더링해 총 144개 조합을 확인했다. 진단 파일은 결과 확인 후 제거했으며 저장소 테스트에는 포함하지 않았다.
+
+| Logical viewport | 결과 |
+| --- | --- |
+| `320×568` | Place 초대, 주소 검색, Place 상세, Plant 상세에서 overflow |
+| `320×640` | `320×568`과 같은 4개 route에서 overflow |
+| `360×800` | Place 초대에서 overflow |
+| `375×667` | 18개 route 통과 |
+| `375×812` | 18개 route 통과 |
+| `412×915` | 18개 route 통과 |
+| `430×812` | 18개 route 통과 |
+| `430×932` | 18개 route 통과 |
+
+`320×568`과 `320×640`이 같은 width 문제를 검출했으므로 기존 테스트와 정렬되는 `320×640`을 Compact width로 채택한다. 짧은 높이 검증은 전체 route가 통과한 `375×667`로 분리한다. 이 검증은 DPR 1과 system inset이 없는 widget 환경의 초기 렌더링 검사이므로 키보드, SafeArea, system back은 수동 QA로 계속 확인한다.
+
+### 확인된 적용 gap
+
+| 화면 | 확인된 문제 | 처리 기준 |
+| --- | --- | --- |
+| Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | 별도 Bug 이슈에서 반응형 action 배치와 회귀 테스트 추가 |
+| 주소 검색 | 결과 Row가 320에서 12px 가로 overflow | 별도 Bug 이슈에서 text/button 제약과 회귀 테스트 추가 |
+| Place 상세 | 공용 Plant card 내부 세로 overflow | 별도 Bug 이슈에서 card compact layout과 회귀 테스트 추가 |
+| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | 별도 Bug 이슈에서 날짜 요약 반응형 배치와 회귀 테스트 추가 |
+
+QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 정책을 현재 화면에 적용하는 구현 작업이므로 #195와 PR #196에 코드 수정으로 포함하지 않는다.
 
 ### 수동 QA 필수 디바이스 profile
 
@@ -63,7 +94,7 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 | iOS | Compact-height simulator | `375×667` | 짧은 높이, 키보드, safe area, navigation 전환 |
 | iOS | Reference-height simulator | `375×812` | Figma 기준 정렬, notch 계열 safe area, 기본 사용자 흐름 |
 
-- 화면 PR은 Reference widget test를 기본으로 하고 레이아웃 위험에 따라 Compact 또는 Wide를 추가한다.
+- 화면 PR은 Reference widget test를 기본으로 하고 레이아웃 위험에 따라 Compact width, Short height, Wide를 추가한다.
 - 화면 구조가 바뀐 PR은 Android와 iOS에서 각각 한 개 이상의 필수 profile로 smoke QA를 수행한다.
 - release candidate QA에서는 네 profile을 모두 확인한다.
 - 실제 기기는 같은 역할과 같거나 더 작은 사용 가능 viewport를 제공하면 해당 profile을 대체할 수 있다. PR 또는 QA 기록에 기기, OS, 사용 가능 viewport를 남긴다.
@@ -82,11 +113,12 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 
 TEST-01은 아래 순서로 별도 이슈화한다.
 
-1. Pretendard와 asset을 명시적으로 로드하는 golden test helper를 만든다.
-2. remote API와 시간, locale에 의존하지 않는 화면 한 개를 `375×812` full-screen pilot으로 선정한다.
-3. baseline 파일명, 저장 위치, DPR, 허용 오차, `--update-goldens` 리뷰 규칙을 정한다.
-4. Compact/Wide baseline은 pilot 화면에 일괄 추가하지 않고 레이아웃 위험과 회귀 효과를 확인해 대상 화면별로 선택한다.
-5. 로컬과 Ubuntu CI에서 같은 baseline이 재현된 뒤 일반 `fvm flutter test`에 포함한다.
+1. Compact width 적용 gap과 대상 화면의 viewport 회귀 테스트를 먼저 해결한다.
+2. Pretendard와 asset을 명시적으로 로드하는 golden test helper를 만든다.
+3. remote API와 시간, locale에 의존하지 않는 `OnboardingPage`를 `375×812` full-screen pilot으로 사용한다.
+4. baseline 파일명, 저장 위치, DPR, 허용 오차, `--update-goldens` 리뷰 규칙을 정한다.
+5. Compact width, Short height, Wide baseline은 pilot 화면에 일괄 추가하지 않고 레이아웃 위험과 회귀 효과를 확인해 대상 화면별로 선택한다.
+6. 로컬과 Ubuntu CI에서 같은 baseline이 재현된 뒤 일반 `fvm flutter test`에 포함한다.
 
 ## TEST-02 Ready와 Blocked 경계
 
@@ -118,5 +150,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | ID | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
 | QA-01 | `3e01a12` | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check`, format 252개 파일, analyze, unit/widget test 218개 |
+| QA-01 검증 | - | 144개 route/viewport 조합 검증, Compact/Short height 분리, 적용 gap과 후속 순서 보완 | 임시 route-level viewport 진단, `git diff --check` 예정 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -1,0 +1,121 @@
+# 품질·테스트 후속 작업 계획
+
+이 문서는 코드 가독성 리팩토링 1~3차 완료 후 `QA-01`, `TEST-01`, `TEST-02`를 별도 이슈로 진행하기 위한 현재 상태, 의존관계, 완료 기준을 관리한다.
+
+## 작업 원칙
+
+- 로컬 코드와 저장소 설정만으로 결정할 수 있는 범위를 먼저 진행한다.
+- staging API, 테스트 계정, seed/cleanup처럼 백엔드 준비가 필요한 항목은 `Blocked`로 분리한다.
+- Golden test와 integration test는 기존 unit/widget test를 대체하지 않는다.
+- 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
+- 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
+
+## 2026-08-12 현재 상태
+
+| 점검 항목 | 현재 상태 | 판단 |
+| --- | --- | --- |
+| 기준 브랜치 | `develop@f001561` | 코드 가독성 리팩토링 3차 병합 완료 |
+| 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
+| Widget test viewport | 일부 화면 테스트가 `375×812`, DPR 1을 파일별로 직접 설정 | 공통 QA profile/helper는 없음 |
+| Golden test | test, baseline image, 공통 font loader 없음 | TEST-01에서 첫 도입 범위 결정 필요 |
+| Font/asset | Pretendard 4종과 앱 asset이 저장소 및 `pubspec.yaml`에 등록됨 | Golden 재현성의 기본 조건 충족 |
+| Integration test | SDK 의존성, `integration_test/`, 실행 script 없음 | 로컬 smoke scaffold부터 별도 도입 가능 |
+| GitHub Actions | Ubuntu에서 `flutter analyze`, `flutter test` 실행 | device 기반 workflow는 없음 |
+| Remote API 환경 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 지점만 존재 | staging URL, 계정, 데이터 격리 정책은 Blocked |
+
+## 의존관계를 반영한 작업 순서
+
+| 순서 | ID | 범위 | 선행 조건 | 현재 상태 |
+| --- | --- | --- | --- | --- |
+| 1 | QA-01 | QA 필수 디바이스와 viewport 기준 확정 | 없음 | Decided (#195) |
+| 2 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | QA-01 | Ready |
+| 3 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 로컬 실행 환경 검토 | 없음. 우선순위상 TEST-01 다음 | Ready |
+| 4 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
+
+TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
+
+## QA-01 필수 기준
+
+### 자동 레이아웃 검증 viewport
+
+Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical viewport와 DPR 1을 사용한다.
+
+| Profile | Logical viewport | 용도 | 적용 기준 |
+| --- | --- | --- | --- |
+| Compact | `320×568` | 작은 휴대폰의 가로 overflow와 짧은 세로 공간 확인 | form, 긴 문구, 가로 배치, 하단 CTA가 있는 화면 |
+| Reference | `375×812` | Figma와 현재 `AppSizes` 기준 회귀 확인 | 모든 신규 화면의 기본 widget test |
+| Wide | `430×932` | 넓고 긴 휴대폰에서 정렬, 최대 너비, 여백 확인 | grid, card list, 좌우 정렬 변화가 있는 화면 |
+
+- `320` logical pixel은 Android의 small phone 기준을 하한 회귀 폭으로 사용한다.
+- `375×812`는 디자인 비교와 향후 full-screen golden의 기본 후보 크기다.
+- 세 프로필을 모든 테스트에 기계적으로 반복하지 않는다. Reference는 기본으로 사용하고 Compact/Wide는 레이아웃 위험이 있는 화면에 추가한다.
+- DPR 차이는 layout 검증 기준과 분리한다. Golden baseline의 DPR은 TEST-01에서 확정한다.
+
+### 수동 QA 필수 디바이스 profile
+
+실제 보유 기기 모델명을 고정하지 않고 재현 가능한 logical viewport와 플랫폼 역할을 기준으로 관리한다.
+
+| Platform | Profile | Logical viewport | 필수 확인 |
+| --- | --- | --- | --- |
+| Android | Compact phone emulator | 약 `360×800` | 작은 폭, 시스템 back, 키보드, scroll, safe inset |
+| Android | Large phone emulator | 약 `412×915` | 넓은 폭, 긴 목록, card/grid 정렬, 하단 CTA |
+| iOS | Compact-height simulator | `375×667` | 짧은 높이, 키보드, safe area, navigation 전환 |
+| iOS | Reference-height simulator | `375×812` | Figma 기준 정렬, notch 계열 safe area, 기본 사용자 흐름 |
+
+- 화면 PR은 Reference widget test를 기본으로 하고 레이아웃 위험에 따라 Compact 또는 Wide를 추가한다.
+- 화면 구조가 바뀐 PR은 Android와 iOS에서 각각 한 개 이상의 필수 profile로 smoke QA를 수행한다.
+- release candidate QA에서는 네 profile을 모두 확인한다.
+- 실제 기기는 같은 역할과 같거나 더 작은 사용 가능 viewport를 제공하면 해당 profile을 대체할 수 있다. PR 또는 QA 기록에 기기, OS, 사용 가능 viewport를 남긴다.
+- 가로 모드, tablet, foldable의 필수 지원 여부는 이 항목에서 임의로 확정하지 않으며 제품 지원 범위가 정해지면 QA matrix를 확장한다.
+
+### 공통 확인 항목
+
+- 첫 진입, loading, empty, error, success 상태
+- 긴 한글 문구, 이미지 없음, 네트워크 실패 상태
+- 키보드가 입력 필드와 CTA를 가리지 않는지
+- SafeArea, system back, scroll 복구, dialog 닫기
+- 화면 하단 CTA와 FAB의 접근 가능성
+- RenderFlex overflow와 잘린 텍스트가 없는지
+
+## TEST-01 다음 작업 범위
+
+TEST-01은 아래 순서로 별도 이슈화한다.
+
+1. Pretendard와 asset을 명시적으로 로드하는 golden test helper를 만든다.
+2. remote API와 시간, locale에 의존하지 않는 화면 한 개를 `375×812` full-screen pilot으로 선정한다.
+3. baseline 파일명, 저장 위치, DPR, 허용 오차, `--update-goldens` 리뷰 규칙을 정한다.
+4. Compact/Wide baseline은 pilot 화면에 일괄 추가하지 않고 레이아웃 위험과 회귀 효과를 확인해 대상 화면별로 선택한다.
+5. 로컬과 Ubuntu CI에서 같은 baseline이 재현된 뒤 일반 `fvm flutter test`에 포함한다.
+
+## TEST-02 Ready와 Blocked 경계
+
+### 로컬에서 진행 가능한 범위
+
+- Flutter SDK의 `integration_test` 의존성과 디렉터리 구조 검토
+- `COMMONPLANT_USE_API=false`인 앱 시작/route smoke flow 작성
+- Android emulator 또는 iOS simulator의 명시적 device ID를 사용하는 실행 명령 정리
+- 독립 workflow를 수동 실행으로 먼저 검증하고 PR 필수 게이트 승격 조건 문서화
+
+### 백엔드 준비 전 Blocked 범위
+
+- `COMMONPLANT_USE_API=true`인 로그인과 CRUD end-to-end flow
+- staging API URL과 API versioning을 포함한 CI 환경값
+- 테스트 전용 계정과 인증 갱신 정책
+- seed 데이터, 중복 방지, 테스트 후 cleanup 정책
+- secret 접근 권한과 외부 API 장애 시 재시도/판정 정책
+
+Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게이트에 추가하지 않는다.
+
+## 외부 기준
+
+- [Flutter testing overview](https://docs.flutter.dev/testing/overview)
+- [Flutter integration testing](https://docs.flutter.dev/testing/integration-tests)
+- [Android responsive/adaptive layouts](https://developer.android.com/develop/ui/views/layout/responsive-adaptive-design-with-views)
+
+## 커밋별 작업 이력
+
+| ID | 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- | --- |
+| QA-01 | - | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check` 예정 |
+
+작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -21,6 +21,7 @@
 | Font/asset | Pretendard 4종과 앱 asset이 저장소 및 `pubspec.yaml`에 등록됨 | Golden 재현성의 기본 조건 충족 |
 | Integration test | SDK 의존성, `integration_test/`, 실행 script 없음 | 로컬 smoke scaffold부터 별도 도입 가능 |
 | GitHub Actions | Ubuntu에서 `flutter analyze`, `flutter test` 실행 | device 기반 workflow는 없음 |
+| 기본 품질 게이트 | format 252개 파일, analyze, unit/widget test 218개 통과 | 현재 필수 게이트 정상 |
 | Remote API 환경 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 지점만 존재 | staging URL, 계정, 데이터 격리 정책은 Blocked |
 
 ## 의존관계를 반영한 작업 순서
@@ -116,6 +117,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 
 | ID | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
-| QA-01 | - | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check` 예정 |
+| QA-01 | `3e01a12` | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check`, format 252개 파일, analyze, unit/widget test 218개 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -150,6 +150,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | ID | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
 | QA-01 | `3e01a12` | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check`, format 252개 파일, analyze, unit/widget test 218개 |
-| QA-01 검증 | - | 144개 route/viewport 조합 검증, Compact/Short height 분리, 적용 gap과 후속 순서 보완 | 임시 route-level viewport 진단, `git diff --check` 예정 |
+| QA-01 검증 | `7e82774` | 144개 route/viewport 조합 검증, Compact/Short height 분리, 적용 gap과 후속 순서 보완 | 임시 route-level viewport 진단, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/screen-publishing-rules.md
+++ b/docs/screen-publishing-rules.md
@@ -76,8 +76,9 @@
 ## 반응형 기준
 
 - 기준 시안 폭은 `AppSizes.mobileWidth` 값인 375입니다.
-- 자동 레이아웃 검증은 logical viewport `320×568`, `375×812`, `430×932` 중 화면 위험에 맞는 profile을 사용합니다.
-- 모든 신규 화면은 `375×812`를 기본으로 확인하고, form, 긴 문구, 가로 배치, 하단 CTA가 있으면 `320×568`을 추가합니다.
+- 자동 레이아웃 검증은 logical viewport `320×640`, `375×667`, `375×812`, `430×932` 중 화면 위험에 맞는 profile을 사용합니다.
+- 모든 신규 화면은 `375×812`를 기본으로 확인하고, form, 긴 문구, 가로 배치가 있으면 Compact width `320×640`을 추가합니다.
+- 키보드, 하단 CTA, 고정 세로 배치가 있으면 Short height `375×667`을 추가합니다.
 - grid, card list, 좌우 정렬 변화가 있으면 `430×932`를 추가합니다.
 - 고정 카드나 버튼은 `AppSizes`로 관리합니다.
 - 리스트와 form은 가능한 `Expanded`, `Flexible`, `Wrap`, `SingleChildScrollView`를 사용해 overflow를 방지합니다.

--- a/docs/screen-publishing-rules.md
+++ b/docs/screen-publishing-rules.md
@@ -76,10 +76,15 @@
 ## 반응형 기준
 
 - 기준 시안 폭은 `AppSizes.mobileWidth` 값인 375입니다.
+- 자동 레이아웃 검증은 logical viewport `320×568`, `375×812`, `430×932` 중 화면 위험에 맞는 profile을 사용합니다.
+- 모든 신규 화면은 `375×812`를 기본으로 확인하고, form, 긴 문구, 가로 배치, 하단 CTA가 있으면 `320×568`을 추가합니다.
+- grid, card list, 좌우 정렬 변화가 있으면 `430×932`를 추가합니다.
 - 고정 카드나 버튼은 `AppSizes`로 관리합니다.
 - 리스트와 form은 가능한 `Expanded`, `Flexible`, `Wrap`, `SingleChildScrollView`를 사용해 overflow를 방지합니다.
 - 키보드가 올라오는 입력 화면은 스크롤 가능해야 합니다.
 - SafeArea를 고려하지 않은 절대 배치는 피합니다.
+
+수동 QA의 Android/iOS 필수 profile과 release candidate matrix는 `docs/quality-testing-follow-up-plan.md`를 따릅니다. 가로 모드, tablet, foldable은 제품 지원 범위가 확정되기 전까지 필수 matrix에 임의로 포함하지 않습니다.
 
 ## 공용화 판단 기준
 
@@ -109,5 +114,4 @@
 
 ## 결정 필요
 
-- Figma 기준 해상도 외에 QA 필수 디바이스 목록이 필요합니다.
 - Splash, onboarding, bottom navigation의 최종 UX 정책은 화면 범위 확정 후 별도 문서로 분리할 수 있습니다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -101,6 +101,23 @@ await tester.pumpWidget(
 
 UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니다.
 
+## QA viewport와 디바이스 기준
+
+화면 테스트와 수동 QA는 `docs/quality-testing-follow-up-plan.md`의 QA-01 profile을 공통 입력값으로 사용합니다.
+
+| 구분 | Logical viewport | 기본 용도 |
+| --- | --- | --- |
+| Compact | `320×568` | 작은 폭, 짧은 높이, 긴 문구, keyboard/CTA overflow |
+| Reference | `375×812` | Figma 및 `AppSizes.mobileWidth`/`mobileHeight` 기준 |
+| Wide | `430×932` | 넓은 휴대폰의 card/grid 정렬과 최대 너비 |
+
+- 모든 신규 화면 widget test는 Reference를 기본으로 사용합니다.
+- form, 긴 문구, 가로 배치, 하단 CTA가 있으면 Compact를 추가합니다.
+- grid, card list, 좌우 정렬 변화가 있으면 Wide를 추가합니다.
+- 화면 구조가 바뀐 PR은 Android와 iOS에서 각각 한 개 이상의 필수 profile로 smoke QA를 수행합니다.
+- release candidate는 QA-01의 Android 2개, iOS 2개 profile을 모두 확인합니다.
+- layout 비교용 widget test는 DPR 1을 사용합니다. Golden baseline DPR은 TEST-01에서 별도로 확정합니다.
+
 ## Golden test 기준
 
 Golden test는 MVP 기본 필수 항목이 아닙니다. 아래 조건 중 하나 이상을 만족하고, baseline 관리 비용보다 회귀 방지 효과가 클 때 추가합니다.
@@ -113,7 +130,8 @@ Golden test를 추가할 때는 아래 기준을 따릅니다.
 
 - 테스트 파일은 대상 위치와 맞춰 `test/shared/widgets/common_button_golden_test.dart`처럼 둡니다.
 - 기준 폭은 `AppSizes.mobileWidth`와 같은 375 logical pixel을 우선 사용합니다.
-- full-screen golden은 QA 필수 디바이스 목록이 확정된 뒤 추가하고, 그 전에는 컴포넌트 단위 golden을 우선합니다.
+- full-screen golden의 기본 후보 viewport는 QA-01의 Reference인 `375×812`입니다.
+- 실제 대상 화면, baseline DPR, Compact/Wide 추가 범위는 TEST-01 이슈에서 확정하며, 그 전에는 full-screen baseline을 추가하지 않습니다.
 - Pretendard font와 asset 로딩이 CI에서 재현 가능해야 합니다.
 - baseline 갱신은 의도한 디자인 변경이 있는 PR에서만 `fvm flutter test --update-goldens`로 수행합니다.
 
@@ -143,7 +161,9 @@ fvm flutter test integration_test \
   --dart-define=COMMONPLANT_API_BASE_URL=<staging-api-url>
 ```
 
-staging API와 runner가 준비되기 전에는 integration test를 PR CI에 연결하지 않습니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
+remote API를 사용하지 않는 앱 시작/route smoke와 device runner 검토는 로컬 준비 범위로 분리할 수 있습니다. staging API, 테스트 계정, seed/cleanup 정책이 필요한 end-to-end flow는 준비 전까지 `Blocked`입니다.
+
+staging API와 runner가 준비되기 전에는 remote integration test를 PR CI에 연결하지 않습니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
 
 ## 테스트 파일 네이밍
 
@@ -191,5 +211,6 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 
 ## 후속 결정 필요
 
-- QA 필수 디바이스 목록이 확정되면 full-screen golden 기준 크기를 추가합니다.
-- staging API, 테스트 계정, runner가 준비되면 integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다.
+- TEST-01에서 QA-01의 `375×812`를 기준으로 full-screen golden 대상 화면, DPR, baseline 갱신 규칙을 확정합니다.
+- TEST-02의 API 비사용 smoke와 runner 검토는 로컬 범위로 진행할 수 있습니다.
+- staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -107,12 +107,14 @@ UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니
 
 | 구분 | Logical viewport | 기본 용도 |
 | --- | --- | --- |
-| Compact | `320×568` | 작은 폭, 짧은 높이, 긴 문구, keyboard/CTA overflow |
+| Compact width | `320×640` | 작은 폭, 긴 문구, 가로 배치 overflow |
+| Short height | `375×667` | 짧은 높이, keyboard/CTA overflow |
 | Reference | `375×812` | Figma 및 `AppSizes.mobileWidth`/`mobileHeight` 기준 |
 | Wide | `430×932` | 넓은 휴대폰의 card/grid 정렬과 최대 너비 |
 
 - 모든 신규 화면 widget test는 Reference를 기본으로 사용합니다.
-- form, 긴 문구, 가로 배치, 하단 CTA가 있으면 Compact를 추가합니다.
+- form, 긴 문구, 가로 배치가 있으면 Compact width를 추가합니다.
+- 키보드, 하단 CTA, 고정 세로 배치가 있으면 Short height를 추가합니다.
 - grid, card list, 좌우 정렬 변화가 있으면 Wide를 추가합니다.
 - 화면 구조가 바뀐 PR은 Android와 iOS에서 각각 한 개 이상의 필수 profile로 smoke QA를 수행합니다.
 - release candidate는 QA-01의 Android 2개, iOS 2개 profile을 모두 확인합니다.
@@ -131,7 +133,7 @@ Golden test를 추가할 때는 아래 기준을 따릅니다.
 - 테스트 파일은 대상 위치와 맞춰 `test/shared/widgets/common_button_golden_test.dart`처럼 둡니다.
 - 기준 폭은 `AppSizes.mobileWidth`와 같은 375 logical pixel을 우선 사용합니다.
 - full-screen golden의 기본 후보 viewport는 QA-01의 Reference인 `375×812`입니다.
-- 실제 대상 화면, baseline DPR, Compact/Wide 추가 범위는 TEST-01 이슈에서 확정하며, 그 전에는 full-screen baseline을 추가하지 않습니다.
+- 실제 대상 화면, baseline DPR, Compact width/Short height/Wide 추가 범위는 TEST-01 이슈에서 확정하며, 그 전에는 full-screen baseline을 추가하지 않습니다.
 - Pretendard font와 asset 로딩이 CI에서 재현 가능해야 합니다.
 - baseline 갱신은 의도한 디자인 변경이 있는 PR에서만 `fvm flutter test --update-goldens`로 수행합니다.
 
@@ -211,6 +213,6 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 
 ## 후속 결정 필요
 
-- TEST-01에서 QA-01의 `375×812`를 기준으로 full-screen golden 대상 화면, DPR, baseline 갱신 규칙을 확정합니다.
+- Compact width 적용 gap을 먼저 수정한 뒤 TEST-01에서 `OnboardingPage`의 `375×812`를 기준으로 full-screen golden DPR과 baseline 갱신 규칙을 확정합니다.
 - TEST-02의 API 비사용 smoke와 runner 검토는 로컬 범위로 진행할 수 있습니다.
 - staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다.


### PR DESCRIPTION
## 관련 이슈
- Closes #195
- 선행 테스트 전략 정리: #78

## 구현 범위
- QA-01 자동 layout viewport와 Android/iOS 수동 QA profile 확정
- route-level 화면 18개와 viewport 8개의 초기 렌더링 144개 조합 검증 결과 기록
- QA-01 → compact 적용 후속 → TEST-01 → TEST-02 작업 순서와 의존관계 문서화
- TEST-02의 로컬 가능 범위와 백엔드 준비가 필요한 Blocked 범위 분리
- README, 화면 퍼블리싱 규칙, 테스트 가이드, 후속 결정 체크리스트 동기화
- 커밋별 작업 이력과 검증 결과 기록

## 주요 변경사항
- 자동 profile을 Compact width `320×640`, Short height `375×667`, Reference `375×812`, Wide `430×932`로 정리했습니다.
- 수동 QA는 Android compact/large, iOS compact-height/reference-height의 4개 profile로 정리했습니다.
- `320×568`과 `320×640`이 같은 width 문제를 검출해 기존 테스트와 정렬되는 `320×640`을 Compact width로 채택했습니다.
- Place 초대, 주소 검색, Place 상세, Plant 상세의 compact overflow를 별도 Bug 범위로 분리했습니다.
- TEST-01은 compact 적용 후속 완료 전까지 `Open`으로 두고, 첫 pilot은 `OnboardingPage`의 `375×812`로 정했습니다.
- TEST-02는 API 비사용 smoke/runner 검토만 로컬 범위로 두고 staging URL, 테스트 계정, seed/cleanup이 필요한 remote workflow는 `Blocked`로 유지했습니다.

## viewport 검증 결과
- `320×568`: 4개 route overflow
- `320×640`: 동일한 4개 route overflow
- `360×800`: Place 초대 overflow
- `375×667`, `375×812`, `412×915`, `430×812`, `430×932`: route-level 화면 18개 통과

임시 진단 테스트는 결과 확인 후 제거했습니다. 이 검증은 DPR 1과 system inset이 없는 초기 렌더링 검사이므로 keyboard, SafeArea, system back은 수동 QA 범위로 유지합니다.

## 현재 PR에서 제외한 범위
- compact overflow 코드 수정
- viewport 공통 테스트 helper와 영구 회귀 테스트
- golden test 구현 및 baseline
- integration test와 workflow

위 항목은 한 PR 한 Task 원칙에 따라 별도 이슈와 develop 기반 브랜치에서 진행합니다.

## 검증
- `git diff --check`
- 임시 route-level viewport 진단: 18개 route × 8개 viewport = 144개 조합
- `fvm dart format --output=none --set-exit-if-changed .` — 252개 파일, 변경 없음
- `fvm flutter analyze` — 이슈 없음
- `fvm flutter test` — 218개 통과
- GitHub Actions `quality` 2건 통과

## 리뷰 포인트
- 폭과 높이 위험을 Compact width와 Short height로 분리한 기준
- 확인된 compact gap을 QA-01 정책 결정과 별도 구현 범위로 분리한 판단
- TEST-01 전에 compact 적용 후속을 배치한 작업 순서
- TEST-02 remote API 관련 항목의 Blocked 경계

## 문서 반영
- `README.md`
- `docs/quality-testing-follow-up-plan.md`
- `docs/follow-up-decision-checklist.md`
- `docs/testing-guide.md`
- `docs/screen-publishing-rules.md`

## Breaking change
- 없음

