### PR TITLE
Fix: compact 화면 overflow 수정 #197

### DIFF
--- a/docs/design-token-rules.md
+++ b/docs/design-token-rules.md
@@ -118,13 +118,14 @@ static const double searchTextFieldHeight = 64;
 
 ### 가변 크기의 최소·최대 기준
 
-화면 폭에 따라 크기가 변해야 하는 요소는 단일 퍼센트나 이진 breakpoint보다 `가용 공간 계산 -> 최소·최대 제한 -> 남은 영역 배치` 순서를 우선합니다.
+화면 폭 대응은 `Expanded`/`Flexible` 같은 제약 기반 배치를 먼저 사용합니다. 그것만으로 콘텐츠의 최소 영역과 시각 요소의 상한을 함께 보장하기 어려울 때 제한형 가변 크기를 적용합니다.
 
-1. 텍스트, action, padding처럼 먼저 보호할 영역의 최소 크기를 정합니다.
-2. `LayoutBuilder`의 실제 `constraints`에서 보호 영역과 간격을 제외해 가용 크기를 계산합니다.
-3. 계산값을 `clamp(min, max)`로 제한해 compact에서 지나치게 작아지거나 wide에서 과도하게 커지지 않게 합니다.
-4. 최소·최대값이 공용 컴포넌트 규격이나 둘 이상의 파일에서 사용되면 `AppSizes`에 `Min`/`Max` 의미가 드러나는 이름으로 정의합니다.
-5. 최소, 중간, 최대 viewport에서 실제 값과 overflow 여부를 widget test로 확인합니다.
+1. `Expanded`/`Flexible`과 overflow 정책만으로 해결 가능한지 먼저 확인합니다.
+2. 텍스트, action, padding처럼 반드시 보호할 최소 영역과 시각 요소의 유효 범위를 정합니다.
+3. `LayoutBuilder`의 실제 `constraints`에서 보호 영역과 간격을 제외해 가용 크기를 계산합니다.
+4. 계산값을 `clamp(min, max)`로 제한해 compact에서 지나치게 작아지거나 wide에서 과도하게 커지지 않게 합니다.
+5. 최소·최대값이 공용 컴포넌트 규격이거나 둘 이상의 파일에서 사용되면 `AppSizes`에 `Min`/`Max` 의미가 드러나는 이름으로 정의합니다. 특정 위젯의 배치 계산에만 필요한 값은 private 상수로 둡니다.
+6. 최소·최대 viewport의 계약값, 중간 viewport의 범위·단조성, 모든 대상 viewport의 overflow 부재를 widget test로 확인합니다.
 
 ```dart
 final availableWidth = constraints.maxWidth - protectedContentWidth;
@@ -136,6 +137,7 @@ final responsiveWidth = availableWidth
 - 버튼 높이와 최소 터치 영역, 아이콘 glyph처럼 접근성·조작성을 보장하는 값은 임의로 비율 축소하지 않습니다.
 - 텍스트는 우선 `Expanded`/`Flexible`로 남은 공간을 사용하고 `maxLines`와 overflow 정책을 함께 지정합니다.
 - spacing은 토큰을 기본으로 하며, 가변 spacing이 필요한 경우에도 최소·최대값은 기존 spacing token 또는 명시적 component token으로 제한합니다.
+- 중간 viewport의 정확한 픽셀값은 디자인 계약이 아닐 수 있으므로, 구현식과 테스트를 불필요하게 결합하지 않습니다.
 - 화면 전체 폭의 고정 비율만 사용하면 내부 콘텐츠의 최소 폭을 보장하기 어려우므로, component constraint를 근거로 계산합니다.
 
 ## 그라디언트 규칙

--- a/docs/design-token-rules.md
+++ b/docs/design-token-rules.md
@@ -116,6 +116,28 @@ static const double placeCardHeight = 156;
 static const double searchTextFieldHeight = 64;
 ```
 
+### 가변 크기의 최소·최대 기준
+
+화면 폭에 따라 크기가 변해야 하는 요소는 단일 퍼센트나 이진 breakpoint보다 `가용 공간 계산 -> 최소·최대 제한 -> 남은 영역 배치` 순서를 우선합니다.
+
+1. 텍스트, action, padding처럼 먼저 보호할 영역의 최소 크기를 정합니다.
+2. `LayoutBuilder`의 실제 `constraints`에서 보호 영역과 간격을 제외해 가용 크기를 계산합니다.
+3. 계산값을 `clamp(min, max)`로 제한해 compact에서 지나치게 작아지거나 wide에서 과도하게 커지지 않게 합니다.
+4. 최소·최대값이 공용 컴포넌트 규격이나 둘 이상의 파일에서 사용되면 `AppSizes`에 `Min`/`Max` 의미가 드러나는 이름으로 정의합니다.
+5. 최소, 중간, 최대 viewport에서 실제 값과 overflow 여부를 widget test로 확인합니다.
+
+```dart
+final availableWidth = constraints.maxWidth - protectedContentWidth;
+final responsiveWidth = availableWidth
+    .clamp(AppSizes.componentMinWidth, AppSizes.componentMaxWidth)
+    .toDouble();
+```
+
+- 버튼 높이와 최소 터치 영역, 아이콘 glyph처럼 접근성·조작성을 보장하는 값은 임의로 비율 축소하지 않습니다.
+- 텍스트는 우선 `Expanded`/`Flexible`로 남은 공간을 사용하고 `maxLines`와 overflow 정책을 함께 지정합니다.
+- spacing은 토큰을 기본으로 하며, 가변 spacing이 필요한 경우에도 최소·최대값은 기존 spacing token 또는 명시적 component token으로 제한합니다.
+- 화면 전체 폭의 고정 비율만 사용하면 내부 콘텐츠의 최소 폭을 보장하기 어려우므로, component constraint를 근거로 계산합니다.
+
 ## 그라디언트 규칙
 
 그라디언트는 `AppGradients`에 정의합니다.

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -13,8 +13,8 @@
 
 | 체크 | ID | 결정 항목 | 출처 | 다음 액션 | 상태 |
 | --- | --- | --- | --- | --- | --- |
