### PR TITLE
Test: API 비사용 integration smoke 도입 #203

### DIFF
--- a/.github/workflows/android_integration_smoke.yml
+++ b/.github/workflows/android_integration_smoke.yml
@@ -1,0 +1,65 @@
+name: Android Integration Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-integration-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.35.7
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run API-free Android smoke
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: >-
+            -no-snapshot-save
+            -no-window
+            -gpu swiftshader_indirect
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -camera-front none
+          script: >-
+            flutter test integration_test/app_smoke_test.dart
+            -d emulator-5554
+            --dart-define=COMMONPLANT_USE_API=false
+            --reporter github

--- a/.github/workflows/android_integration_smoke.yml
+++ b/.github/workflows/android_integration_smoke.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ fvm flutter pub get
 | 이름 | 버전 | 목적 |
 | --- | --- | --- |
 | `flutter_test` | `sdk:flutter` | 위젯 테스트 및 기본 테스트 러너 |
+| `integration_test` | `sdk:flutter` | 실제 앱과 디바이스 기반 integration smoke 실행 |
 | `flutter_lints` | `^5.0.0` | 정적 분석 및 공통 린트 규칙 |
 | `lefthook` | 외부 도구 | pre-commit 품질 게이트 실행 |
 
@@ -116,6 +117,8 @@ test/
   features/
   helpers/
   shared/widgets/
