### PR TITLE
[Task] SVG 최적화 기준 확정

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ test/
   shared/widgets/
 integration_test/
   app_smoke_test.dart
+tool/
+  svg/                         # SVG 최적화 보수 설정
 ```
 
 ## 공통 작업 규칙

--- a/docs/asset-icon-rules.md
+++ b/docs/asset-icon-rules.md
@@ -66,6 +66,71 @@ const CommonSvgIcon(
 - 화면 코드에서 SVG 내부 색상을 임시로 바꾸기 위해 새 파일을 복제하지 않습니다.
 - disabled, active, danger 상태는 가능한 테마 토큰 색상을 사용합니다.
 
+## SVG 최적화 기준
+
+ASSET-01에서는 SVG 용량 자체보다 Flutter 렌더링 호환성과 변경 리뷰 가능성을 우선합니다. SVGO `4.0.1`을 보조 도구로 채택하되, 기본 preset을 그대로 사용하거나 기존 asset 전체를 일괄 변환하지 않습니다.
+
+판단 근거는 [SVGO 4.0.1 release](https://github.com/svg/svgo/releases/tag/v4.0.1), [SVGO preset-default 구성](https://svgo.dev/docs/preset-default/), [flutter_svg의 SVG 호환성 검사 안내](https://pub.dev/packages/flutter_svg)를 기준으로 합니다.
+
+2026-08-19 기준 `assets/icons`, `assets/images`에는 SVG 35개, 총 71,032 byte가 있습니다. 모두 XML parse와 `viewBox` 검사를 통과했으며, 보수 설정을 적용한 복사본도 71,032 byte로 원본과 동일했습니다. 반면 SVGO 기본 preset은 38,696 byte로 45.52% 줄었지만 path 좌표, 색상 표기, ID, group 구조까지 변경했습니다. 현재 bundle 규모에서는 이 차이보다 시각 회귀와 대규모 diff 위험이 크므로 기본 preset은 사용하지 않습니다.
+
+### 도구와 설정
+
+- 버전은 `SVGO 4.0.1`로 고정합니다.
+- Node 의존성을 앱 package에 추가하지 않고 `npx --yes svgo@4.0.1`로 실행합니다.
+- 설정은 `tool/svg/svgo.config.mjs`를 사용합니다.
+- 자동 변환은 doctype, XML processing instruction, comment, metadata, 편집기 namespace, script, 빈 attribute, 미사용 namespace 정리로 제한합니다.
+- 출력은 먼저 별도 후보 파일로 만들며 검증 전 원본을 덮어쓰지 않습니다.
+- 불필요한 정보가 실제로 제거되지 않거나 formatting만 바뀌거나 파일이 커지면 원본을 유지합니다. 최소 절감률을 품질 게이트로 두지 않습니다.
+
+```bash
+svg_source=path/to/figma_export.svg
+svg_candidate=/tmp/commonplant_candidate.svg
+
+npx --yes svgo@4.0.1 \
+  --config tool/svg/svgo.config.mjs \
+  --input "$svg_source" \
+  --output "$svg_candidate"
+```
+
+### 자동 변경 금지와 수동 검토 대상
+
+아래 항목은 현재 설정으로 자동 변경하지 않습니다.
+
+- root `width`, `height`, `viewBox`, `preserveAspectRatio`
+- `id`와 `url(#...)`로 연결된 mask, gradient, clipPath, defs
+- `fill`, `stroke`, `currentColor`, CSS variable fallback을 포함한 색상 표기
+- path 좌표와 숫자 정밀도, transform
+- path 병합, shape 변환, group 축약 또는 이동
+- `title`, `desc`와 접근성 관련 요소
+
+`cleanupIds`, `removeDimensions`, `removeViewBox`, `convertPathData`, `convertTransform`, `convertColors`, `mergePaths`, `collapseGroups` 같은 변환이 필요하면 해당 asset만 별도 작업으로 분리하고 전후 시각 비교 근거를 남깁니다. `<script>`, event handler, 외부 URL image/font, 지원 여부가 불명확한 `<style>`/class가 발견되면 자동 정리 결과를 그대로 채택하지 않고 Figma 원본을 단순한 path/attribute 구조로 다시 export합니다.
+
+### 신규 또는 변경 SVG 검증 순서
+
+1. 원본과 후보의 byte 크기와 `git diff --no-index` 결과를 확인합니다.
+2. `xmllint --noout /tmp/commonplant_candidate.svg`로 XML 구조를 검사합니다.
+3. `vector_graphics_compiler` 호환성 검사를 실행합니다.
+4. 검증된 후보만 asset 경로에 반영하고 SVG asset 회귀 테스트를 실행합니다.
+5. 실제 사용 화면에서 최소·최대 표시 크기와 QA 기준 viewport를 확인합니다. 중간 크기는 비율 유지와 깨짐 여부를 확인합니다.
+6. mask, gradient, CSS variable fallback, 색상 주입이 있는 asset은 해당 상태를 모두 비교합니다.
+
+```bash
+fvm dart run vector_graphics_compiler \
+  -i /tmp/commonplant_candidate.svg \
+  -o /tmp/commonplant_candidate.svg.vec \
+  --no-optimize-masks \
+  --no-optimize-clips \
+  --no-optimize-overdraw \
+  --no-tessellate
+
+fvm flutter test test/core/assets/svg_assets_test.dart
+```
+
+`test/core/assets/svg_assets_test.dart`는 등록 대상 디렉터리의 모든 SVG를 `flutter_svg`로 parse하고 실제 picture로 rasterize합니다. 이 검사는 asset load와 렌더 pipeline 호환성을 확인하지만 픽셀 동일성을 보장하지 않으므로, 화면 시각 비교나 기존 golden test를 대체하지 않습니다.
+
+기존 SVG 전체 정리가 필요하면 신규 export 적용과 분리한 이슈에서 진행합니다. 일괄 변경 PR에는 영향 화면 목록, 용량 전후, 구조 diff, 최소·최대 표시 크기 시각 비교, 관련 golden 또는 screenshot 근거가 필요합니다.
+
 ## 이미지 사용
 
 - 사진 또는 일러스트 이미지는 `assets/images`에 둡니다.
@@ -94,11 +159,12 @@ const CommonSvgIcon(
 ## 추가 절차
 
 1. Figma export 이름을 프로젝트 네이밍 규칙에 맞게 정리합니다.
-2. SVG는 불필요한 metadata와 canvas 크기를 확인합니다.
-3. 파일을 `assets/icons` 또는 `assets/images`에 추가합니다.
-4. 아이콘이면 `AppIconAssets`에 상수를 추가합니다.
-5. 사용 위치에서 `CommonSvgIcon` 또는 적절한 이미지 위젯을 사용합니다.
-6. `fvm flutter test` 또는 앱 실행으로 asset load 오류가 없는지 확인합니다.
+2. SVG는 불필요한 metadata와 canvas 크기를 확인하고 위 보수 설정으로 후보를 만듭니다.
+3. 후보의 구조, Flutter compiler 호환성, 실제 표시 크기를 검증합니다.
+4. 파일을 `assets/icons` 또는 `assets/images`에 추가합니다.
+5. 아이콘이면 `AppIconAssets`에 상수를 추가합니다.
+6. 사용 위치에서 `CommonSvgIcon` 또는 적절한 이미지 위젯을 사용합니다.
+7. SVG asset 회귀 테스트와 영향 화면을 확인합니다.
 
 ## 체크리스트
 
@@ -108,8 +174,18 @@ const CommonSvgIcon(
 - [ ] 의미 있는 `semanticsLabel`을 제공했는가?
 - [ ] 같은 아이콘의 색상별 복제 파일을 불필요하게 만들지 않았는가?
 - [ ] `pubspec.yaml` asset 등록 범위 안에 있는가?
+- [ ] SVGO 후보와 원본의 구조 diff를 검토했는가?
+- [ ] `viewBox`, 크기, 색상, ID 참조가 유지되는가?
+- [ ] 최소·최대 표시 크기에서 시각 회귀가 없는가?
 
 ## 결정 필요
 
-- Figma export 시 SVG 최적화 도구 사용 여부를 정해야 합니다.
 - 이미지 압축 기준과 최대 파일 크기 기준은 아직 정해지지 않았습니다.
+
+## ASSET-01 작업 이력
+
+| 이슈 | 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- | --- |
+| #207 | `a11a585` | SVGO `4.0.1` 보수 allowlist 설정 추가 | 35개 복사본 XML parse, 원본과 byte/diff 동일 확인 |
+| #207 | `5720a3c` | 전체 SVG parse 및 rasterize 회귀 테스트 추가 | 대상 test 36개 통과 |
+| #207 | - | 도구 채택 범위, 금지 변환, 신규/기존 적용 경계와 검증 절차 문서화 | `git diff --check`, format, analyze, 전체 test |

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -33,7 +33,7 @@
 | 체크 | ID | 결정 항목 | 출처 | 다음 액션 | 상태 |
 | --- | --- | --- | --- | --- | --- |
 | [x] | FIGMA-01 | Home/Memo Figma frame의 실제 node-id | `docs/figma-frame-map.md` | #205에서 Home 기본 `1:2332`, Memo 기본 `1:3749`, 메뉴 `1:3852`, 삭제 alert `1:3964`를 Figma 원본 metadata와 screenshot으로 확인해 반영했다. | Decided |
-| [ ] | ASSET-01 | Figma export 시 SVG 최적화 도구 사용 여부 | `docs/asset-icon-rules.md` | SVGO 등 최적화 도구 도입 여부와 설정 기준을 정한다. | Open |
+| [x] | ASSET-01 | Figma export 시 SVG 최적화 도구 사용 여부 | `docs/asset-icon-rules.md` | #207에서 SVGO `4.0.1` 보수 allowlist, 신규/변경 SVG 후보 우선 적용, 기존 asset 일괄 변경 금지와 parse/rasterize·최소/최대 표시 크기 검증을 확정했다. | Decided |
 
 ## UX와 공통 구조
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -101,6 +101,20 @@ await tester.pumpWidget(
 
 UI가 없어도 검증 가능한 로직은 widget test로 우회하지 않습니다.
 
+## SVG asset 회귀 테스트
+
+`test/core/assets/svg_assets_test.dart`는 `assets/icons`, `assets/images`의 모든 SVG를 현재 lockfile의 `flutter_svg` parser로 읽고 picture rasterize까지 실행합니다. 신규 또는 변경 SVG는 아래 검사를 통과해야 합니다.
+
+```bash
+fvm flutter test test/core/assets/svg_assets_test.dart
+```
+
+- 파일을 읽을 수 있고 SVG parser가 지원하는 구조여야 합니다.
+- `viewBox`에서 계산된 width와 height가 0보다 커야 합니다.
+- picture를 실제 image로 rasterize할 수 있어야 합니다.
+- parser/rasterize 성공은 픽셀 동일성을 뜻하지 않습니다. 영향 화면에서 실제 최소·최대 표시 크기와 필요한 중간 크기를 확인하고, 기존 golden 대상이면 baseline 비교도 함께 수행합니다.
+- SVG 최적화 도구와 후보 검증 순서는 `docs/asset-icon-rules.md`를 따릅니다.
+
 ## QA viewport와 디바이스 기준
 
 화면 테스트와 수동 QA는 `docs/quality-testing-follow-up-plan.md`의 QA-01 profile을 공통 입력값으로 사용합니다.

--- a/test/core/assets/svg_assets_test.dart
+++ b/test/core/assets/svg_assets_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final svgFiles = _findSvgFiles();
+
+  test('SVG asset 목록이 비어 있지 않다', () {
+    expect(svgFiles, isNotEmpty);
+  });
+
+  for (final svgFile in svgFiles) {
+    test('${svgFile.path}을 파싱하고 rasterize할 수 있다', () async {
+      final pictureInfo = await vg.loadPicture(SvgFileLoader(svgFile), null);
+      addTearDown(pictureInfo.picture.dispose);
+
+      expect(pictureInfo.size.width, greaterThan(0));
+      expect(pictureInfo.size.height, greaterThan(0));
+
+      final image = await pictureInfo.picture.toImage(
+        pictureInfo.size.width.ceil(),
+        pictureInfo.size.height.ceil(),
+      );
+      image.dispose();
+    });
+  }
+}
+
+List<File> _findSvgFiles() {
+  final svgFiles = <File>[];
+
+  for (final assetDirectory in [
+    Directory('assets/icons'),
+    Directory('assets/images'),
+  ]) {
+    svgFiles.addAll(
+      assetDirectory
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.svg')),
+    );
+  }
+
+  return svgFiles..sort((left, right) => left.path.compareTo(right.path));
+}

--- a/tool/svg/svgo.config.mjs
+++ b/tool/svg/svgo.config.mjs
@@ -1,0 +1,19 @@
+export default {
+  multipass: false,
+  js2svg: {
+    pretty: true,
+    indent: 0,
+    finalNewline: true,
+  },
+  plugins: [
+    'removeDoctype',
+    'removeXMLProcInst',
+    'removeComments',
+    'removeMetadata',
+    'removeEditorsNSData',
+    'removeScripts',
+    'cleanupAttrs',
+    'removeEmptyAttrs',
+    'removeUnusedNS',
+  ],
+};


### PR DESCRIPTION
## 변경 사항

- SVGO 4.0.1 보수 allowlist 설정을 추가했습니다.
- 기존 SVG 35개의 XML, 구조, 용량과 위험 요소를 계측했습니다.
- 전체 SVG를 flutter_svg로 parse하고 rasterize하는 회귀 테스트를 추가했습니다.
- 신규/변경 SVG의 후보 우선 적용, 금지 변환, 최소·최대 표시 크기 검증 절차를 문서화했습니다.
- 기존 SVG 일괄 최적화는 범위에서 제외했습니다.

## 결정 근거

SVGO 기본 preset은 71,032 byte를 38,696 byte로 45.52% 줄였지만 path 좌표, 색상, ID, group 구조까지 변경했습니다. 보수 설정은 현재 35개 파일을 변경하지 않았으므로 용량보다 렌더 호환성과 리뷰 가능성을 우선합니다.

## 검증

- `git diff --check`
- 35개 원본/보수 후보 XML parse 및 byte/diff 비교
- `vector_graphics_compiler` 호환성 확인
- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test` (258 passed, golden 1 skipped on non-Linux)

Closes #207