-| [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | Compact width `320×640`, Short height `375×667`, Reference `375×812`, Wide `430×932`와 Android/iOS 수동 QA profile을 적용한다. 확인된 compact overflow는 별도 Bug 이슈로 수정한다. | Decided |
-| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | compact 적용 gap 수정 후 `OnboardingPage`의 `375×812` pilot으로 대상 화면, DPR, baseline 갱신 규칙을 별도 이슈에서 확정한다. | Open |
+| [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | 네 QA profile을 적용한다. 확인된 compact overflow와 대상 회귀 테스트는 #197에서 완료했다. | Decided |
+| [ ] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | `OnboardingPage`의 `375×812` pilot으로 대상 화면, DPR, baseline 갱신 규칙을 별도 이슈에서 확정한다. | Ready |
 | [ ] | TEST-02 | integration test 실행 환경과 workflow 연결 방식 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | API 비사용 smoke/runner는 로컬 범위로 분리하고 staging URL, 테스트 계정, seed/cleanup이 필요한 remote workflow는 보류한다. | Blocked |
 
 ## 릴리즈와 환경

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -10,18 +10,18 @@
 - 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
 - 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
 
-## 2026-08-12 현재 상태
+## 2026-08-13 현재 상태
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
-| 기준 브랜치 | `develop@f001561` | 코드 가독성 리팩토링 3차 병합 완료 |
+| 기준 브랜치 | `develop@c230237` | QA-01 기준 정리 #195, PR #196 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
-| Widget test viewport | 일부 화면 테스트가 `320×640`, `375×812`, `430×812`, DPR 1을 파일별로 직접 설정 | 공통 QA profile/helper는 없음 |
+| Widget test viewport | `test/helpers/test_viewport.dart`에서 네 QA profile과 DPR 1 설정을 제공하고 compact gap 대상 화면에 적용 | 기존 raw viewport 설정은 관련 화면 수정 시 점진적으로 helper로 전환 |
 | Golden test | test, baseline image, 공통 font loader 없음 | TEST-01에서 첫 도입 범위 결정 필요 |
 | Font/asset | Pretendard 4종과 앱 asset이 저장소 및 `pubspec.yaml`에 등록됨 | Golden 재현성의 기본 조건 충족 |
 | Integration test | SDK 의존성, `integration_test/`, 실행 script 없음 | 로컬 smoke scaffold부터 별도 도입 가능 |
 | GitHub Actions | Ubuntu에서 `flutter analyze`, `flutter test` 실행 | device 기반 workflow는 없음 |
-| 기본 품질 게이트 | format 252개 파일, analyze, unit/widget test 218개 통과 | 현재 필수 게이트 정상 |
+| 기본 품질 게이트 | format 253개 파일, analyze, unit/widget test 222개 통과 | #197 compact 회귀 테스트 포함, 현재 필수 게이트 정상 |
 | Remote API 환경 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 지점만 존재 | staging URL, 계정, 데이터 격리 정책은 Blocked |
 
 ## 의존관계를 반영한 작업 순서
@@ -29,8 +29,8 @@
 | 순서 | ID | 범위 | 선행 조건 | 현재 상태 |
 | --- | --- | --- | --- | --- |
 | 1 | QA-01 | QA 필수 디바이스와 viewport 기준 확정 | 없음 | Decided (#195) |
-| 2 | QA-01 적용 후속 | compact-width overflow 수정과 viewport 회귀 테스트 추가 | QA-01 | Ready. 별도 Bug 이슈 필요 |
-| 3 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | QA-01 적용 후속 | Open. 선행 작업 완료 후 Ready |
+| 2 | QA-01 적용 후속 | compact-width overflow 수정과 viewport 회귀 테스트 추가 | QA-01 | Done (#197) |
+| 3 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | QA-01 적용 후속 | Ready |
 | 4 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 로컬 실행 환경 검토 | 없음. 우선순위상 TEST-01 다음 | Ready |
 | 5 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
 
@@ -76,12 +76,12 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 
 | 화면 | 확인된 문제 | 처리 기준 |
 | --- | --- | --- |
-| Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | 별도 Bug 이슈에서 반응형 action 배치와 회귀 테스트 추가 |
-| 주소 검색 | 결과 Row가 320에서 12px 가로 overflow | 별도 Bug 이슈에서 text/button 제약과 회귀 테스트 추가 |
-| Place 상세 | 공용 Plant card 내부 세로 overflow | 별도 Bug 이슈에서 card compact layout과 회귀 테스트 추가 |
-| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | 별도 Bug 이슈에서 날짜 요약 반응형 배치와 회귀 테스트 추가 |
+| Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | #197에서 가용 폭에 맞는 동일 비율 버튼과 `320×640`, `360×800` 회귀 테스트 적용 |
+| 주소 검색 | 결과 Row가 320에서 12px 가로 overflow | #197에서 가변 text 영역과 `320×640` 회귀 테스트 적용 |
+| Place 상세 | 공용 Plant card 내부 세로 overflow | #197에서 compact thumbnail과 `320×640` 회귀 테스트 적용 |
+| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | #197에서 compact 간격과 `320×640` 회귀 테스트 적용 |
 
-QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 정책을 현재 화면에 적용하는 구현 작업이므로 #195와 PR #196에 코드 수정으로 포함하지 않는다.
+QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 #197에서 정책 적용과 회귀 테스트를 완료했으며, TEST-01의 선행 조건은 해소되었다.
 
 ### 수동 QA 필수 디바이스 profile
 
@@ -111,14 +111,13 @@ QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 정책을
 
 ## TEST-01 다음 작업 범위
 
-TEST-01은 아래 순서로 별도 이슈화한다.
+Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료했다. TEST-01은 아래 남은 범위로 별도 이슈화한다.
 
-1. Compact width 적용 gap과 대상 화면의 viewport 회귀 테스트를 먼저 해결한다.
-2. Pretendard와 asset을 명시적으로 로드하는 golden test helper를 만든다.
-3. remote API와 시간, locale에 의존하지 않는 `OnboardingPage`를 `375×812` full-screen pilot으로 사용한다.
-4. baseline 파일명, 저장 위치, DPR, 허용 오차, `--update-goldens` 리뷰 규칙을 정한다.
-5. Compact width, Short height, Wide baseline은 pilot 화면에 일괄 추가하지 않고 레이아웃 위험과 회귀 효과를 확인해 대상 화면별로 선택한다.
-6. 로컬과 Ubuntu CI에서 같은 baseline이 재현된 뒤 일반 `fvm flutter test`에 포함한다.
+1. Pretendard와 asset을 명시적으로 로드하는 golden test helper를 만든다.
+2. remote API와 시간, locale에 의존하지 않는 `OnboardingPage`를 `375×812` full-screen pilot으로 사용한다.
+3. baseline 파일명, 저장 위치, DPR, 허용 오차, `--update-goldens` 리뷰 규칙을 정한다.
+4. Compact width, Short height, Wide baseline은 pilot 화면에 일괄 추가하지 않고 레이아웃 위험과 회귀 효과를 확인해 대상 화면별로 선택한다.
+5. 로컬과 Ubuntu CI에서 같은 baseline이 재현된 뒤 일반 `fvm flutter test`에 포함한다.
 
 ## TEST-02 Ready와 Blocked 경계
 
@@ -151,5 +150,7 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | --- | --- | --- | --- |
 | QA-01 | `3e01a12` | QA 필수 viewport/device profile, 후속 작업 순서, Ready/Blocked 경계 문서화 | `git diff --check`, format 252개 파일, analyze, unit/widget test 218개 |
 | QA-01 검증 | `7e82774` | 144개 route/viewport 조합 검증, Compact/Short height 분리, 적용 gap과 후속 순서 보완 | 임시 route-level viewport 진단, `git diff --check` |
+| QA-01 적용 | `b09e6a7` | Place 초대, 주소 검색, Place 상세, Plant 상세 compact 반응형 레이아웃 수정 | 대상 화면 test 21개, `fvm flutter analyze` |
+| QA-01 회귀 | `20a1ed5` | 공통 viewport helper와 compact 회귀 widget test 4개 추가 | format 253개 파일, `fvm flutter analyze`, unit/widget test 222개 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -78,8 +78,8 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 | --- | --- | --- |
 | Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | #197에서 버튼 폭을 72~114로 제한하고 `320×640`, `360×800` 연속 변화와 overflow 부재 검증 |
 | 주소 검색 | 결과 Row가 320에서 12px 가로 overflow | #197에서 가변 text 영역과 `320×640` 회귀 테스트 적용 |
-| Place 상세 | 공용 Plant card 내부 세로 overflow | #197에서 image를 96~136 폭과 96~108 높이로 제한하고 320/340/375 폭 검증 |
-| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | #197에서 간격을 8~34로 제한하고 320/333/375 폭 검증 |
+| Place 상세 | 공용 Plant card 내부 세로 overflow | #197에서 image를 96~136 폭과 96~108 높이로 제한하고 320/340/375 폭의 끝값·범위·단조성 검증 |
+| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | #197에서 320~375 폭의 진행률로 간격을 8~34 사이 보간하고 최소/중간/최대 폭의 끝값·범위·단조성 검증 |
 
 QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 #197에서 정책 적용과 회귀 테스트를 완료했으며, TEST-01의 선행 조건은 해소되었다.
 
@@ -153,5 +153,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | QA-01 적용 | `b09e6a7` | Place 초대, 주소 검색, Place 상세, Plant 상세 compact 반응형 레이아웃 수정 | 대상 화면 test 21개, `fvm flutter analyze` |
 | QA-01 회귀 | `20a1ed5` | 공통 viewport helper와 compact 회귀 widget test 4개 추가 | format 253개 파일, `fvm flutter analyze`, unit/widget test 222개 |
 | QA-01 가변 범위 | `fe0f5fc` | 초대 버튼, 장소 식물 카드 image, 식물 날짜 간격을 최소·최대 범위의 연속 계산으로 보완 | 대상 화면 test 21개, 최소·중간·최대 viewport 값 검증 |
+| QA-01 가변 기준 정리 | `a80d3ae` | 위젯 전용 보호값을 private 상수로 이동하고 날짜 간격을 정규화 보간하며 중간값 테스트를 범위·단조성 기준으로 완화 | Place/Plant 상세 test 15개, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -10,7 +10,7 @@
 - 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
 - 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
 
-## 2026-08-13 현재 상태
+## 2026-08-14 현재 상태
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
@@ -76,10 +76,10 @@ Flutter test의 `tester.view`에는 physical pixel이 아니라 아래 logical v
 
 | 화면 | 확인된 문제 | 처리 기준 |
 | --- | --- | --- |
-| Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | #197에서 가용 폭에 맞는 동일 비율 버튼과 `320×640`, `360×800` 회귀 테스트 적용 |
+| Place 초대 | action button Row가 320에서 50px, 360에서 10px 가로 overflow | #197에서 버튼 폭을 72~114로 제한하고 `320×640`, `360×800` 연속 변화와 overflow 부재 검증 |
 | 주소 검색 | 결과 Row가 320에서 12px 가로 overflow | #197에서 가변 text 영역과 `320×640` 회귀 테스트 적용 |
-| Place 상세 | 공용 Plant card 내부 세로 overflow | #197에서 compact thumbnail과 `320×640` 회귀 테스트 적용 |
-| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | #197에서 compact 간격과 `320×640` 회귀 테스트 적용 |
+| Place 상세 | 공용 Plant card 내부 세로 overflow | #197에서 image를 96~136 폭과 96~108 높이로 제한하고 320/340/375 폭 검증 |
+| Plant 상세 | 날짜 요약 Row가 320에서 22px 가로 overflow | #197에서 간격을 8~34로 제한하고 320/333/375 폭 검증 |
 
 QA-01은 정책 결정 상태인 `Decided`로 유지한다. 위 gap은 #197에서 정책 적용과 회귀 테스트를 완료했으며, TEST-01의 선행 조건은 해소되었다.
 
@@ -152,5 +152,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | QA-01 검증 | `7e82774` | 144개 route/viewport 조합 검증, Compact/Short height 분리, 적용 gap과 후속 순서 보완 | 임시 route-level viewport 진단, `git diff --check` |
 | QA-01 적용 | `b09e6a7` | Place 초대, 주소 검색, Place 상세, Plant 상세 compact 반응형 레이아웃 수정 | 대상 화면 test 21개, `fvm flutter analyze` |
 | QA-01 회귀 | `20a1ed5` | 공통 viewport helper와 compact 회귀 widget test 4개 추가 | format 253개 파일, `fvm flutter analyze`, unit/widget test 222개 |
+| QA-01 가변 범위 | `fe0f5fc` | 초대 버튼, 장소 식물 카드 image, 식물 날짜 간격을 최소·최대 범위의 연속 계산으로 보완 | 대상 화면 test 21개, 최소·중간·최대 viewport 값 검증 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/screen-publishing-rules.md
+++ b/docs/screen-publishing-rules.md
@@ -82,8 +82,10 @@
 - grid, card list, 좌우 정렬 변화가 있으면 `430×932`를 추가합니다.
 - 고정 카드나 버튼은 `AppSizes`로 관리합니다.
 - 리스트와 form은 가능한 `Expanded`, `Flexible`, `Wrap`, `SingleChildScrollView`를 사용해 overflow를 방지합니다.
-- 화면 폭에 따라 크기를 조정할 때는 단일 퍼센트보다 `LayoutBuilder`의 가용 공간을 기준으로 계산하고, `AppSizes`의 최소·최대값 사이로 제한합니다.
-- 가변 크기 적용 순서는 `보호할 text/action 최소 영역 결정 -> padding/spacing 제외 -> 가용 크기 계산 -> clamp(min, max) -> 최소/중간/최대 viewport 검증`입니다.
+- `Expanded`/`Flexible`만으로 보호할 최소 영역과 시각 요소의 크기 범위를 함께 보장하기 어려울 때 제한형 가변 크기를 적용합니다.
+- 제한형 가변 크기는 단일 퍼센트보다 `LayoutBuilder`의 가용 공간을 기준으로 계산하고, 명시한 최소·최대값 사이로 제한합니다.
+- 적용 순서는 `보호할 text/action 최소 영역 결정 -> padding/spacing 제외 -> 가용 크기 계산 -> clamp(min, max) -> 최소/중간/최대 viewport 검증`입니다.
+- 최소·최대값은 공용 규격일 때만 `AppSizes`에 두고, 특정 위젯의 내부 배치 보호값이면 해당 위젯 내부 상수로 관리합니다.
 - 버튼 높이와 최소 터치 영역은 비율로 축소하지 않고, 텍스트는 `Expanded`/`Flexible`과 overflow 정책으로 남은 공간을 사용합니다.
 - 키보드가 올라오는 입력 화면은 스크롤 가능해야 합니다.
 - SafeArea를 고려하지 않은 절대 배치는 피합니다.

--- a/docs/screen-publishing-rules.md
+++ b/docs/screen-publishing-rules.md
@@ -82,6 +82,9 @@
 - grid, card list, 좌우 정렬 변화가 있으면 `430×932`를 추가합니다.
 - 고정 카드나 버튼은 `AppSizes`로 관리합니다.
 - 리스트와 form은 가능한 `Expanded`, `Flexible`, `Wrap`, `SingleChildScrollView`를 사용해 overflow를 방지합니다.
+- 화면 폭에 따라 크기를 조정할 때는 단일 퍼센트보다 `LayoutBuilder`의 가용 공간을 기준으로 계산하고, `AppSizes`의 최소·최대값 사이로 제한합니다.
+- 가변 크기 적용 순서는 `보호할 text/action 최소 영역 결정 -> padding/spacing 제외 -> 가용 크기 계산 -> clamp(min, max) -> 최소/중간/최대 viewport 검증`입니다.
+- 버튼 높이와 최소 터치 영역은 비율로 축소하지 않고, 텍스트는 `Expanded`/`Flexible`과 overflow 정책으로 남은 공간을 사용합니다.
 - 키보드가 올라오는 입력 화면은 스크롤 가능해야 합니다.
 - SafeArea를 고려하지 않은 절대 배치는 피합니다.
 
@@ -104,6 +107,7 @@
 - [ ] 공용 위젯으로 대체 가능한 UI를 새로 만들지 않았는가?
 - [ ] loading, empty, error 상태를 고려했는가?
 - [ ] 긴 한글 문구와 작은 화면에서 overflow가 없는가?
+- [ ] 가변 크기를 사용했다면 최소·중간·최대 viewport에서 범위와 연속 변화를 확인했는가?
 - [ ] 키보드 노출 시 입력 필드와 CTA가 가려지지 않는가?
 - [ ] 터치 영역이 충분한가?
 - [ ] `fvm flutter analyze`를 통과하는가?

--- a/docs/shared-widget-guide.md
+++ b/docs/shared-widget-guide.md
@@ -218,8 +218,9 @@ CommonAddressOrPlaceField(
 - 크기: 335x136
 - padding: 10
 - 이미지: Reference에서 최대 136x108, compact에서 최소 96x96
-- 이미지 폭은 카드에서 padding, 간격, 정보 영역 최소 156을 제외한 값으로 계산하고 96~136 사이로 제한
+- 이미지 폭은 카드에서 padding, 간격, 정보 영역 보호 폭을 제외한 값으로 계산하고 96~136 사이로 제한
 - 이미지 높이는 계산된 폭을 따르되 96~108 사이로 제한
+- 현재 정보 영역 보호 폭 156은 이 카드의 내부 배치값이므로 공용 `AppSizes`가 아닌 위젯 private 상수로 관리
 - name: 16/700
 - species/description/date: 12/500
 - D-day: 16/500, SeaGreen/Dark2
@@ -228,8 +229,8 @@ CommonAddressOrPlaceField(
 
 1. 텍스트, action, 터치 영역의 최소 크기를 먼저 보존합니다.
 2. 남은 가용 공간에서 시각 요소 크기를 계산합니다.
-3. 공용 `AppSizes`의 최소·최대 범위로 `clamp`합니다.
-4. Compact, 중간 폭, Reference에서 크기가 연속적으로 변하고 overflow가 없는지 테스트합니다.
+3. 최소·최대 범위로 `clamp`하고, 여러 곳에서 공유하는 규격만 `AppSizes`에 둡니다.
+4. Compact와 Reference의 계약값, 중간 폭의 범위·단조성, 모든 폭의 overflow 부재를 테스트합니다.
 
 ### CommonMemoCard
 

--- a/docs/shared-widget-guide.md
+++ b/docs/shared-widget-guide.md
@@ -217,10 +217,19 @@ CommonAddressOrPlaceField(
 
 - 크기: 335x136
 - padding: 10
-- 이미지: 136x108
+- 이미지: Reference에서 최대 136x108, compact에서 최소 96x96
+- 이미지 폭은 카드에서 padding, 간격, 정보 영역 최소 156을 제외한 값으로 계산하고 96~136 사이로 제한
+- 이미지 높이는 계산된 폭을 따르되 96~108 사이로 제한
 - name: 16/700
 - species/description/date: 12/500
 - D-day: 16/500, SeaGreen/Dark2
+
+가변 크기 요소를 추가하거나 변경할 때는 아래 순서로 검토합니다.
+
+1. 텍스트, action, 터치 영역의 최소 크기를 먼저 보존합니다.
+2. 남은 가용 공간에서 시각 요소 크기를 계산합니다.
+3. 공용 `AppSizes`의 최소·최대 범위로 `clamp`합니다.
+4. Compact, 중간 폭, Reference에서 크기가 연속적으로 변하고 overflow가 없는지 테스트합니다.
 
 ### CommonMemoCard
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -119,6 +119,8 @@ UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니
 - 화면 구조가 바뀐 PR은 Android와 iOS에서 각각 한 개 이상의 필수 profile로 smoke QA를 수행합니다.
 - release candidate는 QA-01의 Android 2개, iOS 2개 profile을 모두 확인합니다.
 - layout 비교용 widget test는 DPR 1을 사용합니다. Golden baseline DPR은 TEST-01에서 별도로 확정합니다.
+- 공통 profile과 DPR 설정은 `test/helpers/test_viewport.dart`의 `TestViewports`와 `configureTestViewport`를 사용합니다.
+- 기존 테스트의 raw viewport 설정은 해당 화면을 수정할 때 공통 helper로 점진적으로 전환합니다.
 
 ## Golden test 기준
 
@@ -213,6 +215,6 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 
 ## 후속 결정 필요
 
-- Compact width 적용 gap을 먼저 수정한 뒤 TEST-01에서 `OnboardingPage`의 `375×812`를 기준으로 full-screen golden DPR과 baseline 갱신 규칙을 확정합니다.
+- Compact width 적용 gap과 대상 회귀 테스트는 #197에서 완료했습니다. 다음 TEST-01에서 `OnboardingPage`의 `375×812`를 기준으로 full-screen golden DPR과 baseline 갱신 규칙을 확정합니다.
 - TEST-02의 API 비사용 smoke와 runner 검토는 로컬 범위로 진행할 수 있습니다.
 - staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -121,8 +121,8 @@ UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니
 - layout 비교용 widget test는 DPR 1을 사용합니다. Golden baseline DPR은 TEST-01에서 별도로 확정합니다.
 - 공통 profile과 DPR 설정은 `test/helpers/test_viewport.dart`의 `TestViewports`와 `configureTestViewport`를 사용합니다.
 - 기존 테스트의 raw viewport 설정은 해당 화면을 수정할 때 공통 helper로 점진적으로 전환합니다.
-- `clamp(min, max)` 기반 가변 크기는 Compact와 Reference만 확인하지 않고 중간 viewport도 추가해 값이 갑자기 변하지 않는지 검증합니다.
-- 최소 viewport에서는 min 이상 유지와 overflow 부재, 중간 viewport에서는 연속 변화, Reference 또는 Wide에서는 max 이하 유지 여부를 확인합니다.
+- 제한형 가변 크기는 Compact와 Reference만 확인하지 않고 중간 viewport도 추가해 값이 갑자기 변하지 않는지 검증합니다.
+- 최소·최대 viewport에서는 확정된 계약값과 overflow 부재를 확인하고, 중간 viewport에서는 정확한 픽셀값보다 최소·최대 범위와 단조 변화를 검증합니다.
 - 버튼 높이와 최소 터치 영역처럼 고정해야 하는 값은 viewport별로 유지되는지도 함께 검증합니다.
 
 ## Golden test 기준

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -121,6 +121,9 @@ UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니
 - layout 비교용 widget test는 DPR 1을 사용합니다. Golden baseline DPR은 TEST-01에서 별도로 확정합니다.
 - 공통 profile과 DPR 설정은 `test/helpers/test_viewport.dart`의 `TestViewports`와 `configureTestViewport`를 사용합니다.
 - 기존 테스트의 raw viewport 설정은 해당 화면을 수정할 때 공통 helper로 점진적으로 전환합니다.
+- `clamp(min, max)` 기반 가변 크기는 Compact와 Reference만 확인하지 않고 중간 viewport도 추가해 값이 갑자기 변하지 않는지 검증합니다.
+- 최소 viewport에서는 min 이상 유지와 overflow 부재, 중간 viewport에서는 연속 변화, Reference 또는 Wide에서는 max 이하 유지 여부를 확인합니다.
+- 버튼 높이와 최소 터치 영역처럼 고정해야 하는 값은 viewport별로 유지되는지도 함께 검증합니다.
 
 ## Golden test 기준
 

--- a/lib/core/theme/app_sizes.dart
+++ b/lib/core/theme/app_sizes.dart
@@ -3,6 +3,7 @@ abstract final class AppSizes {
 
   static const double mobileWidth = 375;
   static const double mobileHeight = 812;
+  static const double compactMobileWidth = 320;
 
   static const double iconSmall = 20;
   static const double iconMedium = 24;
@@ -48,9 +49,10 @@ abstract final class AppSizes {
   static const double placePlantCardWidth = 335;
   static const double placePlantCardHeight = 136;
   static const double placePlantCardPadding = 10;
-  static const double placePlantCardImageWidth = 136;
-  static const double placePlantCardImageHeight = 108;
-  static const double plantThumbnailSize = 96;
+  static const double placePlantCardImageMinSize = 96;
+  static const double placePlantCardImageMaxWidth = 136;
+  static const double placePlantCardImageMaxHeight = 108;
+  static const double placePlantCardDetailsMinWidth = 156;
   static const double plantEmptyIconHeight = 60;
   static const double plantCardFadeHeight = 28;
   static const double plantCardFadeBottom = 8;
@@ -77,6 +79,7 @@ abstract final class AppSizes {
   static const double placeImageCameraBoxSize = 40;
   static const double placeImageCameraIconSize = 27;
   static const double placeInvitationAvatarSize = 80;
-  static const double placeInvitationActionButtonWidth = 114;
+  static const double placeInvitationActionButtonMinWidth = 72;
+  static const double placeInvitationActionButtonMaxWidth = 114;
   static const double placeInvitationActionButtonHeight = 36;
 }

--- a/lib/core/theme/app_sizes.dart
+++ b/lib/core/theme/app_sizes.dart
@@ -52,7 +52,6 @@ abstract final class AppSizes {
   static const double placePlantCardImageMinSize = 96;
   static const double placePlantCardImageMaxWidth = 136;
   static const double placePlantCardImageMaxHeight = 108;
-  static const double placePlantCardDetailsMinWidth = 156;
   static const double plantEmptyIconHeight = 60;
   static const double plantCardFadeHeight = 28;
   static const double plantCardFadeBottom = 8;

--- a/lib/features/place/presentation/pages/address_search_page.dart
+++ b/lib/features/place/presentation/pages/address_search_page.dart
@@ -90,26 +90,33 @@ class _AddressSearchResultTile extends StatelessWidget {
           ),
           child: Row(
             children: [
-              SizedBox(
-                width: _addressSearchResultTextWidth,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    _AddressSearchResultTitle(result: result),
-                    const SizedBox(height: AppSpacing.x4),
-                    Text(
-                      result.address,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTextStyles.size14Medium.copyWith(
-                        color: AppColors.textBody,
-                      ),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxWidth: _addressSearchResultTextWidth,
                     ),
-                  ],
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        _AddressSearchResultTitle(result: result),
+                        const SizedBox(height: AppSpacing.x4),
+                        Text(
+                          result.address,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTextStyles.size14Medium.copyWith(
+                            color: AppColors.textBody,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: AppSpacing.x8),
               _AddressSearchSelectButton(onPressed: onSelect),
             ],
           ),

--- a/lib/features/place/presentation/widgets/place_invitation_list_item.dart
+++ b/lib/features/place/presentation/widgets/place_invitation_list_item.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 
 const double _invitationContentGap = 14;
 const double _invitationButtonGap = 8;
+const double _invitationActionsWidth =
+    AppSizes.placeInvitationActionButtonWidth * 2 + _invitationButtonGap;
 
 class PlaceInvitationListItem extends StatelessWidget {
   const PlaceInvitationListItem({
@@ -180,24 +182,40 @@ class _InvitationActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        _InvitationActionButton(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useFlexibleButtons =
+            constraints.maxWidth < _invitationActionsWidth;
+
+        final acceptButton = _InvitationActionButton(
           label: '확인',
           semanticsLabel: '${invitation.placeName} 확인',
           backgroundColor: AppColors.brandPrimary,
           foregroundColor: AppColors.white,
           onPressed: onAccept,
-        ),
-        const SizedBox(width: _invitationButtonGap),
-        _InvitationActionButton(
+        );
+        final deleteButton = _InvitationActionButton(
           label: '삭제',
           semanticsLabel: '${invitation.placeName} 삭제',
           backgroundColor: AppColors.borderDefault,
           foregroundColor: AppColors.textStrong,
           onPressed: onDelete,
-        ),
-      ],
+        );
+
+        return Row(
+          children: [
+            if (useFlexibleButtons)
+              Expanded(child: acceptButton)
+            else
+              acceptButton,
+            const SizedBox(width: _invitationButtonGap),
+            if (useFlexibleButtons)
+              Expanded(child: deleteButton)
+            else
+              deleteButton,
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/place/presentation/widgets/place_invitation_list_item.dart
+++ b/lib/features/place/presentation/widgets/place_invitation_list_item.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 
 const double _invitationContentGap = 14;
 const double _invitationButtonGap = 8;
-const double _invitationActionsWidth =
-    AppSizes.placeInvitationActionButtonWidth * 2 + _invitationButtonGap;
 
 class PlaceInvitationListItem extends StatelessWidget {
   const PlaceInvitationListItem({
@@ -184,8 +182,14 @@ class _InvitationActions extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final useFlexibleButtons =
-            constraints.maxWidth < _invitationActionsWidth;
+        final availableButtonWidth =
+            (constraints.maxWidth - _invitationButtonGap) / 2;
+        final buttonWidth = availableButtonWidth
+            .clamp(
+              AppSizes.placeInvitationActionButtonMinWidth,
+              AppSizes.placeInvitationActionButtonMaxWidth,
+            )
+            .toDouble();
 
         final acceptButton = _InvitationActionButton(
           label: '확인',
@@ -193,6 +197,7 @@ class _InvitationActions extends StatelessWidget {
           backgroundColor: AppColors.brandPrimary,
           foregroundColor: AppColors.white,
           onPressed: onAccept,
+          width: buttonWidth,
         );
         final deleteButton = _InvitationActionButton(
           label: '삭제',
@@ -200,19 +205,15 @@ class _InvitationActions extends StatelessWidget {
           backgroundColor: AppColors.borderDefault,
           foregroundColor: AppColors.textStrong,
           onPressed: onDelete,
+          width: buttonWidth,
         );
 
         return Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            if (useFlexibleButtons)
-              Expanded(child: acceptButton)
-            else
-              acceptButton,
+            acceptButton,
             const SizedBox(width: _invitationButtonGap),
-            if (useFlexibleButtons)
-              Expanded(child: deleteButton)
-            else
-              deleteButton,
+            deleteButton,
           ],
         );
       },
@@ -227,6 +228,7 @@ class _InvitationActionButton extends StatelessWidget {
     required this.backgroundColor,
     required this.foregroundColor,
     required this.onPressed,
+    required this.width,
   });
 
   final String label;
@@ -234,6 +236,7 @@ class _InvitationActionButton extends StatelessWidget {
   final Color backgroundColor;
   final Color foregroundColor;
   final VoidCallback onPressed;
+  final double width;
 
   @override
   Widget build(BuildContext context) {
@@ -249,7 +252,7 @@ class _InvitationActionButton extends StatelessWidget {
             onTap: onPressed,
             borderRadius: BorderRadius.circular(AppRadius.small),
             child: SizedBox(
-              width: AppSizes.placeInvitationActionButtonWidth,
+              width: width,
               height: AppSizes.placeInvitationActionButtonHeight,
               child: Center(
                 child: Text(

--- a/lib/features/plant/presentation/widgets/plant_care_summary.dart
+++ b/lib/features/plant/presentation/widgets/plant_care_summary.dart
@@ -7,6 +7,7 @@ import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_d
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 
+const double _plantDateSummaryMinGap = AppSpacing.x8;
 const double _plantDateSummaryMaxGap = 34;
 
 class PlantCareSummary extends StatelessWidget {
@@ -108,11 +109,14 @@ class _PlantDateSummary extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final availableGap =
-            AppSpacing.x8 + constraints.maxWidth - AppSizes.compactMobileWidth;
-        final gap = availableGap
-            .clamp(AppSpacing.x8, _plantDateSummaryMaxGap)
-            .toDouble();
+        final widthProgress =
+            ((constraints.maxWidth - AppSizes.compactMobileWidth) /
+                    (AppSizes.mobileWidth - AppSizes.compactMobileWidth))
+                .clamp(0.0, 1.0)
+                .toDouble();
+        final gap =
+            _plantDateSummaryMinGap +
+            (_plantDateSummaryMaxGap - _plantDateSummaryMinGap) * widthProgress;
 
         return Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/plant/presentation/widgets/plant_care_summary.dart
+++ b/lib/features/plant/presentation/widgets/plant_care_summary.dart
@@ -1,10 +1,13 @@
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_detail_content_width.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+
+const double _plantDateSummaryGap = 34;
 
 class PlantCareSummary extends StatelessWidget {
   const PlantCareSummary({
@@ -103,26 +106,34 @@ class _PlantDateSummary extends StatelessWidget {
       color: AppColors.iconInactive,
     );
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text('처음 함께한 날', style: textStyle),
-            Text('마지막으로 물 준 날짜', style: textStyle),
-          ],
-        ),
-        const SizedBox(width: 34),
-        Column(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final gap = constraints.maxWidth < AppSizes.mobileWidth
+            ? AppSpacing.x8
+            : _plantDateSummaryGap;
+
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(startDate, style: textStyle),
-            Text(lastWateredDate, style: textStyle),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text('처음 함께한 날', style: textStyle),
+                Text('마지막으로 물 준 날짜', style: textStyle),
+              ],
+            ),
+            SizedBox(width: gap),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(startDate, style: textStyle),
+                Text(lastWateredDate, style: textStyle),
+              ],
+            ),
           ],
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/features/plant/presentation/widgets/plant_care_summary.dart
+++ b/lib/features/plant/presentation/widgets/plant_care_summary.dart
@@ -7,7 +7,7 @@ import 'package:commonplant_frontend/features/plant/presentation/widgets/plant_d
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 
-const double _plantDateSummaryGap = 34;
+const double _plantDateSummaryMaxGap = 34;
 
 class PlantCareSummary extends StatelessWidget {
   const PlantCareSummary({
@@ -108,9 +108,11 @@ class _PlantDateSummary extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final gap = constraints.maxWidth < AppSizes.mobileWidth
-            ? AppSpacing.x8
-            : _plantDateSummaryGap;
+        final availableGap =
+            AppSpacing.x8 + constraints.maxWidth - AppSizes.compactMobileWidth;
+        final gap = availableGap
+            .clamp(AppSpacing.x8, _plantDateSummaryMaxGap)
+            .toDouble();
 
         return Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -123,7 +125,7 @@ class _PlantDateSummary extends StatelessWidget {
                 Text('마지막으로 물 준 날짜', style: textStyle),
               ],
             ),
-            SizedBox(width: gap),
+            SizedBox(key: const ValueKey('plant-date-summary-gap'), width: gap),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/shared/widgets/common_plant_card.dart
+++ b/lib/shared/widgets/common_plant_card.dart
@@ -137,14 +137,23 @@ class CommonPlacePlantCard extends StatelessWidget {
         height: height,
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final useCompactThumbnail =
-                constraints.maxWidth < AppSizes.placePlantCardWidth;
-            final imageWidth = useCompactThumbnail
-                ? AppSizes.plantThumbnailSize
-                : AppSizes.placePlantCardImageWidth;
-            final imageHeight = useCompactThumbnail
-                ? AppSizes.plantThumbnailSize
-                : AppSizes.placePlantCardImageHeight;
+            final availableImageWidth =
+                constraints.maxWidth -
+                (AppSizes.placePlantCardPadding * 2) -
+                AppSpacing.x8 -
+                AppSizes.placePlantCardDetailsMinWidth;
+            final imageWidth = availableImageWidth
+                .clamp(
+                  AppSizes.placePlantCardImageMinSize,
+                  AppSizes.placePlantCardImageMaxWidth,
+                )
+                .toDouble();
+            final imageHeight = imageWidth
+                .clamp(
+                  AppSizes.placePlantCardImageMinSize,
+                  AppSizes.placePlantCardImageMaxHeight,
+                )
+                .toDouble();
 
             return Padding(
               padding: const EdgeInsets.all(AppSizes.placePlantCardPadding),
@@ -154,6 +163,7 @@ class CommonPlacePlantCard extends StatelessWidget {
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(AppRadius.medium),
                       child: SizedBox(
+                        key: const ValueKey('place-plant-card-thumbnail'),
                         width: imageWidth,
                         height: imageHeight,
                         child: DecoratedBox(

--- a/lib/shared/widgets/common_plant_card.dart
+++ b/lib/shared/widgets/common_plant_card.dart
@@ -8,6 +8,8 @@ import 'package:commonplant_frontend/core/theme/app_theme_tokens.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 
+const double _placePlantCardDetailsMinWidth = 156;
+
 class CommonPlantCard extends StatelessWidget {
   const CommonPlantCard({
     super.key,
@@ -141,7 +143,7 @@ class CommonPlacePlantCard extends StatelessWidget {
                 constraints.maxWidth -
                 (AppSizes.placePlantCardPadding * 2) -
                 AppSpacing.x8 -
-                AppSizes.placePlantCardDetailsMinWidth;
+                _placePlantCardDetailsMinWidth;
             final imageWidth = availableImageWidth
                 .clamp(
                   AppSizes.placePlantCardImageMinSize,

--- a/lib/shared/widgets/common_plant_card.dart
+++ b/lib/shared/widgets/common_plant_card.dart
@@ -135,126 +135,140 @@ class CommonPlacePlantCard extends StatelessWidget {
       child: SizedBox(
         width: width,
         height: height,
-        child: Padding(
-          padding: const EdgeInsets.all(AppSizes.placePlantCardPadding),
-          child: Row(
-            children: [
-              Center(
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppRadius.medium),
-                  child: SizedBox(
-                    width: AppSizes.placePlantCardImageWidth,
-                    height: AppSizes.placePlantCardImageHeight,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: tokens.surfaceMuted,
-                        image: imageProvider != null
-                            ? DecorationImage(
-                                image: imageProvider!,
-                                fit: BoxFit.cover,
-                              )
-                            : null,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final useCompactThumbnail =
+                constraints.maxWidth < AppSizes.placePlantCardWidth;
+            final imageWidth = useCompactThumbnail
+                ? AppSizes.plantThumbnailSize
+                : AppSizes.placePlantCardImageWidth;
+            final imageHeight = useCompactThumbnail
+                ? AppSizes.plantThumbnailSize
+                : AppSizes.placePlantCardImageHeight;
+
+            return Padding(
+              padding: const EdgeInsets.all(AppSizes.placePlantCardPadding),
+              child: Row(
+                children: [
+                  Center(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(AppRadius.medium),
+                      child: SizedBox(
+                        width: imageWidth,
+                        height: imageHeight,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: tokens.surfaceMuted,
+                            image: imageProvider != null
+                                ? DecorationImage(
+                                    image: imageProvider!,
+                                    fit: BoxFit.cover,
+                                  )
+                                : null,
+                          ),
+                          child: imageProvider == null
+                              ? placeholder ??
+                                    ColoredBox(
+                                      color: tokens.surfaceAlt,
+                                      child: Center(
+                                        child: CommonSvgIcon(
+                                          AppIconAssets.plantEmpty,
+                                          height: AppSizes.plantEmptyIconHeight,
+                                          semanticsLabel: '식물 기본 이미지',
+                                        ),
+                                      ),
+                                    )
+                              : null,
+                        ),
                       ),
-                      child: imageProvider == null
-                          ? placeholder ??
-                                ColoredBox(
-                                  color: tokens.surfaceAlt,
-                                  child: Center(
-                                    child: CommonSvgIcon(
-                                      AppIconAssets.plantEmpty,
-                                      height: AppSizes.plantEmptyIconHeight,
-                                      semanticsLabel: '식물 기본 이미지',
-                                    ),
-                                  ),
-                                )
-                          : null,
                     ),
                   ),
-                ),
-              ),
-              const SizedBox(width: AppSpacing.x8),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Column(
+                  const SizedBox(width: AppSpacing.x8),
+                  Expanded(
+                    child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          name,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: AppTextStyles.size16Bold.copyWith(
-                            color: AppColors.textBody,
-                          ),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.size16Bold.copyWith(
+                                color: AppColors.textBody,
+                              ),
+                            ),
+                            Text(
+                              species,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.size12Medium.copyWith(
+                                color: AppColors.textBody,
+                              ),
+                            ),
+                            Text(
+                              description,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.size12Medium.copyWith(
+                                color: AppColors.textBody,
+                              ),
+                            ),
+                          ],
                         ),
-                        Text(
-                          species,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: AppTextStyles.size12Medium.copyWith(
-                            color: AppColors.textBody,
-                          ),
-                        ),
-                        Text(
-                          description,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: AppTextStyles.size12Medium.copyWith(
-                            color: AppColors.textBody,
-                          ),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            if (action != null) ...[
+                              action!,
+                              const SizedBox(width: AppSpacing.x8),
+                            ],
+                            Expanded(
+                              child: Align(
+                                alignment: Alignment.bottomRight,
+                                child:
+                                    trailing ??
+                                    Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.end,
+                                      children: [
+                                        if (dDayLabel != null)
+                                          Text(
+                                            dDayLabel!,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: AppTextStyles.size16Medium
+                                                .copyWith(
+                                                  color: AppColors.brandPrimary,
+                                                ),
+                                          ),
+                                        if (dateLabel != null)
+                                          Text(
+                                            dateLabel!,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: AppTextStyles.size12Medium
+                                                .copyWith(
+                                                  color: AppColors.textBody,
+                                                ),
+                                          ),
+                                      ],
+                                    ),
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        if (action != null) ...[
-                          action!,
-                          const SizedBox(width: AppSpacing.x8),
-                        ],
-                        Expanded(
-                          child: Align(
-                            alignment: Alignment.bottomRight,
-                            child:
-                                trailing ??
-                                Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  children: [
-                                    if (dDayLabel != null)
-                                      Text(
-                                        dDayLabel!,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: AppTextStyles.size16Medium
-                                            .copyWith(
-                                              color: AppColors.brandPrimary,
-                                            ),
-                                      ),
-                                    if (dateLabel != null)
-                                      Text(
-                                        dateLabel!,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: AppTextStyles.size12Medium
-                                            .copyWith(
-                                              color: AppColors.textBody,
-                                            ),
-                                      ),
-                                  ],
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/test/features/place/presentation/pages/address_search_page_test.dart
+++ b/test/features/place/presentation/pages/address_search_page_test.dart
@@ -3,13 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../helpers/test_viewport.dart';
+
 void main() {
   testWidgets('주소 검색 화면은 Figma 기준 검색어와 결과 목록을 표시한다', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      const ProviderScope(child: MaterialApp(home: AddressSearchPage())),
-    );
+    await _pumpPage(tester);
 
     expect(find.text('주소 검색'), findsOneWidget);
     expect(find.text('신도림역'), findsOneWidget);
@@ -21,6 +21,16 @@ void main() {
     await tester.drag(find.byType(ListView), const Offset(0, -260));
     await tester.pumpAndSettle();
 
+    expect(find.text('선택'), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('compact 폭에서도 주소와 선택 버튼을 overflow 없이 표시한다', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPage(tester, viewport: TestViewports.compactWidth);
+
+    expect(find.text('신도림역 1호선', findRichText: true), findsOneWidget);
     expect(find.text('선택'), findsWidgets);
     expect(tester.takeException(), isNull);
   });
@@ -61,4 +71,15 @@ void main() {
     expect(find.text('주소 검색 열기'), findsOneWidget);
     expect(navigatorKey.currentState?.canPop(), isFalse);
   });
+}
+
+Future<void> _pumpPage(
+  WidgetTester tester, {
+  Size viewport = TestViewports.reference,
+}) async {
+  configureTestViewport(tester, viewport);
+  await tester.pumpWidget(
+    const ProviderScope(child: MaterialApp(home: AddressSearchPage())),
+  );
+  await tester.pumpAndSettle();
 }

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
@@ -48,28 +49,66 @@ void main() {
   });
 
   testWidgets('장소 식물 카드 이미지는 viewport 사이에서 최소·최대 범위로 변한다', (tester) async {
-    final cases = <({Size viewport, Size thumbnail})>[
-      (viewport: TestViewports.compactWidth, thumbnail: const Size(96, 96)),
-      (viewport: const Size(340, 800), thumbnail: const Size(116, 108)),
-      (viewport: TestViewports.reference, thumbnail: const Size(136, 108)),
+    final thumbnailSizes = <Size>[];
+    final viewports = <Size>[
+      TestViewports.compactWidth,
+      const Size(340, 800),
+      TestViewports.reference,
     ];
 
-    for (final testCase in cases) {
-      configureTestViewport(tester, testCase.viewport);
+    for (final viewport in viewports) {
+      configureTestViewport(tester, viewport);
       await tester.pumpWidget(
         buildPageTestApp(const PlaceDetailPage(placeId: 'place-1')),
       );
       await tester.pumpAndSettle();
 
       expect(find.text('몬테'), findsWidgets);
-      expect(tester.takeException(), isNull, reason: '${testCase.viewport}');
+      expect(tester.takeException(), isNull, reason: '$viewport');
+      final thumbnailSize = tester.getSize(
+        find.byKey(const ValueKey('place-plant-card-thumbnail')).first,
+      );
+      thumbnailSizes.add(thumbnailSize);
       expect(
-        tester.getSize(
-          find.byKey(const ValueKey('place-plant-card-thumbnail')).first,
+        thumbnailSize.width,
+        inInclusiveRange(
+          AppSizes.placePlantCardImageMinSize,
+          AppSizes.placePlantCardImageMaxWidth,
         ),
-        testCase.thumbnail,
+      );
+      expect(
+        thumbnailSize.height,
+        inInclusiveRange(
+          AppSizes.placePlantCardImageMinSize,
+          AppSizes.placePlantCardImageMaxHeight,
+        ),
       );
     }
+
+    expect(
+      thumbnailSizes.first,
+      const Size(
+        AppSizes.placePlantCardImageMinSize,
+        AppSizes.placePlantCardImageMinSize,
+      ),
+    );
+    expect(
+      thumbnailSizes.last,
+      const Size(
+        AppSizes.placePlantCardImageMaxWidth,
+        AppSizes.placePlantCardImageMaxHeight,
+      ),
+    );
+    expect(thumbnailSizes[0].width, lessThan(thumbnailSizes[1].width));
+    expect(thumbnailSizes[1].width, lessThan(thumbnailSizes[2].width));
+    expect(
+      thumbnailSizes[0].height,
+      lessThanOrEqualTo(thumbnailSizes[1].height),
+    );
+    expect(
+      thumbnailSizes[1].height,
+      lessThanOrEqualTo(thumbnailSizes[2].height),
+    );
   });
 
   testWidgets('장소 나가기는 확인 dialog를 표시한다', (tester) async {

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../helpers/test_app.dart';
+import '../../../../helpers/test_viewport.dart';
 
 void main() {
   testWidgets('리더는 FAB에서 장소 수정 액션을 확인할 수 있다', (tester) async {
@@ -44,6 +45,17 @@ void main() {
     expect(find.text('식물 추가하기'), findsOneWidget);
     expect(find.text('장소 수정하기'), findsNothing);
     expect(find.text('장소 나가기'), findsOneWidget);
+  });
+
+  testWidgets('compact 폭에서도 장소 식물 카드를 overflow 없이 표시한다', (tester) async {
+    configureTestViewport(tester, TestViewports.compactWidth);
+    await tester.pumpWidget(
+      buildPageTestApp(const PlaceDetailPage(placeId: 'place-1')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('몬테'), findsWidgets);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('장소 나가기는 확인 dialog를 표시한다', (tester) async {

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -47,15 +47,29 @@ void main() {
     expect(find.text('장소 나가기'), findsOneWidget);
   });
 
-  testWidgets('compact 폭에서도 장소 식물 카드를 overflow 없이 표시한다', (tester) async {
-    configureTestViewport(tester, TestViewports.compactWidth);
-    await tester.pumpWidget(
-      buildPageTestApp(const PlaceDetailPage(placeId: 'place-1')),
-    );
-    await tester.pumpAndSettle();
+  testWidgets('장소 식물 카드 이미지는 viewport 사이에서 최소·최대 범위로 변한다', (tester) async {
+    final cases = <({Size viewport, Size thumbnail})>[
+      (viewport: TestViewports.compactWidth, thumbnail: const Size(96, 96)),
+      (viewport: const Size(340, 800), thumbnail: const Size(116, 108)),
+      (viewport: TestViewports.reference, thumbnail: const Size(136, 108)),
+    ];
 
-    expect(find.text('몬테'), findsWidgets);
-    expect(tester.takeException(), isNull);
+    for (final testCase in cases) {
+      configureTestViewport(tester, testCase.viewport);
+      await tester.pumpWidget(
+        buildPageTestApp(const PlaceDetailPage(placeId: 'place-1')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('몬테'), findsWidgets);
+      expect(tester.takeException(), isNull, reason: '${testCase.viewport}');
+      expect(
+        tester.getSize(
+          find.byKey(const ValueKey('place-plant-card-thumbnail')).first,
+        ),
+        testCase.thumbnail,
+      );
+    }
   });
 
   testWidgets('장소 나가기는 확인 dialog를 표시한다', (tester) async {

--- a/test/features/place/presentation/pages/place_invitations_page_test.dart
+++ b/test/features/place/presentation/pages/place_invitations_page_test.dart
@@ -26,7 +26,7 @@ void main() {
     expect(
       tester.getSize(find.bySemanticsLabel('스윗홈_욕실 확인')),
       const Size(
-        AppSizes.placeInvitationActionButtonWidth,
+        AppSizes.placeInvitationActionButtonMaxWidth,
         AppSizes.placeInvitationActionButtonHeight,
       ),
     );
@@ -56,15 +56,26 @@ void main() {
   testWidgets('compact 폭에서도 초대 action button을 overflow 없이 표시한다', (
     WidgetTester tester,
   ) async {
+    final buttonWidths = <double>[];
+
     for (final viewport in [TestViewports.compactWidth, const Size(360, 800)]) {
       await _pumpPage(tester, viewport: viewport);
 
       expect(tester.takeException(), isNull, reason: '$viewport viewport');
+      final buttonWidth = tester
+          .getSize(find.bySemanticsLabel('스윗홈_욕실 확인'))
+          .width;
+      buttonWidths.add(buttonWidth);
       expect(
-        tester.getSize(find.bySemanticsLabel('스윗홈_욕실 확인')).width,
-        lessThanOrEqualTo(AppSizes.placeInvitationActionButtonWidth),
+        buttonWidth,
+        inInclusiveRange(
+          AppSizes.placeInvitationActionButtonMinWidth,
+          AppSizes.placeInvitationActionButtonMaxWidth,
+        ),
       );
     }
+
+    expect(buttonWidths.first, lessThan(buttonWidths.last));
   });
 }
 

--- a/test/features/place/presentation/pages/place_invitations_page_test.dart
+++ b/test/features/place/presentation/pages/place_invitations_page_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../helpers/test_viewport.dart';
+
 void main() {
   testWidgets('장소 친구 요청 기본 화면을 Figma 항목과 버튼으로 표시한다', (
     WidgetTester tester,
@@ -50,13 +52,27 @@ void main() {
     expect(find.text('확인'), findsOneWidget);
     expect(find.text('삭제'), findsOneWidget);
   });
+
+  testWidgets('compact 폭에서도 초대 action button을 overflow 없이 표시한다', (
+    WidgetTester tester,
+  ) async {
+    for (final viewport in [TestViewports.compactWidth, const Size(360, 800)]) {
+      await _pumpPage(tester, viewport: viewport);
+
+      expect(tester.takeException(), isNull, reason: '$viewport viewport');
+      expect(
+        tester.getSize(find.bySemanticsLabel('스윗홈_욕실 확인')).width,
+        lessThanOrEqualTo(AppSizes.placeInvitationActionButtonWidth),
+      );
+    }
+  });
 }
 
-Future<void> _pumpPage(WidgetTester tester) async {
-  tester.view.devicePixelRatio = 1;
-  tester.view.physicalSize = const Size(375, 812);
-  addTearDown(tester.view.resetDevicePixelRatio);
-  addTearDown(tester.view.resetPhysicalSize);
+Future<void> _pumpPage(
+  WidgetTester tester, {
+  Size viewport = TestViewports.reference,
+}) async {
+  configureTestViewport(tester, viewport);
 
   await tester.pumpWidget(
     const ProviderScope(child: MaterialApp(home: PlaceInvitationsPage())),

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../helpers/test_app.dart';
+import '../../../../helpers/test_viewport.dart';
 
 void main() {
   testWidgets('식물 상세는 Figma 주요 정보와 더보기 메뉴를 표시한다', (tester) async {
@@ -68,6 +69,17 @@ void main() {
 
     expect(find.text('식물을 삭제할까요?'), findsOneWidget);
     expect(find.text('삭제하면 기록된 메모도 함께 사라져요.'), findsOneWidget);
+  });
+
+  testWidgets('compact 폭에서도 날짜 요약을 overflow 없이 표시한다', (tester) async {
+    configureTestViewport(tester, TestViewports.compactWidth);
+    await tester.pumpWidget(
+      buildPageTestApp(const PlantDetailPage(plantId: 'plant-1')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('remote loading 상태는 식물 상세 대신 로딩 안내를 표시한다', (tester) async {

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
@@ -72,28 +73,34 @@ void main() {
   });
 
   testWidgets('날짜 요약 간격은 viewport 사이에서 최소·최대 범위로 변한다', (tester) async {
-    final cases = <({Size viewport, double gap})>[
-      (viewport: TestViewports.compactWidth, gap: 8),
-      (viewport: const Size(333, 800), gap: 21),
-      (viewport: TestViewports.reference, gap: 34),
+    const maxGap = 34.0;
+    final gaps = <double>[];
+    final viewports = <Size>[
+      TestViewports.compactWidth,
+      const Size(333, 800),
+      TestViewports.reference,
     ];
 
-    for (final testCase in cases) {
-      configureTestViewport(tester, testCase.viewport);
+    for (final viewport in viewports) {
+      configureTestViewport(tester, viewport);
       await tester.pumpWidget(
         buildPageTestApp(const PlantDetailPage(plantId: 'plant-1')),
       );
       await tester.pumpAndSettle();
 
       expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
-      expect(tester.takeException(), isNull, reason: '${testCase.viewport}');
-      expect(
-        tester
-            .getSize(find.byKey(const ValueKey('plant-date-summary-gap')))
-            .width,
-        testCase.gap,
-      );
+      expect(tester.takeException(), isNull, reason: '$viewport');
+      final gap = tester
+          .getSize(find.byKey(const ValueKey('plant-date-summary-gap')))
+          .width;
+      gaps.add(gap);
+      expect(gap, inInclusiveRange(AppSpacing.x8, maxGap));
     }
+
+    expect(gaps.first, AppSpacing.x8);
+    expect(gaps.last, maxGap);
+    expect(gaps[0], lessThan(gaps[1]));
+    expect(gaps[1], lessThan(gaps[2]));
   });
 
   testWidgets('remote loading 상태는 식물 상세 대신 로딩 안내를 표시한다', (tester) async {

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -71,15 +71,29 @@ void main() {
     expect(find.text('삭제하면 기록된 메모도 함께 사라져요.'), findsOneWidget);
   });
 
-  testWidgets('compact 폭에서도 날짜 요약을 overflow 없이 표시한다', (tester) async {
-    configureTestViewport(tester, TestViewports.compactWidth);
-    await tester.pumpWidget(
-      buildPageTestApp(const PlantDetailPage(plantId: 'plant-1')),
-    );
-    await tester.pumpAndSettle();
+  testWidgets('날짜 요약 간격은 viewport 사이에서 최소·최대 범위로 변한다', (tester) async {
+    final cases = <({Size viewport, double gap})>[
+      (viewport: TestViewports.compactWidth, gap: 8),
+      (viewport: const Size(333, 800), gap: 21),
+      (viewport: TestViewports.reference, gap: 34),
+    ];
 
-    expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
-    expect(tester.takeException(), isNull);
+    for (final testCase in cases) {
+      configureTestViewport(tester, testCase.viewport);
+      await tester.pumpWidget(
+        buildPageTestApp(const PlantDetailPage(plantId: 'plant-1')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
+      expect(tester.takeException(), isNull, reason: '${testCase.viewport}');
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('plant-date-summary-gap')))
+            .width,
+        testCase.gap,
+      );
+    }
   });
 
   testWidgets('remote loading 상태는 식물 상세 대신 로딩 안내를 표시한다', (tester) async {

--- a/test/helpers/test_viewport.dart
+++ b/test/helpers/test_viewport.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+abstract final class TestViewports {
+  const TestViewports._();
+
+  static const Size compactWidth = Size(320, 640);
+  static const Size shortHeight = Size(375, 667);
+  static const Size reference = Size(375, 812);
+  static const Size wide = Size(430, 932);
+}
+
+void configureTestViewport(
+  WidgetTester tester,
+  Size logicalSize, {
+  double devicePixelRatio = 1,
+}) {
+  tester.view.devicePixelRatio = devicePixelRatio;
+  tester.view.physicalSize = Size(
+    logicalSize.width * devicePixelRatio,
+    logicalSize.height * devicePixelRatio,
+  );
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+}

--- a/test/helpers/test_viewport.dart
+++ b/test/helpers/test_viewport.dart
@@ -1,12 +1,16 @@
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 abstract final class TestViewports {
   const TestViewports._();
 
-  static const Size compactWidth = Size(320, 640);
-  static const Size shortHeight = Size(375, 667);
-  static const Size reference = Size(375, 812);
+  static const Size compactWidth = Size(AppSizes.compactMobileWidth, 640);
+  static const Size shortHeight = Size(AppSizes.mobileWidth, 667);
+  static const Size reference = Size(
+    AppSizes.mobileWidth,
+    AppSizes.mobileHeight,
+  );
   static const Size wide = Size(430, 932);
 }
 


### PR DESCRIPTION
## 관련 이슈
- Closes #197
- QA viewport 기준: #195

## 구현 범위
- Place 초대 action button을 가용 폭에 맞춰 동일 비율로 축소
- 주소 검색 결과 text 영역을 가변 폭으로 바꾸고 선택 버튼 간격 보장
- `CommonPlacePlantCard`가 compact 폭에서 96px thumbnail을 사용하도록 조정
- Plant 상세 날짜 요약이 compact~reference 폭 사이에서 제한 범위로 변하도록 조정
- Compact width, Short height, Reference, Wide를 제공하는 공통 test viewport helper 추가
- 네 대상 화면의 compact widget 회귀 테스트 추가
- 제한형 가변 크기의 토큰 소유권과 테스트 기준 정리
- QA 적용 후속을 Done, TEST-01을 Ready로 문서 갱신

## 원인
기존 화면은 Reference `375×812`에서의 고정 폭과 간격을 그대로 사용했습니다. `320×640`에서는 초대 버튼 2개, 주소 결과 text/button, 장소 식물 카드의 image/action/date, 식물 날짜 요약의 합산 최소 폭이 가용 영역을 넘어 RenderFlex overflow가 발생했습니다.

## 주요 변경사항
- 초대 버튼 폭은 가용 공간에 따라 72~114px 범위에서 연속 조정하고 높이 36px를 유지합니다.
- 장소 식물 카드 image는 정보 영역을 먼저 보호하고 폭 96~136px, 높이 96~108px 범위에서 연속 조정합니다.
- 카드 정보 영역 보호 폭 156은 앱 전역 규격이 아니므로 위젯 private 상수로 관리합니다.
- Plant 날짜 간격은 compact~reference 폭의 정규화된 진행률로 8~34px 사이를 보간합니다.
- 주소 결과는 선택 버튼을 고정하고 text가 남은 공간을 사용합니다.
- 중간 viewport 테스트는 정확한 픽셀값 대신 최소·최대 범위와 단조 증가를 검증합니다.
- 테스트의 logical viewport와 DPR 설정을 `test/helpers/test_viewport.dart`로 공통화했습니다.

## 검증
- `fvm dart format --output=none --set-exit-if-changed .` — 253개 파일, 변경 없음
- `fvm flutter analyze` — 이슈 없음
- 대상 화면 widget test — 21개 통과
- `fvm flutter test` — 222개 통과
- `git diff --check` — 통과

## 수동 QA
- Android/iOS emulator/simulator 설치 상태는 확인했습니다.
- 실제 기기 또는 simulator 화면 smoke는 이번 자동 검증에서 실행하지 않았습니다.
- 리뷰 시 Android compact와 iOS reference profile에서 변경된 네 화면의 시각 배치를 확인해 주세요.

## 리뷰 포인트
- Reference에서 기존 114px 초대 버튼과 136×108px 카드 이미지가 유지되는지
- compact에서 2개 action의 터치 영역과 주소 선택 버튼이 충분한지
- 96px compact thumbnail이 식물 정보와 물주기/날짜 영역의 우선순위를 적절히 보존하는지
- 중간 폭에서 카드 이미지와 날짜 간격이 범위 안에서 자연스럽게 증가하는지
- TEST-01 선행 조건을 #197 완료로 판정한 문서 상태

## 범위 밖
- full-screen golden test와 baseline
- integration test와 device workflow
- staging API, 테스트 계정, seed/cleanup
- tablet, foldable, 가로 모드 지원

## 커밋
- `b09e6a7` Fix: compact 레이아웃 수정 #197
- `20a1ed5` Test: compact 회귀 테스트 추가 #197
- `317a038` Docs: 테스트 작업 순서 갱신 #197
- `fe0f5fc` Fix: 가변 크기 범위 적용 #197
- `560876d` Docs: 가변 크기 기준 추가 #197
- `a80d3ae` Refactor: 가변 크기 기준 정리 #197
- `06fa2fc` Docs: 가변 크기 검증 정리 #197

## Breaking change
- 없음