+integration_test/
+  app_smoke_test.dart
 ```
 
 ## 공통 작업 규칙
@@ -136,7 +139,8 @@ test/
 - API 모델은 `freezed`와 `json_serializable` 기반 생성을 기본 방향으로 삼되, 실제 패키지 추가는 첫 API 연동 PR에서 함께 진행합니다.
 - 인증 토큰은 `flutter_secure_storage` 기반 보관을 기본 방향으로 합니다.
 - 백엔드 에러 코드는 아직 미정이므로, 확정 전까지는 공통 에러 타입으로 감쌀 수 있는 구조를 우선합니다.
-- Golden test는 `OnboardingPage`의 `375×812`, DPR 1 pilot과 Ubuntu canonical baseline을 기준으로 도입했으며, integration test 범위는 아직 미정입니다.
+- Golden test는 `OnboardingPage`의 `375×812`, DPR 1 pilot과 Ubuntu canonical baseline을 기준으로 사용합니다.
+- Integration test는 remote API를 사용하지 않는 Home 진입과 장소 친구 요청 이동을 Android smoke pilot으로 사용합니다. staging API, 테스트 계정, seed/cleanup이 필요한 end-to-end 범위는 준비 전까지 `Blocked`입니다.
 
 ## 프로젝트 문서
 
@@ -201,6 +205,8 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 - `flutter pub get`
 - `flutter analyze`
 - `flutter test`
+
+`Android Integration Smoke`는 Android emulator에서 API 비사용 앱 시작과 route 이동을 확인하는 수동 workflow입니다. 안정성과 실행 비용을 확인하는 pilot 동안에는 PR 필수 게이트와 분리합니다.
 
 ## 진행해야 할 작업 내역
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -15,7 +15,8 @@
 | --- | --- | --- | --- | --- | --- |
 | [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | 네 QA profile을 적용한다. 확인된 compact overflow와 대상 회귀 테스트는 #197에서 완료했다. | Decided |
 | [x] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator와 workflow 기반 baseline 갱신 규칙을 적용한다. | Decided |
-| [ ] | TEST-02 | integration test 실행 환경과 workflow 연결 방식 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | API 비사용 smoke/runner는 로컬 범위로 분리하고 staging URL, 테스트 계정, seed/cleanup이 필요한 remote workflow는 보류한다. | Blocked |
+| [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke, 명시적 device 실행, 수동 workflow와 required check 승격 조건을 적용한다. | Decided |
+| [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | staging URL, 테스트 계정, seed/cleanup과 secret 정책이 준비될 때까지 remote end-to-end workflow를 보류한다. | Blocked |
 
 ## 릴리즈와 환경
 

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -173,5 +173,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | TEST-01 Ubuntu baseline | `2c1907b` | Ubuntu test image를 canonical baseline으로 반영 | GitHub Actions run `31807337886` analyzer와 unit/widget/golden 223개 통과 |
 | TEST-02-A smoke | `61fd571` | `integration_test` 의존성과 API 비사용 Home → 장소 친구 요청 실제 앱 smoke 추가 | Android API 36.1 `emulator-5554` target test, `fvm flutter analyze` 통과 |
 | TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
+| TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -10,17 +10,17 @@
 - 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
 - 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
 
-## 2026-08-14 현재 상태
+## 2026-08-19 현재 상태
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
-| 기준 브랜치 | `develop@48f9cd7` | TEST-01 폰트 선행 #200, PR #201 병합 완료 |
+| 기준 브랜치 | `develop@5a6b000` | TEST-01 #199, PR #202 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
 | Widget test viewport | `test/helpers/test_viewport.dart`에서 네 QA profile과 DPR 1 설정을 제공하고 compact gap 대상 화면에 적용 | 기존 raw viewport 설정은 관련 화면 수정 시 점진적으로 helper로 전환 |
-| Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer에서 Flutter 기본 exact comparator 사용 |
+| Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer의 exact 비교와 수동 baseline workflow run `31811426737` 성공 확인 |
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
-| Integration test | SDK 의존성, `integration_test/`, 실행 script 없음 | 로컬 smoke scaffold부터 별도 도입 가능 |
-| GitHub Actions | Ubuntu에서 `flutter analyze`, unit/widget/golden test 실행, 수동 `Golden Baseline` workflow 제공 | golden 실패 diff artifact를 7일 보존, device 기반 workflow는 없음 |
+| Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
+| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke는 병합 후 첫 수동 실행 검증이 필요하며 아직 required check가 아님 |
 | 기본 품질 게이트 | macOS에서 unit/widget 222개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 223개 통과 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
 | Remote API 환경 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 지점만 존재 | staging URL, 계정, 데이터 격리 정책은 Blocked |
 
@@ -31,8 +31,8 @@
 | 1 | QA-01 | QA 필수 디바이스와 viewport 기준 확정 | 없음 | Decided (#195) |
 | 2 | QA-01 적용 후속 | compact-width overflow 수정과 viewport 회귀 테스트 추가 | QA-01 | Done (#197) |
 | 3 | TEST-01 폰트 선행 | 한글 Pretendard asset과 라이선스 정리 | QA-01 적용 후속 | Done (#200) |
-| 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | In Review (#199) |
-| 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 로컬 실행 환경 검토 | 없음. 우선순위상 TEST-01 다음 | Ready |
+| 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | Done (#199) |
+| 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | In Review (#203) |
 | 6 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
 
 TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
@@ -129,12 +129,14 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 
 ## TEST-02 Ready와 Blocked 경계
 
-### 로컬에서 진행 가능한 범위
+### TEST-02-A 확정 범위
 
-- Flutter SDK의 `integration_test` 의존성과 디렉터리 구조 검토
-- `COMMONPLANT_USE_API=false`인 앱 시작/route smoke flow 작성
-- Android emulator 또는 iOS simulator의 명시적 device ID를 사용하는 실행 명령 정리
-- 독립 workflow를 수동 실행으로 먼저 검증하고 PR 필수 게이트 승격 조건 문서화
+- Flutter SDK의 `integration_test`를 dev dependency로 등록한다.
+- `integration_test/app_smoke_test.dart`에서 production `main()`을 실행하고 `COMMONPLANT_USE_API=false`를 assertion으로 고정한다.
+- Home의 기본 콘텐츠를 확인한 뒤 `장소 요청 3건`을 탭해 장소 친구 요청 화면까지 이동한다.
+- 로컬 명령은 Android device ID를 명시하고, GitHub Actions는 Android API 35 Google APIs x86_64 Pixel 6 emulator의 수동 workflow로 실행한다.
+- 새 `workflow_dispatch` 파일은 기본 브랜치 병합 전 실행할 수 없으므로 #203 병합 직후 `develop`에서 첫 run을 검증한다.
+- `develop` 수동 run이 assertion 실패나 재시도 없이 3회 연속 성공하고 로그 구분, 실행 시간·비용, 팀 동의를 확인한 뒤에만 required check 승격을 검토한다.
 
 ### 백엔드 준비 전 Blocked 범위
 
@@ -150,6 +152,8 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 
 - [Flutter testing overview](https://docs.flutter.dev/testing/overview)
 - [Flutter integration testing](https://docs.flutter.dev/testing/integration-tests)
+- [GitHub Actions workflow 수동 실행](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)
+- [Android emulator command line](https://developer.android.com/studio/run/emulator-commandline)
 - [Android responsive/adaptive layouts](https://developer.android.com/develop/ui/views/layout/responsive-adaptive-design-with-views)
 
 ## 커밋별 작업 이력
@@ -167,5 +171,7 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | TEST-01 pilot | `c97beaa` | Pretendard 4개 weight와 Theme을 준비하는 helper, Onboarding full-screen test와 375×812 baseline 추가 | macOS target exact test, `fvm flutter analyze` |
 | TEST-01 canonical 환경 | `874dfb3` | non-Linux golden skip, Ubuntu baseline 생성 workflow, CI failure artifact 업로드 추가 | macOS unit/widget 222개 통과, golden 1개 skip, Ubuntu diff artifact 확인 |
 | TEST-01 Ubuntu baseline | `2c1907b` | Ubuntu test image를 canonical baseline으로 반영 | GitHub Actions run `31807337886` analyzer와 unit/widget/golden 223개 통과 |
+| TEST-02-A smoke | `61fd571` | `integration_test` 의존성과 API 비사용 Home → 장소 친구 요청 실제 앱 smoke 추가 | Android API 36.1 `emulator-5554` target test, `fvm flutter analyze` 통과 |
+| TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -50,7 +50,7 @@ CI는 GitHub Actions에서 Flutter `3.35.7`을 설치한 뒤 `flutter pub get`, 
 | Unit test | validator, DTO/entity mapper, repository 에러 매핑, Provider/Controller 분기 로직은 필수 |
 | Widget test | 새 화면, 상태 UI, form validation, 버튼 활성/비활성, route parameter 처리는 필수 |
 | Golden test | 공용 컴포넌트 또는 반복 화면에서 디자인 회귀 위험이 높을 때만 추가 |
-| Integration test | staging API, 테스트 계정, 실행 runner, 데이터 초기화 정책이 준비된 핵심 플로우에만 추가 |
+| Integration test | API 비사용 앱 시작/route smoke는 디바이스 runner로 먼저 검증하고, remote flow는 staging API, 테스트 계정, 데이터 초기화 정책이 준비된 핵심 플로우에만 추가 |
 
 MVP에서 새 기능을 만들 때 unit/widget test로 검증 가능한 동작을 golden 또는 integration test로 대체하지 않습니다. Golden test는 시각 회귀를 보강하는 용도이고, integration test는 여러 화면과 실제 실행 환경을 통과하는 흐름을 확인하는 용도입니다.
 
@@ -171,7 +171,51 @@ Golden 실패 시 `Flutter CI`는 `test/**/failures/`의 master, test, isolated 
 
 ## Integration test 기준
 
-Integration test는 MVP 기본 PR 필수 게이트가 아닙니다. 아래 조건이 준비된 뒤 핵심 사용자 흐름부터 추가합니다.
+Integration test는 MVP 기본 PR 필수 게이트가 아닙니다. 백엔드 준비 여부에 따라 API 비사용 smoke와 remote API end-to-end를 분리합니다.
+
+### TEST-02-A API 비사용 smoke
+
+첫 pilot인 `integration_test/app_smoke_test.dart`는 production `main()`으로 실제 앱을 시작하고 아래 계약을 확인합니다.
+
+- `COMMONPLANT_USE_API=false`를 명시하고 테스트 안에서도 remote API가 꺼져 있는지 확인합니다.
+- Home의 `My place`, `My plant`, `장소 요청 3건`을 확인합니다.
+- `장소 요청 3건`을 탭해 장소 친구 요청 화면과 요청 항목이 노출되는지 확인합니다.
+- 네트워크, 계정, seed 데이터에 의존하지 않으며 기존 unit/widget test를 대체하지 않습니다.
+
+로컬 Android 실행은 연결된 기기의 ID를 명시합니다.
+
+```bash
+fvm flutter devices
+fvm flutter test integration_test/app_smoke_test.dart \
+  -d <android-device-id> \
+  --dart-define=COMMONPLANT_USE_API=false
+```
+
+Android emulator가 필요하면 `fvm flutter emulators`로 ID를 확인한 뒤 `fvm flutter emulators --launch <emulator-id>`로 시작합니다. Flutter wrapper로 기동 상태를 확인하기 어려운 환경에서는 Android SDK의 공식 emulator CLI로 같은 AVD를 실행할 수 있습니다.
+
+`.github/workflows/android_integration_smoke.yml`은 Ubuntu의 Android API 35 Google APIs x86_64 Pixel 6 emulator에서 같은 테스트를 실행하는 수동 workflow입니다.
+
+```bash
+gh workflow run android_integration_smoke.yml --ref <작업-브랜치>
+gh run list --workflow android_integration_smoke.yml --branch <작업-브랜치> --limit 1
+gh run watch <run-id>
+gh run view <run-id> --log
+```
+
+`workflow_dispatch`로 새로 추가한 workflow는 파일이 기본 브랜치에 병합된 뒤 실행할 수 있습니다. 따라서 첫 병합 직후 `develop`을 대상으로 smoke를 실행하고 결과를 #203에 남깁니다.
+
+앱 build, 설치, 시작 또는 테스트 assertion 실패는 smoke 실패입니다. emulator provisioning 같은 runner 인프라 실패는 로그에서 테스트 실패와 분리하고 한 번 재실행할 수 있지만, assertion 실패를 이유 없이 재실행해 통과로 바꾸지 않습니다.
+
+다음 조건을 모두 충족하기 전에는 PR 필수 게이트로 승격하지 않습니다.
+
+1. `develop` 수동 실행이 assertion 실패나 재시도 없이 연속 3회 성공합니다.
+2. 실패 원인을 앱과 runner 인프라로 구분할 수 있는 로그가 안정적으로 남습니다.
+3. 실행 시간과 GitHub Actions 비용이 팀이 수용할 수 있는 범위입니다.
+4. 팀이 required check 승격에 동의합니다.
+
+### TEST-02-B remote API end-to-end
+
+remote API를 사용하는 핵심 사용자 흐름은 아래 조건이 준비된 뒤 추가합니다.
 
 - staging 또는 테스트용 API base URL이 확정되어 있습니다.
 - 테스트 전용 계정과 seed 데이터 또는 테스트 후 정리 방식이 준비되어 있습니다.
@@ -193,9 +237,7 @@ fvm flutter test integration_test \
   --dart-define=COMMONPLANT_API_BASE_URL=<staging-api-url>
 ```
 
