### PR TITLE
[Task] 개발 API와 Swagger 정보 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ fvm use 3.35.7
 fvm flutter pub get
 ```
 
+### 5. 개발 API 확인
+
+- 개발 서버 origin: `https://commonplant-dev.okbear.dev`
+- 개발 API base URL: `https://commonplant-dev.okbear.dev/api/v1`
+- Swagger UI: [CommonPlant dev Swagger](https://commonplant-dev.okbear.dev/api/v1/swagger-ui/index.html#)
+- OpenAPI JSON: [CommonPlant dev OpenAPI](https://commonplant-dev.okbear.dev/api/v1/api-docs/json)
+
+개발 서버 루트에는 화면이나 API route가 없어 `https://commonplant-dev.okbear.dev/` 요청은 `404`가 정상입니다. 서버 확인은 Swagger UI 또는 실제 `/api/v1` endpoint를 사용합니다.
+
+현재 앱 코드의 기본 URL은 별도 변경 전까지 이전 값을 유지하므로 dev API를 실행할 때는 base URL을 명시합니다.
+
+```bash
+fvm flutter run \
+  --dart-define=COMMONPLANT_USE_API=true \
+  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant-dev.okbear.dev/api/v1
+```
+
 ## 사용 라이브러리
 
 ### Runtime
@@ -139,12 +156,13 @@ tool/
 - HTTP 클라이언트는 API 연동 시점에 `dio`를 기준으로 도입합니다.
 - MVP 앱은 `커먼플랜트`, Android/iOS 식별자 `com.plant.common`인 단일 prod 앱으로 운영합니다.
 - 실제 API 사용 여부와 base URL은 `dart-define` 또는 CI/CD 환경값으로 주입합니다. dev/staging flavor는 별도 설치·배포 채널·환경별 Firebase가 필요해질 때 도입합니다.
+- dev API base URL은 `https://commonplant-dev.okbear.dev/api/v1`이며, staging/prod URL은 별도 확인 전까지 확정하지 않습니다.
 - 앱 version과 build number는 `pubspec.yaml`의 `X.Y.Z+N`을 단일 원본으로 사용하고 release 브랜치에서 수동 증가합니다. store 이력 확인 전에는 CI 실행 번호로 덮어쓰지 않습니다.
 - API 모델은 `freezed`와 `json_serializable` 기반 생성을 기본 방향으로 삼되, 실제 패키지 추가는 첫 API 연동 PR에서 함께 진행합니다.
 - 인증 토큰은 `flutter_secure_storage` 기반 보관을 기본 방향으로 합니다.
 - 백엔드 에러 코드는 아직 미정이므로, 확정 전까지는 공통 에러 타입으로 감쌀 수 있는 구조를 우선합니다.
 - Golden test는 `OnboardingPage`의 `375×812`, DPR 1 pilot과 Ubuntu canonical baseline을 기준으로 사용합니다.
-- Integration test는 remote API를 사용하지 않는 Home 진입과 장소 친구 요청 이동을 Android smoke pilot으로 사용합니다. staging API, 테스트 계정, seed/cleanup이 필요한 end-to-end 범위는 준비 전까지 `Blocked`입니다.
+- Integration test는 remote API를 사용하지 않는 Home 진입과 장소 친구 요청 이동을 Android smoke pilot으로 사용합니다. dev API URL은 준비됐지만 테스트 계정, seed/cleanup과 secret 정책이 필요한 end-to-end 범위는 준비 전까지 `Blocked`입니다.
 
 ## 프로젝트 문서
 

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -5,16 +5,23 @@
 
 ## 확인 기준
 
-- Swagger UI: https://commonplant.site/api/v1/swagger-ui/index.html
-- OpenAPI JSON: https://commonplant.site/api/v1/api-docs/json
-- Swagger config: https://commonplant.site/api/v1/api-docs/json/swagger-config
-- 확인일: 2026-05-25
+- 환경: `dev`
+- 개발 서버 origin: https://commonplant-dev.okbear.dev
+- API base URL: https://commonplant-dev.okbear.dev/api/v1
+- Swagger UI: https://commonplant-dev.okbear.dev/api/v1/swagger-ui/index.html#
+- OpenAPI JSON: https://commonplant-dev.okbear.dev/api/v1/api-docs/json
+- Swagger config: https://commonplant-dev.okbear.dev/api/v1/api-docs/json/swagger-config
+- 확인일: 2026-08-23
+- 접속 결과: Swagger UI, OpenAPI JSON, Swagger config HTTP 200
+- 개발 서버 루트: HTTP 404. 루트 route가 없다는 의미이며 Swagger/API endpoint 상태와 분리한다.
+- 인증 endpoint 확인: token 없이 `GET /api/v1/users` 요청 시 HTTP 401, code `A009`로 인증 요구 응답
 - OpenAPI 버전: `3.1.0`
 - API title: `Common Plant API Document`
 - 서버 base path: `/api/v1`
+- endpoint inventory: 19 paths, 27 operations
 - 기존 문서 비교 기준: `docs/api-swagger-summary-43` 브랜치의 `docs/api-swagger-reference.md` 확인일 2026-05-20
 - 코드 비교 기준: `feature/api-integration-45` 브랜치의 `lib/core/network`, `features/*/data` API 계층
-- 참고: 2026-05-25 기준 `develop`에는 기존 API 문서와 #45 API 계층 코드가 아직 병합되어 있지 않다.
+- 참고: 2026-05-25의 상세 schema 비교 기록을 보존하고, 2026-08-23에는 dev 접속 정보와 현재 endpoint/schema 차이를 재검증했다.
 
 ## 프론트엔드 연계 원칙
 
@@ -36,7 +43,19 @@
 
 ## Swagger 변경 요약
 
-### 추가된 API
+### 2026-08-23 dev Swagger 재확인
+
+| 구분 | 확인 내용 | 프론트 판단 |
+| --- | --- | --- |
+| 실행 환경 | dev origin과 `/api/v1` base URL 제공 | 로컬 remote API 실행 시 명시적 `dart-define` 주입 가능 |
+| API 문서 | Swagger UI, OpenAPI JSON/config 공개 접근 가능 | live spec 확인과 문서 대조 가능 |
+| Place | `GET /place/{code}/members` 추가 | 친구 관리 화면 후보지만 성공 response schema가 없어 mapper 구현 보류 |
+| Auth register | request/response가 `RegisterRequest`/`RegisterResponse`로 분리 | 기존 request schema 충돌 해소, multipart datasource 반영은 별도 작업 |
+| Multipart encoding | Auth/User/Plant JSON part에 `application/json` 명시 | 해당 도메인 전송 기준 확인, Place는 encoding 미표기로 추가 확인 유지 |
+
+아래의 추가/삭제/변경 표는 2026-05-25 상세 비교 기록이며, 위 표는 2026-08-23 재확인에서 달라진 항목입니다.
+
+### 2026-05-25 추가된 API
 
 | Domain | Method | Path | Summary | 상태 |
 | --- | --- | --- | --- | --- |
@@ -46,13 +65,13 @@
 | Friend | POST | `/friends/decline` | 없음 | 요청 schema만 있음 |
 | User | GET | `/users/{keyword}` | 사용자 이름 검색 | 응답 schema 있음 |
 
-### 삭제된 API
+### 2026-05-25 삭제된 API
 
 | Domain | Method | Path | 비고 |
 | --- | --- | --- | --- |
 | 없음 | - | - | 기존 문서의 API 중 삭제된 endpoint는 확인되지 않는다. |
 
-### 변경된 API
+### 2026-05-25 변경된 API
 
 | Domain | API | 변경 내용 | 프론트 영향 |
 | --- | --- | --- | --- |
@@ -83,6 +102,7 @@
 | Place | GET | `/place/myGarden` | 내 정원 조회 | 필요 | 없음 |
 | Place | GET | `/place/user` | 소속 장소 조회 | 필요 | 없음 |
 | Place | GET | `/place/{code}` | 장소 조회 | 필요 | 없음 |
+| Place | GET | `/place/{code}/members` | 장소 멤버 목록 조회 | 필요 | 없음 |
 | Place | POST | `/place/create` | 장소 생성 | 필요 | 없음 |
 | Place | PUT | `/place/update/{code}` | 장소 수정 | 필요 | 없음 |
 | Place | DELETE | `/place/delete/{code}` | 장소 삭제 | 필요 | 없음 |
@@ -139,10 +159,15 @@
 - Content-Type: `multipart/form-data`
 - Request schema: `RegisterMultipartRequest`
 - Form parts:
-  - `register`: `Register`, required
+  - `register`: `RegisterRequest`, required, `Content-Type: application/json`
   - `image`: binary, optional
-- 성공 response: `RegisterJsonResponse.result` -> `Register`
-- `Register` fields:
+- `RegisterRequest` required:
+  - `signupToken`
+  - `name`
+- `RegisterRequest` optional:
+  - `introduction`
+- 성공 response: `RegisterJsonResponse.result` -> `RegisterResponse`
+- `RegisterResponse` fields:
   - `accessToken`
   - `refreshToken`
   - `newUser`
@@ -151,10 +176,12 @@
   - `401`: `A006`, `A004`
   - `409`: `A007`, `A011`
 
-확인 필요:
+현재 판단:
 
-- `Register` schema가 request part와 response result에 동시에 연결되어 있으나, 필드가 `signupToken`, `name`, `introduction`이 아니라 `accessToken`, `refreshToken`, `newUser`이다.
-- 이전 Swagger 설명의 회원가입 입력값과 충돌하므로, 현재 코드의 `RegisterRequest(signupToken, name, introduction, imgUrl)`를 바로 multipart로 바꾸면 안 된다.
+- 기존의 request/response `Register` schema 충돌은 해소됐다.
+- 프로필 이미지는 `RegisterMultipartRequest.image` optional part이며 request JSON에는 `imgUrl`이 없다.
+- 성공 example의 `isNewUser`와 schema의 `newUser` 명칭은 여전히 일치하지 않으므로 response DTO는 schema와 실제 응답을 함께 확인한다.
+- 현재 `AuthRemoteDataSource.register`는 JSON body를 보내므로 multipart 전환은 별도 구현 이슈에서 진행한다.
 
 ### User
 
@@ -229,6 +256,17 @@
 - Error:
   - `403`: 장소 접근 권한 없음
   - `404`: 장소 없음
+
+#### GET `/place/{code}/members`
+
+- 가입 순서대로 장소 멤버 목록을 조회한다.
+- Path parameter:
+  - `code`: 장소 코드, required
+- 성공 response 설명은 `멤버 목록 조회 성공`이지만 body schema는 없다.
+- Error:
+  - `403`: 장소 접근 권한 없음
+  - `404`: 장소 없음
+- 친구 관리 화면에 연결하려면 member id, 이름, 프로필 이미지, 역할 필드와 wrapper를 백엔드에 확인해야 한다.
 
 #### POST `/place/create`
 
@@ -475,12 +513,13 @@
 
 | 화면 | Route | 새로 연결 가능한 API | 판단 |
 | --- | --- | --- | --- |
-| 프로필 설정 | `/profile/setup` | `POST /auth/register` | request schema 충돌이 있어 백엔드 확인 후 반영 |
+| 프로필 설정 | `/profile/setup` | `POST /auth/register` | request schema는 확인됐으며 현재 JSON datasource를 multipart로 바꾸는 별도 구현 필요 |
 | 프로필 설정 또는 마이페이지 | 미정 | `PUT /users` | User 수정 request/response schema가 보강되어 반영 가능 |
 | 친구 추가 | `/places/new/friends` | `GET /users/{keyword}` | 사용자 이름 검색 DTO 반영 가능 |
 | 친구 추가 | `/places/new/friends` | `POST /friends/request` | 요청 전송은 가능하나 response schema와 화면 성공 정책 확인 필요 |
 | 장소 친구 요청 | `/places/invitations` | `GET /friends/requests` | 목록 response schema가 없어 백엔드 확인 필요 |
 | 장소 친구 요청 | `/places/invitations` | `POST /friends/accept`, `POST /friends/decline` | accept/decline 요청은 가능하나 response와 갱신 정책 확인 필요 |
+| 친구 관리 | `/places/:placeId/friends` | `GET /place/{code}/members` | endpoint는 확인됐지만 목록 response schema가 없어 백엔드 확인 필요 |
 | 장소 수정 | `/places/:placeId/edit` | `PUT /place/update/{code}` | multipart 여부는 해소됐지만 성공 response schema 없음 |
 | 식물 등록 정보 입력 | `/plants/new/details` | `POST /plants` | `placeCode` 기준으로 현재 코드 DTO 수정 필요 |
 | 식물 상세 | `/plants/:plantId` | `GET /plants/{plantId}` | query parameter 제거 필요 |
@@ -503,14 +542,15 @@
 | 공통 응답 wrapper 사용 여부 | `timeStamp`, `success`, `status`, `message`, `result` wrapper 확인 | 일부 해소 |
 | `/auth/login` 성공 응답 body 구조 | 기존/신규 유저 `oneOf` schema 추가 | 해소 |
 | `/auth/register` 성공 응답 body 구조 | `RegisterJsonResponse` 추가 | 해소 |
-| `/auth/register` 요청 body 구조 | multipart로 변경됐지만 `Register` schema가 응답 필드와 같음 | 확인 필요 |
+| `/auth/register` 요청 body 구조 | `RegisterRequest`/`RegisterResponse` 분리와 `register` JSON part encoding 확인 | 해소 |
 | `/users` 조회 성공 응답 body 구조 | `UserJsonResponse`, `UserResponse` 추가 | 해소 |
 | `PUT /users` request schema 오연결 | `UserUpdateMultipartRequest`로 변경 | 해소 |
 | Place 조회/생성/수정/삭제 성공 응답 body 구조 | 여전히 schema 없음 | 남음 |
 | Plant 목록/상세/수정 화면 조회 성공 응답 body 구조 | 목록, 생성, 상세, 수정 정보, 삭제 schema 추가 | 해소 |
 | Image 업로드/조회/수정/삭제 성공 응답 body 구조 | 여전히 schema 없음 | 남음 |
 | `PUT /place/update/{code}` multipart 여부 | `multipart/form-data`로 변경 | 해소 |
-| multipart 요청 JSON part content type | multipart schema는 있으나 part별 content type 명시는 없음 | 일부 남음 |
+| multipart 요청 JSON part content type | Auth/User/Plant는 `application/json` 명시, Place create/update는 encoding 미표기 | 일부 남음 |
+| 장소 멤버 목록 API | `GET /place/{code}/members` 추가, 성공 response schema 없음 | endpoint 확인, schema 확인 필요 |
 | Place create/update required와 validation | `name`, `address` required와 `name` maxLength 확인 | 일부 해소 |
 | Plant create/update validation과 nullable 정책 | 문자열 maxLength와 date format 확인 | 일부 해소 |
 | 에러 응답 body 구조와 code/message 필드명 | 성공 wrapper는 있으나 에러 body schema 없음 | 남음 |
@@ -552,7 +592,7 @@
 
 현재 보류 범위:
 
-- 프로필 설정의 회원가입 이미지 업로드는 `POST /auth/register` request schema 충돌이 있어 연결하지 않는다.
+- 프로필 설정의 회원가입 request schema 충돌은 해소됐지만 현재 datasource가 JSON body를 사용하므로 multipart 전환과 이미지 part 연결은 별도 구현으로 진행한다.
 - 장소/식물 화면은 도메인 multipart `image` part 전달 경계까지만 열어두고, 실제 파일 선택기 도입은 별도 UI 작업에서 진행한다.
 - 메모 화면은 아직 Memo API가 없어 로컬 사진 상태만 유지한다.
 - `/s3/images` 다운로드 URL 조회는 성공 response의 URL 필드 또는 wrapper 구조가 확정된 뒤 화면 fallback 정책과 함께 연결한다.
@@ -563,21 +603,29 @@
 
 | 영역 | 대표 확인 항목 | 프론트 영향 |
 | --- | --- | --- |
-| Auth | `POST /auth/register` request part schema, multipart 전송 정책 | 프로필 설정 회원가입 API 연결 보류 |
+| Auth | `POST /auth/register` response example의 `isNewUser`와 schema `newUser` 불일치 | 회원가입 응답 DTO의 실제 필드 확인 필요 |
 | 공통 Multipart | JSON part의 `Content-Type: application/json` 필요 여부 | Auth/Place/Plant/User multipart 전송 정책 정합성 |
-| Place | 조회/생성/수정/삭제 성공 response, 목록/상세 wrapper와 필드명 | 장소 mapper와 실데이터 화면 정책 제한 |
+| Place | 조회/생성/수정/삭제 성공 response, 목록/상세/멤버 wrapper와 필드명 | 장소 mapper와 실데이터 화면 정책 제한 |
 | Friend | 요청 목록/전송/수락/거절 response, `receiverName`, `friendId` 의미 | 친구 요청 화면과 액션 payload 확정 불가 |
 | Image | `/s3/images` 성공 response, image key/url 필드, 업로드 흐름 | 프로필/장소/식물/메모 이미지 key/url 매핑 보류 |
 | Error | 에러 body의 `code`, `message`, field error 구조 | 공통 사용자 메시지와 field error 매핑 보류 |
 | Token | refresh token 재발급, 로그아웃 API 제공 여부 | 인증 만료 복구와 세션 종료 정책 보류 |
 | 검색 | 주소 검색, 식물 검색 API 제공 여부와 사용자 검색 매칭 정책 | 주소/식물 검색 실데이터 연결 보류 |
 | Memo | 메모 CRUD API, 이미지 첨부, 목록 response 구조 | 메모 화면 실데이터 연결 보류 |
-| 환경 | staging/prod full base URL과 API versioning 정책 | CI/CD 환경값과 release 검증 보류 |
+| 환경 | dev URL은 확인, staging/prod full base URL과 API versioning 정책은 미확정 | dev 로컬 실행 가능, release 검증 보류 |
 
 ## 첫 API 연계 보강 우선순위 제안
 
-1. Auth register request schema는 백엔드 확인 전까지 변경하지 않는다.
+1. Auth register request schema 충돌은 해소됐으므로 multipart datasource 전환과 profile image part 연결을 별도 구현 이슈로 진행한다.
 2. User 조회/검색/수정 datasource는 추가됐으므로, 화면 적용 시 상태 Provider와 UI 성공/실패 정책을 별도 작업으로 연결한다.
 3. Place update는 multipart 전송까지만 추가했으므로, response schema가 확정될 때까지 mapper는 넓히지 않는다.
 4. Friend API는 transport만 추가했으므로, 목록 response schema 확인 후 초대 요청 화면에 연결한다.
 5. Image API는 transport만 추가했으므로, 반환 image key/url schema와 에러 body가 보강되면 이미지 업로드 흐름을 연결한다.
+
+## DEV API 문서화 작업 이력
+
+| 이슈 | 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- | --- |
+| #213 | - | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
+
+작업 이력만 갱신하는 후속 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -626,6 +626,6 @@
 
 | 이슈 | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
-| #213 | - | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
+| #213 | `6a9fbc9` | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
 
 작업 이력만 갱신하는 후속 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -13,12 +13,13 @@
 
 | ID | 영역 | 질문 | 현재 영향 | 상태 |
 | --- | --- | --- | --- | --- |
-| AUTH-01 | Auth | `POST /auth/register` request part의 실제 schema는 무엇인가? | 프로필 설정 회원가입 API 연결 보류 | Open |
-| AUTH-02 | Auth | 회원가입은 이미지가 없어도 항상 multipart로 보내야 하는가? | 회원가입 datasource 전송 방식 보류 | Open |
+| AUTH-01 | Auth | `POST /auth/register` request part의 실제 schema는 무엇인가? | multipart datasource 구현 가능 | Answered |
+| AUTH-02 | Auth | 회원가입은 이미지가 없어도 항상 multipart로 보내야 하는가? | JSON body 대신 multipart, image optional 기준 확인 | Answered |
 | MULTIPART-01 | 공통 | multipart JSON part의 `Content-Type`은 `application/json`이 필수인가? | Auth/Place/Plant/User multipart 일관성 확인 필요 | Open |
 | PLACE-01 | Place | Place 조회/생성/수정/삭제 성공 response body 구조는 무엇인가? | Place mapper와 화면 성공 정책 제한 | Open |
 | PLACE-02 | Place | `/place/myGarden`, `/place/user`, `/place/{code}`의 wrapper와 필드명은 무엇인가? | 장소 목록/상세 실데이터 신뢰도 제한 | Open |
 | PLACE-03 | Place | `placeCode`, `placeId`, `code` 중 화면/요청에서 표준으로 쓸 식별자는 무엇인가? | route query와 API 요청 이름 혼재 가능성 | Open |
+| PLACE-04 | Place | `GET /place/{code}/members` 성공 response schema는 무엇인가? | 친구 관리 화면 멤버 목록 API 연결 보류 | Open |
 | FRIEND-01 | Friend | `GET /friends/requests` response schema는 무엇인가? | 장소 친구 요청 화면 API 연결 보류 | Open |
 | FRIEND-02 | Friend | 친구 요청 전송/수락/거절 성공 response와 화면 갱신 정책은 무엇인가? | 친구 요청 액션 성공 처리 제한 | Open |
 | FRIEND-03 | Friend | `sendFriendReq.receiverName`은 display name인가, 고유 user id인가? | 친구 추가 요청 payload 확정 불가 | Open |
@@ -37,37 +38,38 @@
 | MEMO-01 | Memo | 메모 생성, 목록, 수정, 삭제 API 제공 계획은 무엇인가? | 메모 화면 실데이터 연결 보류 | Open |
 | MEMO-02 | Memo | 메모 이미지 첨부는 어떤 API와 필드로 연결하는가? | 메모 사진 업로드 흐름 보류 | Open |
 | MEMO-03 | Memo | 메모 목록 response의 작성자, 이미지, 작성일, pagination 구조는 무엇인가? | 메모 목록 mapper와 카드 상태 보류 | Open |
-| ENV-01 | 환경 | 백엔드 staging/prod full base URL과 API versioning 정책은 무엇인가? | 배포 환경값 주입 검증 필요 | Open |
+| ENV-01-A | 환경 | dev backend와 Swagger endpoint는 무엇인가? | 로컬 remote API URL 확정 | Answered |
+| ENV-01-B | 환경 | 백엔드 staging/prod full base URL과 API versioning 정책은 무엇인가? | 배포 환경값 주입 검증 필요 | Open |
 
 ## Auth
 
 ### AUTH-01. `POST /auth/register` request part의 실제 schema
 
-- 현재 근거: Swagger의 `RegisterMultipartRequest.register`가 `Register` schema를 참조하지만, `Register` fields는 `accessToken`, `refreshToken`, `newUser`이다.
-- 프론트 영향: 현재 `RegisterRequest(signupToken, name, introduction, imgUrl)`와 충돌한다.
-- 확인 질문: `register` JSON part의 실제 필드가 `signupToken`, `name`, `introduction`, `imgUrl`인지, 아니면 다른 schema가 있는지 확인한다.
-- 프론트 반영: 답변 전까지 프로필 설정 화면에서 회원가입 API 전송 방식을 바꾸지 않는다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 2026-08-23 dev Swagger에서 `RegisterMultipartRequest.register`가 `RegisterRequest`를 참조하고 request/response schema가 분리됐다.
+- 프론트 영향: `signupToken`, `name` required와 optional `introduction` 기준으로 multipart JSON part를 만들 수 있다. `imgUrl`은 request JSON에 없고 `image` binary part가 optional이다.
+- 확인 질문: 해결됨.
+- 프론트 반영: 현재 JSON body를 보내는 `AuthRemoteDataSource.register`의 multipart 전환은 별도 구현 이슈에서 진행한다.
+- 답변: `register`는 `RegisterRequest(signupToken, name, introduction)`이고 `image`는 별도 optional binary part이다.
+- 상태: Answered
 
 ### AUTH-02. 회원가입 multipart 전송 정책
 
-- 현재 근거: Swagger는 `multipart/form-data`와 optional `image` part를 명시한다.
-- 프론트 영향: 이미지가 없는 회원가입도 multipart로 보내야 하는지, JSON body fallback이 가능한지 불명확하다.
-- 확인 질문: 이미지가 없을 때도 `register` part만 포함한 multipart로 전송해야 하는가?
-- 프론트 반영: 답변 전까지 `AuthRemoteDataSource.register`의 기존 JSON body를 임의 변경하지 않는다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 2026-08-23 dev Swagger는 request content type을 `multipart/form-data` 하나로 정의하고 `register`를 required, `image`를 optional로 명시한다.
+- 프론트 영향: 이미지 유무와 관계없이 `register` JSON part를 포함한 multipart로 전송해야 한다.
+- 확인 질문: 해결됨.
+- 프론트 반영: `AuthRemoteDataSource.register`를 `FormData` 기반으로 바꾸고 image가 있을 때만 binary part를 추가한다.
+- 답변: 이미지가 없어도 multipart이며 `image` part만 생략한다.
+- 상태: Answered
 
 ## 공통 Multipart
 
 ### MULTIPART-01. JSON part `Content-Type` 정책
 
-- 현재 근거: User/Place/Plant datasource는 JSON part를 `application/json`으로 전송하도록 구성되어 있다.
-- 프론트 영향: 백엔드 multipart parser가 part별 content type을 요구하는지에 따라 Auth/Place/Plant/User 전송 안정성이 달라진다.
-- 확인 질문: `user`, `place`, `plant`, `register` JSON part에는 `Content-Type: application/json`이 필수인가?
-- 프론트 반영: 필수라면 모든 multipart JSON part에 동일 정책을 유지하고, 아니라면 호환 범위를 문서화한다.
-- 답변: 미확인
+- 현재 근거: dev Swagger encoding은 Auth `register`, User `user`, Plant `plant` JSON part에 `application/json`을 명시한다. Place create/update의 `place` part에는 encoding이 없다.
+- 프론트 영향: Auth/User/Plant는 명세대로 전송할 수 있지만 Place multipart parser 요구사항은 여전히 확인이 필요하다.
+- 확인 질문: Place `place` JSON part에도 `Content-Type: application/json`이 필수인가?
+- 프론트 반영: Auth/User/Plant는 명시된 content type을 유지하고 Place는 답변 전까지 현재 호환 경계를 바꾸지 않는다.
+- 답변: Auth/User/Plant는 `application/json`; Place는 미확인.
 - 상태: Open
 
 ## Place
@@ -96,6 +98,15 @@
 - 프론트 영향: route parameter, query parameter, request DTO 이름이 섞일 수 있다.
 - 확인 질문: 프론트가 저장하고 전달해야 하는 표준 식별자는 `placeCode`인가, `placeId`인가?
 - 프론트 반영: 표준이 확정되면 route helper, provider key, request DTO naming을 정리한다.
+- 답변: 미확인
+- 상태: Open
+
+### PLACE-04. 장소 멤버 목록 response schema
+
+- 현재 근거: dev Swagger에 `GET /place/{code}/members`가 추가됐고 가입 순서대로 멤버를 조회한다고 설명하지만 성공 response body schema는 없다.
+- 프론트 영향: `/places/:placeId/friends`의 fixture 멤버를 remote response로 안전하게 바꿀 수 없다.
+- 확인 질문: wrapper와 member id, 이름, 프로필 이미지, 역할, 가입일 필드명은 무엇인가?
+- 프론트 반영: 답변 후 Place datasource/repository와 친구 관리 상태를 연결한다.
 - 답변: 미확인
 - 상태: Open
 
@@ -275,9 +286,23 @@
 
 ## 환경
 
-### ENV-01. 백엔드 환경 URL과 API versioning
+### ENV-01-A. dev backend와 Swagger endpoint
 
-- 현재 근거: Swagger server는 `/api/v1`만 제공하고, 프론트는 `COMMONPLANT_API_BASE_URL` 주입 전략을 문서화했다.
+- 현재 근거: 2026-08-23 dev Swagger config와 OpenAPI JSON의 `servers` 값을 직접 확인했다.
+- 프론트 영향: 로컬 remote API mode에서 full base URL을 명시적으로 주입할 수 있다.
+- 확인 질문: 해결됨.
+- 프론트 반영: 문서와 로컬 실행 명령에 dev base URL을 반영한다. 코드 기본 URL 변경은 별도 구현 범위로 둔다.
+- 답변:
+  - origin: `https://commonplant-dev.okbear.dev`
+  - API base URL: `https://commonplant-dev.okbear.dev/api/v1`
+  - Swagger UI: `https://commonplant-dev.okbear.dev/api/v1/swagger-ui/index.html#`
+  - OpenAPI JSON: `https://commonplant-dev.okbear.dev/api/v1/api-docs/json`
+  - Swagger config: `https://commonplant-dev.okbear.dev/api/v1/api-docs/json/swagger-config`
+- 상태: Answered
+
+### ENV-01-B. staging/prod 환경 URL과 API versioning
+
+- 현재 근거: dev는 `/api/v1`로 확인됐지만 staging/prod endpoint는 제공되지 않았다.
 - 프론트 영향: staging/prod 배포 검증에서 실제 full base URL이 필요하다.
 - 확인 질문: staging/prod full base URL과 API versioning 정책은 무엇인가?
 - 프론트 반영: 답변 후 CI/CD 환경값과 release 체크리스트를 갱신한다.

--- a/docs/feature-development-guide.md
+++ b/docs/feature-development-guide.md
@@ -176,12 +176,14 @@ lib/core/network/
 feature의 datasource는 공통 Dio client를 주입받아 사용하고, 화면이나 Controller에서 직접 Dio를 생성하지 않습니다.
 
 실제 API 호출은 기본 개발/테스트 흐름을 깨지 않도록 `COMMONPLANT_USE_API` 환경값으로 켭니다.
-base URL은 `COMMONPLANT_API_BASE_URL`로 바꾸며, 기본값은 서버 Swagger 기준 `https://commonplant.site/api/v1`입니다.
+확인된 dev API base URL은 `https://commonplant-dev.okbear.dev/api/v1`이며 `COMMONPLANT_API_BASE_URL`로 명시적으로 주입합니다.
+현재 `lib/core/config/app_environment.dart`의 기본값은 이전 `https://commonplant.site/api/v1`이므로 별도 코드 변경 전에는 기본값에 의존하지 않습니다.
 앱 flavor는 dev/staging/prod 앱 정체성 구분에 사용하고, API mode와 base URL은 `dart-define` 또는 CI/CD 주입값으로 관리합니다.
 
 ```bash
-fvm flutter run --dart-define=COMMONPLANT_USE_API=true
-fvm flutter run --dart-define=COMMONPLANT_USE_API=true --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant.site/api/v1
+fvm flutter run \
+  --dart-define=COMMONPLANT_USE_API=true \
+  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant-dev.okbear.dev/api/v1
 fvm flutter run --dart-define-from-file=env/local.api.json
 ```
 
@@ -211,6 +213,6 @@ Swagger에 성공 response body schema가 없는 API는 mapper에서 확인 가�
 
 ## 결정 필요
 
-- 백엔드 staging/prod full base URL과 API versioning 정책은 API 연동 시점에 확정해야 합니다.
+- dev API와 Swagger URL은 #213에서 확인했습니다. staging/prod full base URL과 API versioning 정책은 배포 환경 준비 시 별도로 확정해야 합니다.
 - flavor별 앱명, application id, bundle id는 배포 정책 확정 시 `docs/release-workflow.md` 기준으로 정합니다.
 - 백엔드 에러 코드가 확정되면 `api_exception.dart`의 mapping table을 갱신해야 합니다.

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -16,7 +16,7 @@
 | [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | 네 QA profile을 적용한다. 확인된 compact overflow와 대상 회귀 테스트는 #197에서 완료했다. | Decided |
 | [x] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator와 workflow 기반 baseline 갱신 규칙을 적용한다. | Decided |
 | [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke, 명시적 device 실행, 수동 workflow와 required check 승격 조건을 적용한다. | Decided |
-| [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | staging URL, 테스트 계정, seed/cleanup과 secret 정책이 준비될 때까지 remote end-to-end workflow를 보류한다. | Blocked |
+| [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #213에서 dev API URL은 확인했다. 테스트 계정, seed/cleanup, secret과 데이터 격리 정책이 준비될 때까지 remote end-to-end workflow를 보류한다. | Blocked |
 
 ## 릴리즈와 환경
 
@@ -27,7 +27,8 @@
 | [ ] | RELEASE-02-B | 최초 store build number 기준값 | `docs/release-workflow.md` | 같은 식별자를 쓴 v2와 Play/App Store의 최대 업로드 번호를 RELEASE-03에서 확인한 뒤 공통 `N`을 확정한다. | Blocked |
 | [ ] | RELEASE-03 | Android Play Console과 Apple Developer/App Store Connect 계정 준비 여부 | `docs/release-workflow.md` | 계정, 앱 등록, 권한, secret 등록 가능 여부를 확인한다. | Open |
 | [ ] | RELEASE-04 | 내부 테스트 배포 안정화 후 production 제출 자동화 범위 | `docs/release-workflow.md` | manual approval 유지 범위와 자동 제출 허용 범위를 정한다. | Open |
-| [ ] | ENV-01 | staging/prod 서버 full base URL과 API versioning 정책 | `docs/release-workflow.md`, `docs/api-swagger-reference.md`, `docs/backend-api-open-questions.md` | 백엔드 답변을 받아 CI/CD 환경값과 release 검증 기준에 반영한다. | Open |
+| [x] | ENV-01-A | dev backend, API base URL과 Swagger endpoint | `docs/release-workflow.md`, `docs/api-swagger-reference.md`, `docs/backend-api-open-questions.md` | #213에서 dev origin, `/api/v1`, Swagger UI와 OpenAPI JSON/config 접속을 확인했다. | Decided |
+| [ ] | ENV-01-B | staging/prod full base URL과 API versioning 정책 | `docs/release-workflow.md`, `docs/api-swagger-reference.md`, `docs/backend-api-open-questions.md` | 백엔드 답변을 받아 CI/CD 환경값과 release 검증 기준에 반영한다. | Open |
 
 ## 디자인과 에셋
 
@@ -52,15 +53,17 @@
 
 | 체크 | ID | 범위 | 관련 질문 ID | 현재 막힌 작업 | 상태 |
 | --- | --- | --- | --- | --- | --- |
-| [ ] | API-AUTH | Auth 회원가입 전송 정책 | AUTH-01, AUTH-02, MULTIPART-01 | 프로필 설정 회원가입 API 연결 | Open |
-| [ ] | API-PLACE | Place response와 식별자 정책 | PLACE-01, PLACE-02, PLACE-03 | 장소 목록/상세/생성/수정/삭제 실데이터 연결 | Open |
+| [x] | API-AUTH | Auth 회원가입 전송 정책 | AUTH-01, AUTH-02 | dev Swagger의 `RegisterRequest`와 image optional multipart 기준으로 datasource 구현을 분리한다. | Ready |
+| [ ] | API-MULTIPART | Place multipart JSON part 정책 | MULTIPART-01 | Auth/User/Plant의 `application/json` encoding은 확인됐고 Place encoding은 백엔드 확인이 필요하다. | Open |
+| [ ] | API-PLACE | Place response와 식별자 정책 | PLACE-01, PLACE-02, PLACE-03, PLACE-04 | 장소 목록/상세/멤버/생성/수정/삭제 실데이터 연결 | Open |
 | [ ] | API-FRIEND | Friend 요청 목록과 액션 정책 | FRIEND-01, FRIEND-02, FRIEND-03, FRIEND-04 | 장소 친구 요청/추가 화면 API 연결 | Open |
 | [ ] | API-IMAGE | Image upload/download/update/delete 정책 | IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-04 | 프로필/장소/식물/메모 이미지 key/url 매핑 | Open |
 | [ ] | API-ERROR | 공통/도메인 에러 response 정책 | ERROR-01, ERROR-02 | 사용자 메시지와 field error 매핑 | Open |
 | [ ] | API-TOKEN | refresh token과 로그아웃 정책 | TOKEN-01, TOKEN-02 | 인증 만료 복구와 세션 종료 처리 | Open |
 | [ ] | API-SEARCH | 주소/식물/사용자 검색 정책 | SEARCH-01, SEARCH-02, SEARCH-03 | 주소 검색, 식물 검색, 친구 추가 검색 UX | Open |
 | [ ] | API-MEMO | Memo CRUD와 이미지 첨부 정책 | MEMO-01, MEMO-02, MEMO-03 | 메모 화면 실데이터 연결 | Open |
-| [ ] | API-ENV | 서버 환경값과 API versioning | ENV-01 | staging/prod release 검증 | Open |
+| [x] | API-ENV-DEV | dev 서버 환경값과 Swagger | ENV-01-A | #213에서 dev origin, API base URL과 문서 endpoint를 확인했다. | Decided |
+| [ ] | API-ENV-RELEASE | staging/prod 환경값과 versioning | ENV-01-B | staging/prod release 검증은 백엔드 답변 전까지 미확정이다. | Open |
 
 ## 다음 이슈화 기준
 

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -174,6 +174,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | TEST-02-A smoke | `61fd571` | `integration_test` 의존성과 API 비사용 Home → 장소 친구 요청 실제 앱 smoke 추가 | Android API 36.1 `emulator-5554` target test, `fvm flutter analyze` 통과 |
 | TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
 | TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
-| TEST-02-B dev 환경 | - | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
+| TEST-02-B dev 환경 | `6a9fbc9` | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -5,24 +5,24 @@
 ## 작업 원칙
 
 - 로컬 코드와 저장소 설정만으로 결정할 수 있는 범위를 먼저 진행한다.
-- staging API, 테스트 계정, seed/cleanup처럼 백엔드 준비가 필요한 항목은 `Blocked`로 분리한다.
+- dev API URL은 확인된 값으로 사용하고, 테스트 계정, seed/cleanup처럼 추가 백엔드 준비가 필요한 항목은 `Blocked`로 분리한다.
 - Golden test와 integration test는 기존 unit/widget test를 대체하지 않는다.
 - 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
 - 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
 
-## 2026-08-19 현재 상태
+## 2026-08-23 현재 상태
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
-| 기준 브랜치 | `develop@5a6b000` | TEST-01 #199, PR #202 병합 완료 |
+| 기준 브랜치 | `develop@37501b6` | RELEASE-02 #211, PR #212까지 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
 | Widget test viewport | `test/helpers/test_viewport.dart`에서 네 QA profile과 DPR 1 설정을 제공하고 compact gap 대상 화면에 적용 | 기존 raw viewport 설정은 관련 화면 수정 시 점진적으로 helper로 전환 |
 | Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer의 exact 비교와 수동 baseline workflow run `31811426737` 성공 확인 |
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
-| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke는 병합 후 첫 수동 실행 검증이 필요하며 아직 required check가 아님 |
-| 기본 품질 게이트 | macOS에서 unit/widget 222개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 223개 통과 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
-| Remote API 환경 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 지점만 존재 | staging URL, 계정, 데이터 격리 정책은 Blocked |
+| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke run `32243828623` 성공, 연속 3회 기준 전이라 아직 required check가 아님 |
+| 기본 품질 게이트 | macOS에서 unit/widget/asset 258개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 259개 통과 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
+| Remote API 환경 | dev API `https://commonplant-dev.okbear.dev/api/v1`과 환경값 주입 지점 확인 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책은 Blocked |
 
 ## 의존관계를 반영한 작업 순서
 
@@ -32,8 +32,8 @@
 | 2 | QA-01 적용 후속 | compact-width overflow 수정과 viewport 회귀 테스트 추가 | QA-01 | Done (#197) |
 | 3 | TEST-01 폰트 선행 | 한글 Pretendard asset과 라이선스 정리 | QA-01 적용 후속 | Done (#200) |
 | 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | Done (#199) |
-| 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | In Review (#203) |
-| 6 | TEST-02-B | staging API 기반 integration workflow와 핵심 CRUD flow 연결 | staging URL, 테스트 계정, seed/cleanup, secret 정책 | Blocked |
+| 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | Done (#203) |
+| 6 | TEST-02-B | dev API 기반 integration workflow와 핵심 CRUD flow 연결 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책 | Blocked |
 
 TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
 
@@ -135,13 +135,13 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 - `integration_test/app_smoke_test.dart`에서 production `main()`을 실행하고 `COMMONPLANT_USE_API=false`를 assertion으로 고정한다.
 - Home의 기본 콘텐츠를 확인한 뒤 `장소 요청 3건`을 탭해 장소 친구 요청 화면까지 이동한다.
 - 로컬 명령은 Android device ID를 명시하고, GitHub Actions는 Android API 35 Google APIs x86_64 Pixel 6 emulator의 수동 workflow로 실행한다.
-- 새 `workflow_dispatch` 파일은 기본 브랜치 병합 전 실행할 수 없으므로 #203 병합 직후 `develop`에서 첫 run을 검증한다.
+- `develop`의 첫 수동 run `32243828623`은 성공했다.
 - `develop` 수동 run이 assertion 실패나 재시도 없이 3회 연속 성공하고 로그 구분, 실행 시간·비용, 팀 동의를 확인한 뒤에만 required check 승격을 검토한다.
 
 ### 백엔드 준비 전 Blocked 범위
 
 - `COMMONPLANT_USE_API=true`인 로그인과 CRUD end-to-end flow
-- staging API URL과 API versioning을 포함한 CI 환경값
+- 확인된 dev API URL을 CI에 주입할 variable/secret 정책
 - 테스트 전용 계정과 인증 갱신 정책
 - seed 데이터, 중복 방지, 테스트 후 cleanup 정책
 - secret 접근 권한과 외부 API 장애 시 재시도/판정 정책
@@ -174,5 +174,6 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | TEST-02-A smoke | `61fd571` | `integration_test` 의존성과 API 비사용 Home → 장소 친구 요청 실제 앱 smoke 추가 | Android API 36.1 `emulator-5554` target test, `fvm flutter analyze` 통과 |
 | TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
 | TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
+| TEST-02-B dev 환경 | - | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -13,6 +13,7 @@
 | iOS 배포 자동화 | 보류: Apple 계정과 signing asset 준비 후 도입 |
 | Store 계정/secret | 저장소에 커밋하지 않고 GitHub Secrets/Environments에만 등록 |
 | 환경값 주입 | `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL`을 `dart-define` 또는 CI/CD에서 주입 |
+| Dev API | `https://commonplant-dev.okbear.dev/api/v1` 확인, 로컬에서 명시적으로 주입 |
 | Flavor 전략 | MVP는 flavor 없는 단일 prod 앱으로 운영하고 환경값은 CI/CD로 주입 |
 | Version 전략 | `pubspec.yaml`의 `X.Y.Z+N`을 공통 원본으로 두고 release 브랜치에서 수동 증가 |
 
@@ -164,12 +165,20 @@ dev/staging 앱명과 식별자 suffix는 미리 정하지 않습니다. 별도 
 
 ### 환경값 주입
 
+| 환경 | Origin | API base URL | 상태 |
+| --- | --- | --- | --- |
+| dev | `https://commonplant-dev.okbear.dev` | `https://commonplant-dev.okbear.dev/api/v1` | 확인 완료 |
+| staging | 미확정 | 미확정 | ENV-01-B Open |
+| prod | 미확정 | 미확정 | ENV-01-B Open |
+
+dev Swagger UI는 `https://commonplant-dev.okbear.dev/api/v1/swagger-ui/index.html#`, OpenAPI JSON은 `https://commonplant-dev.okbear.dev/api/v1/api-docs/json`입니다. origin 루트의 `404`는 루트 route가 없다는 뜻이며 Swagger와 `/api/v1` 가용성 판정에 사용하지 않습니다.
+
 로컬 개발에서는 필요할 때 `dart-define`으로 API mode를 켭니다.
 
 ```bash
 fvm flutter run \
   --dart-define=COMMONPLANT_USE_API=true \
-  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant.site/api/v1
+  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant-dev.okbear.dev/api/v1
 ```
 
 배포 빌드에서는 CI/CD가 환경별 값을 주입합니다.
@@ -189,7 +198,7 @@ fvm flutter build appbundle --release --dart-define-from-file=env/prod.json
 
 ### 단계별 도입
 
-1. 현재 단계에서는 단일 prod 앱 정체성과 `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 주입 기준을 유지합니다.
+1. 현재 단계에서는 단일 prod 앱 정체성과 확인된 dev API의 `COMMONPLANT_USE_API`, `COMMONPLANT_API_BASE_URL` 명시적 주입 기준을 유지합니다.
 2. release workflow를 만들 때 GitHub Environment별 variables/secrets로 환경값을 주입합니다.
 3. 별도 앱 설치나 스토어 채널 분리가 필요해지면 Android/iOS `dev`, `staging`, `prod` flavor를 추가합니다.
 4. flavor가 추가된 뒤에도 API base URL과 API mode는 CI/CD 주입값을 우선합니다.
@@ -371,7 +380,7 @@ release workflow를 추가할 때도 `GITHUB_RUN_NUMBER`로 `pubspec.yaml`의 bu
 ## 후속 결정 필요
 
 - 별도 설치, 배포 채널, 환경별 Firebase가 필요해지면 dev/staging flavor와 식별값을 새 작업에서 정해야 합니다.
-- staging/prod 서버 full base URL과 API versioning 정책을 정해야 합니다.
+- dev API와 Swagger endpoint는 확인됐습니다. staging/prod 서버 full base URL과 API versioning 정책은 별도로 정해야 합니다.
 - 최초 store build number는 Play Console/App Store Connect의 기존 업로드 이력을 확인한 뒤 정해야 합니다.
 - Android Play Console과 Apple Developer/App Store Connect 계정 준비 여부를 확인해야 합니다.
 - 내부 테스트 배포 안정화 후 production 제출 자동화 범위를 다시 판단합니다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -50,7 +50,7 @@ CI는 GitHub Actions에서 Flutter `3.35.7`을 설치한 뒤 `flutter pub get`, 
 | Unit test | validator, DTO/entity mapper, repository 에러 매핑, Provider/Controller 분기 로직은 필수 |
 | Widget test | 새 화면, 상태 UI, form validation, 버튼 활성/비활성, route parameter 처리는 필수 |
 | Golden test | 공용 컴포넌트 또는 반복 화면에서 디자인 회귀 위험이 높을 때만 추가 |
-| Integration test | API 비사용 앱 시작/route smoke는 디바이스 runner로 먼저 검증하고, remote flow는 staging API, 테스트 계정, 데이터 초기화 정책이 준비된 핵심 플로우에만 추가 |
+| Integration test | API 비사용 앱 시작/route smoke는 디바이스 runner로 먼저 검증하고, remote flow는 dev API 외에 테스트 계정과 데이터 초기화 정책까지 준비된 핵심 플로우에만 추가 |
 
 MVP에서 새 기능을 만들 때 unit/widget test로 검증 가능한 동작을 golden 또는 integration test로 대체하지 않습니다. Golden test는 시각 회귀를 보강하는 용도이고, integration test는 여러 화면과 실제 실행 환경을 통과하는 흐름을 확인하는 용도입니다.
 
@@ -231,7 +231,7 @@ gh run view <run-id> --log
 
 remote API를 사용하는 핵심 사용자 흐름은 아래 조건이 준비된 뒤 추가합니다.
 
-- staging 또는 테스트용 API base URL이 확정되어 있습니다.
+- dev API base URL `https://commonplant-dev.okbear.dev/api/v1`은 확정되어 있습니다.
 - 테스트 전용 계정과 seed 데이터 또는 테스트 후 정리 방식이 준비되어 있습니다.
 - Android emulator, iOS simulator, 실제 기기, 또는 GitHub Actions runner 중 실행 환경이 정해져 있습니다.
 - 네트워크 실패, 인증 만료, 데이터 중복이 테스트 결과를 불안정하게 만들지 않도록 격리 전략이 있습니다.
@@ -248,10 +248,10 @@ remote API를 사용하는 핵심 사용자 흐름은 아래 조건이 준비된
 ```bash
 fvm flutter test integration_test \
   --dart-define=COMMONPLANT_USE_API=true \
-  --dart-define=COMMONPLANT_API_BASE_URL=<staging-api-url>
+  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant-dev.okbear.dev/api/v1
 ```
 
-staging API, 테스트 계정, seed/cleanup 정책이 필요한 end-to-end flow는 준비 전까지 `Blocked`입니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
+dev API URL 조건은 해소됐습니다. 테스트 계정, seed/cleanup, secret과 데이터 격리 정책이 필요한 end-to-end flow는 나머지 조건이 준비될 때까지 `Blocked`입니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
 
 ## 테스트 파일 네이밍
 
@@ -300,5 +300,5 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 ## 후속 결정 필요
 
 - TEST-01 pilot은 #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator로 확정했습니다. 추가 화면과 viewport baseline은 회귀 위험과 유지 비용을 확인해 별도 이슈로 확장합니다.
-- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했습니다. 병합 후 `develop` 수동 실행을 검증하고 연속 성공 기준을 충족하기 전에는 PR 필수 게이트로 승격하지 않습니다.
-- TEST-02-B는 staging API, 테스트 계정, seed/cleanup이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결합니다. 준비 전 상태는 `Blocked`입니다.
+- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고 `develop` run `32243828623`이 성공했습니다. 연속 3회 성공 기준을 충족하기 전에는 PR 필수 게이트로 승격하지 않습니다.
+- TEST-02-B의 dev API URL은 #213에서 확인했습니다. 테스트 계정, seed/cleanup, secret 정책이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결하며, 그전 상태는 `Blocked`입니다.


### PR DESCRIPTION
## 변경 내용

- README와 개발·릴리즈 문서에 dev origin, `/api/v1` base URL, Swagger UI/OpenAPI/config 주소를 반영했습니다.
- 서버 루트의 HTTP 404는 root route 부재이며 Swagger/API 가용성과 분리해 판단하도록 기록했습니다.
- `ENV-01`을 dev 확정(`ENV-01-A`)과 staging/prod 미확정(`ENV-01-B`)으로 분리했습니다.
- TEST-02-B는 dev URL 조건만 해소하고 테스트 계정, seed/cleanup, secret, 데이터 격리 정책을 `Blocked`로 유지했습니다.
- 현재 Swagger의 19 paths·27 operations, `GET /place/{code}/members`, Auth register schema 분리와 multipart encoding 차이를 문서에 반영했습니다.
- 문서의 커밋별 작업 이력을 `6a9fbc9` 기준으로 갱신했습니다.

## 범위 경계

- `lib/core/config/app_environment.dart`의 기존 기본 URL은 변경하지 않았습니다.
- staging/prod URL, API versioning, 테스트 계정과 데이터 정책은 임의로 확정하지 않았습니다.
- remote integration workflow와 API datasource 구현은 포함하지 않습니다.

## 검증

- dev root: HTTP 404 (`text/html`)
- Swagger UI: HTTP 200
- Swagger config: HTTP 200 (`application/json`)
- OpenAPI JSON: HTTP 200 (`application/json`)
- token 없는 `GET /api/v1/users`: HTTP 401, code `A009`
- OpenAPI 3.1.0, `/api/v1`, 19 paths·27 operations와 관련 schema를 `jq`로 대조
- `git diff --check`

Closes #213