-remote API를 사용하지 않는 앱 시작/route smoke와 device runner 검토는 로컬 준비 범위로 분리할 수 있습니다. staging API, 테스트 계정, seed/cleanup 정책이 필요한 end-to-end flow는 준비 전까지 `Blocked`입니다.
-
-staging API와 runner가 준비되기 전에는 remote integration test를 PR CI에 연결하지 않습니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
+staging API, 테스트 계정, seed/cleanup 정책이 필요한 end-to-end flow는 준비 전까지 `Blocked`입니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
 
 ## 테스트 파일 네이밍
 
@@ -227,7 +269,7 @@ feature 구조와 test 구조를 비슷하게 맞추면 찾기 쉽습니다.
 
 로컬에 `.fvmrc`와 FVM이 있으면 lefthook도 `fvm` 명령을 우선 사용합니다.
 
-GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. Integration test는 실행 환경이 준비된 뒤 별도 workflow 또는 release candidate 검증으로 연결합니다.
+GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. API 비사용 Android integration smoke는 별도 수동 workflow로 검증하며 승격 조건을 충족하기 전에는 required check가 아닙니다. Remote integration test는 백엔드 실행 환경이 준비된 뒤 release candidate 검증 또는 별도 CI job으로 연결합니다.
 
 ## 체크리스트
 
@@ -244,5 +286,5 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 ## 후속 결정 필요
 
 - TEST-01 pilot은 #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator로 확정했습니다. 추가 화면과 viewport baseline은 회귀 위험과 유지 비용을 확인해 별도 이슈로 확장합니다.
-- TEST-02의 API 비사용 smoke와 runner 검토는 로컬 범위로 진행할 수 있습니다.
-- staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다.
+- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했습니다. 병합 후 `develop` 수동 실행을 검증하고 연속 성공 기준을 충족하기 전에는 PR 필수 게이트로 승격하지 않습니다.
+- TEST-02-B는 staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다. 준비 전 상태는 `Blocked`입니다.

--- a/integration_test/app_smoke_test.dart
+++ b/integration_test/app_smoke_test.dart
@@ -1,0 +1,29 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/main.dart' as app;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('API 비사용 앱은 Home에서 장소 친구 요청으로 이동한다', (tester) async {
+    expect(
+      AppEnvironment.useRemoteApi,
+      isFalse,
+      reason: 'TEST-02-A smoke는 remote API를 사용하지 않아야 합니다.',
+    );
+
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.text('My place'), findsOneWidget);
+    expect(find.text('My plant'), findsOneWidget);
+    expect(find.bySemanticsLabel('장소 요청 3건'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('장소 요청 3건'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('장소 친구 요청'), findsOneWidget);
+    expect(find.text('스윗홈_욕실'), findsOneWidget);
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -150,6 +150,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -240,6 +245,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -280,6 +290,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -496,6 +511,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -605,6 +628,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -717,6 +748,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## 변경 사항

- Flutter SDK `integration_test` 의존성과 실제 앱 기반 smoke test를 추가했습니다.
- `COMMONPLANT_USE_API=false`를 확인하고 Home에서 장소 친구 요청 화면까지 이동합니다.
- Android API 35 emulator에서 실행하는 수동 `Android Integration Smoke` workflow를 추가했습니다.
- TEST-02-A 실행·실패 판정·required check 승격 기준을 문서화하고, remote API 범위는 TEST-02-B `Blocked`로 분리했습니다.

## 도입 이유

unit/widget test만으로는 실제 Android 앱의 build·설치·기동과 production router 연결을 함께 확인할 수 없습니다. 백엔드 준비 없이 재현 가능한 가장 작은 실제 앱 경로부터 검증해 runner 안정성을 먼저 측정합니다.

## 검증

- `fvm dart format --output=none --set-exit-if-changed .` — 256개 파일, 변경 없음
- `fvm flutter analyze` — 통과
- `fvm flutter test` — unit/widget 222건 통과, non-Linux golden 1건 의도된 skip
- Android API 36.1 `emulator-5554`에서 target integration smoke 통과
- workflow YAML parse 및 `git diff --check` 통과

## 후속 확인

새 `workflow_dispatch` 파일은 기본 브랜치에 존재해야 하므로 병합 후 `develop`에서 최초 수동 run을 확인합니다. 연속 3회 무재시도 성공 등 문서화한 조건을 충족하기 전에는 PR required check로 승격하지 않습니다.

Closes #203
Parent: #78
Prior: #199