### PR TITLE
[Task] 회원가입 multipart 전송 적용

### DIFF
--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -629,6 +629,6 @@
 | 이슈 | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
 | #213 | `6a9fbc9` | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
-| #216 | `ae134d0` | Auth register JSON part와 optional image multipart datasource/repository, Swagger request DTO 반영 | Auth DTO/datasource/repository unit test 5개, format 260개 파일, analyze |
+| #216 | `ae134d0` | Auth register JSON part와 optional image multipart datasource/repository, Swagger request DTO 반영 | Auth unit test 5개, macOS 전체 263개와 Ubuntu golden 포함 264개, format 260개 파일, analyze |
 
 작업 이력만 갱신하는 후속 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -50,7 +50,7 @@
 | 실행 환경 | dev origin과 `/api/v1` base URL 제공 | 로컬 remote API 실행 시 명시적 `dart-define` 주입 가능 |
 | API 문서 | Swagger UI, OpenAPI JSON/config 공개 접근 가능 | live spec 확인과 문서 대조 가능 |
 | Place | `GET /place/{code}/members` 추가 | 친구 관리 화면 후보지만 성공 response schema가 없어 mapper 구현 보류 |
-| Auth register | request/response가 `RegisterRequest`/`RegisterResponse`로 분리 | 기존 request schema 충돌 해소, multipart datasource 반영은 별도 작업 |
+| Auth register | request/response가 `RegisterRequest`/`RegisterResponse`로 분리 | #216에서 JSON part와 optional image multipart datasource 반영 |
 | Multipart encoding | Auth/User/Plant JSON part에 `application/json` 명시 | 해당 도메인 전송 기준 확인, Place는 encoding 미표기로 추가 확인 유지 |
 
 아래의 추가/삭제/변경 표는 2026-05-25 상세 비교 기록이며, 위 표는 2026-08-23 재확인에서 달라진 항목입니다.
@@ -181,7 +181,9 @@
 - 기존의 request/response `Register` schema 충돌은 해소됐다.
 - 프로필 이미지는 `RegisterMultipartRequest.image` optional part이며 request JSON에는 `imgUrl`이 없다.
 - 성공 example의 `isNewUser`와 schema의 `newUser` 명칭은 여전히 일치하지 않으므로 response DTO는 schema와 실제 응답을 함께 확인한다.
-- 현재 `AuthRemoteDataSource.register`는 JSON body를 보내므로 multipart 전환은 별도 구현 이슈에서 진행한다.
+- #216에서 `AuthRemoteDataSource.register`를 `register` JSON part와 optional `image` part를 보내는 multipart 요청으로 전환했다.
+- `RegisterRequest`에서는 명세에 없는 `imgUrl`을 제거했다.
+- repository까지 optional `MultipartFile` 전달 경계를 열었으며 실제 profile image 파일 생성과 화면 연결은 별도 UI 작업으로 진행한다.
 
 ### User
 
@@ -513,7 +515,7 @@
 
 | 화면 | Route | 새로 연결 가능한 API | 판단 |
 | --- | --- | --- | --- |
-| 프로필 설정 | `/profile/setup` | `POST /auth/register` | request schema는 확인됐으며 현재 JSON datasource를 multipart로 바꾸는 별도 구현 필요 |
+| 프로필 설정 | `/profile/setup` | `POST /auth/register` | #216에서 multipart datasource/repository 반영 완료, 실제 image picker 파일과 submit 연결은 별도 구현 필요 |
 | 프로필 설정 또는 마이페이지 | 미정 | `PUT /users` | User 수정 request/response schema가 보강되어 반영 가능 |
 | 친구 추가 | `/places/new/friends` | `GET /users/{keyword}` | 사용자 이름 검색 DTO 반영 가능 |
 | 친구 추가 | `/places/new/friends` | `POST /friends/request` | 요청 전송은 가능하나 response schema와 화면 성공 정책 확인 필요 |
@@ -592,7 +594,7 @@
 
 현재 보류 범위:
 
-- 프로필 설정의 회원가입 request schema 충돌은 해소됐지만 현재 datasource가 JSON body를 사용하므로 multipart 전환과 이미지 part 연결은 별도 구현으로 진행한다.
+- 프로필 설정의 회원가입 multipart datasource/repository는 #216에서 반영했으며 실제 image picker 파일과 submit 연결은 별도 UI 작업으로 진행한다.
 - 장소/식물 화면은 도메인 multipart `image` part 전달 경계까지만 열어두고, 실제 파일 선택기 도입은 별도 UI 작업에서 진행한다.
 - 메모 화면은 아직 Memo API가 없어 로컬 사진 상태만 유지한다.
 - `/s3/images` 다운로드 URL 조회는 성공 response의 URL 필드 또는 wrapper 구조가 확정된 뒤 화면 fallback 정책과 함께 연결한다.
@@ -616,7 +618,7 @@
 
 ## 첫 API 연계 보강 우선순위 제안
 
-1. Auth register request schema 충돌은 해소됐으므로 multipart datasource 전환과 profile image part 연결을 별도 구현 이슈로 진행한다.
+1. Auth register multipart datasource/repository는 #216에서 반영했다. profile image 파일 생성과 화면 submit 연결은 별도 구현 이슈로 진행한다.
 2. User 조회/검색/수정 datasource는 추가됐으므로, 화면 적용 시 상태 Provider와 UI 성공/실패 정책을 별도 작업으로 연결한다.
 3. Place update는 multipart 전송까지만 추가했으므로, response schema가 확정될 때까지 mapper는 넓히지 않는다.
 4. Friend API는 transport만 추가했으므로, 목록 response schema 확인 후 초대 요청 화면에 연결한다.
@@ -627,5 +629,6 @@
 | 이슈 | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
 | #213 | `6a9fbc9` | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
+| #216 | `ae134d0` | Auth register JSON part와 optional image multipart datasource/repository, Swagger request DTO 반영 | Auth DTO/datasource/repository unit test 5개, format 260개 파일, analyze |
 
 작업 이력만 갱신하는 후속 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -13,8 +13,8 @@
 
 | ID | 영역 | 질문 | 현재 영향 | 상태 |
 | --- | --- | --- | --- | --- |
-| AUTH-01 | Auth | `POST /auth/register` request part의 실제 schema는 무엇인가? | multipart datasource 구현 가능 | Answered |
-| AUTH-02 | Auth | 회원가입은 이미지가 없어도 항상 multipart로 보내야 하는가? | JSON body 대신 multipart, image optional 기준 확인 | Answered |
+| AUTH-01 | Auth | `POST /auth/register` request part의 실제 schema는 무엇인가? | #216 multipart datasource/repository 반영 완료 | Done |
+| AUTH-02 | Auth | 회원가입은 이미지가 없어도 항상 multipart로 보내야 하는가? | #216 image optional 전송 기준 반영 완료 | Done |
 | MULTIPART-01 | 공통 | multipart JSON part의 `Content-Type`은 `application/json`이 필수인가? | Auth/Place/Plant/User multipart 일관성 확인 필요 | Open |
 | PLACE-01 | Place | Place 조회/생성/수정/삭제 성공 response body 구조는 무엇인가? | Place mapper와 화면 성공 정책 제한 | Open |
 | PLACE-02 | Place | `/place/myGarden`, `/place/user`, `/place/{code}`의 wrapper와 필드명은 무엇인가? | 장소 목록/상세 실데이터 신뢰도 제한 | Open |
@@ -48,18 +48,18 @@
 - 현재 근거: 2026-08-23 dev Swagger에서 `RegisterMultipartRequest.register`가 `RegisterRequest`를 참조하고 request/response schema가 분리됐다.
 - 프론트 영향: `signupToken`, `name` required와 optional `introduction` 기준으로 multipart JSON part를 만들 수 있다. `imgUrl`은 request JSON에 없고 `image` binary part가 optional이다.
 - 확인 질문: 해결됨.
-- 프론트 반영: 현재 JSON body를 보내는 `AuthRemoteDataSource.register`의 multipart 전환은 별도 구현 이슈에서 진행한다.
+- 프론트 반영: #216에서 `register` JSON part와 optional `image` part를 보내도록 datasource/repository를 전환하고 request JSON의 `imgUrl`을 제거했다.
 - 답변: `register`는 `RegisterRequest(signupToken, name, introduction)`이고 `image`는 별도 optional binary part이다.
-- 상태: Answered
+- 상태: Done
 
 ### AUTH-02. 회원가입 multipart 전송 정책
 
 - 현재 근거: 2026-08-23 dev Swagger는 request content type을 `multipart/form-data` 하나로 정의하고 `register`를 required, `image`를 optional로 명시한다.
 - 프론트 영향: 이미지 유무와 관계없이 `register` JSON part를 포함한 multipart로 전송해야 한다.
 - 확인 질문: 해결됨.
-- 프론트 반영: `AuthRemoteDataSource.register`를 `FormData` 기반으로 바꾸고 image가 있을 때만 binary part를 추가한다.
+- 프론트 반영: #216에서 `FormData` 기반으로 바꾸고 image가 있을 때만 binary part를 추가했다. 실제 파일 생성과 화면 submit 연결은 별도 UI 작업이다.
 - 답변: 이미지가 없어도 multipart이며 `image` part만 생략한다.
-- 상태: Answered
+- 상태: Done
 
 ## 공통 Multipart
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -53,7 +53,7 @@
 
 | 체크 | ID | 범위 | 관련 질문 ID | 현재 막힌 작업 | 상태 |
 | --- | --- | --- | --- | --- | --- |
-| [x] | API-AUTH | Auth 회원가입 전송 정책 | AUTH-01, AUTH-02 | dev Swagger의 `RegisterRequest`와 image optional multipart 기준으로 datasource 구현을 분리한다. | Ready |
+| [x] | API-AUTH | Auth 회원가입 전송 정책 | AUTH-01, AUTH-02 | #216에서 `RegisterRequest` JSON part와 optional image multipart datasource/repository를 반영했다. 실제 파일 생성과 화면 submit은 별도 구현으로 분리한다. | Done |
 | [ ] | API-MULTIPART | Place multipart JSON part 정책 | MULTIPART-01 | Auth/User/Plant의 `application/json` encoding은 확인됐고 Place encoding은 백엔드 확인이 필요하다. | Open |
 | [ ] | API-PLACE | Place response와 식별자 정책 | PLACE-01, PLACE-02, PLACE-03, PLACE-04 | 장소 목록/상세/멤버/생성/수정/삭제 실데이터 연결 | Open |
 | [ ] | API-FRIEND | Friend 요청 목록과 액션 정책 | FRIEND-01, FRIEND-02, FRIEND-03, FRIEND-04 | 장소 친구 요청/추가 화면 API 연결 | Open |

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -21,7 +21,7 @@
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
 | GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke run `32243828623` 성공, 연속 3회 기준 전이라 아직 required check가 아님 |
-| 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 예상 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
+| 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 통과 | Ubuntu PR run `32627288004`에서 canonical golden 포함 결과 확인 |
 | Remote API 환경 | dev API `https://commonplant-dev.okbear.dev/api/v1`과 환경값 주입 지점 확인 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책은 Blocked |
 
 ## 의존관계를 반영한 작업 순서

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -21,7 +21,7 @@
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
 | GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke run `32243828623` 성공, 연속 3회 기준 전이라 아직 required check가 아님 |
-| 기본 품질 게이트 | macOS에서 unit/widget/asset 258개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 259개 통과 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
+| 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 예상 | non-Linux font rasterization 차이는 skip하고 Ubuntu exact 결과를 필수 판정으로 사용 |
 | Remote API 환경 | dev API `https://commonplant-dev.okbear.dev/api/v1`과 환경값 주입 지점 확인 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책은 Blocked |
 
 ## 의존관계를 반영한 작업 순서

--- a/lib/features/login/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/login/data/datasources/auth_remote_data_source.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:commonplant_frontend/core/network/api_exception.dart';
 import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
 import 'package:dio/dio.dart';
@@ -20,11 +22,20 @@ class AuthRemoteDataSource {
     }
   }
 
-  Future<Object?> register(RegisterRequest request) async {
+  Future<Object?> register(
+    RegisterRequest request, {
+    MultipartFile? image,
+  }) async {
     try {
       final response = await _dio.post<Object?>(
         '/auth/register',
-        data: request.toJson(),
+        data: FormData.fromMap({
+          'register': MultipartFile.fromString(
+            jsonEncode(request.toJson()),
+            contentType: DioMediaType('application', 'json'),
+          ),
+          if (image != null) 'image': image,
+        }),
       );
 
       return response.data;

--- a/lib/features/login/data/dtos/auth_requests.dart
+++ b/lib/features/login/data/dtos/auth_requests.dart
@@ -14,20 +14,17 @@ class RegisterRequest {
     required this.signupToken,
     required this.name,
     this.introduction,
-    this.imgUrl,
   });
 
   final String signupToken;
   final String name;
   final String? introduction;
-  final String? imgUrl;
 
   Map<String, Object?> toJson() {
     return {
       'signupToken': signupToken,
       'name': name,
       if (introduction != null) 'introduction': introduction,
-      if (imgUrl != null) 'imgUrl': imgUrl,
     };
   }
 }

--- a/lib/features/login/data/repositories/auth_repository.dart
+++ b/lib/features/login/data/repositories/auth_repository.dart
@@ -4,6 +4,7 @@ import 'package:commonplant_frontend/core/network/auth_token_store.dart';
 import 'package:commonplant_frontend/features/login/data/datasources/auth_remote_data_source.dart';
 import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
 import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final authRemoteDataSourceProvider = Provider<AuthRemoteDataSource>((ref) {
@@ -34,8 +35,11 @@ class AuthRepository {
     return result;
   }
 
-  Future<AuthResult> register(RegisterRequest request) async {
-    final data = await _remoteDataSource.register(request);
+  Future<AuthResult> register(
+    RegisterRequest request, {
+    MultipartFile? image,
+  }) async {
+    final data = await _remoteDataSource.register(request, image: image);
     final result = authResultFromJson(
       jsonObjectFromResponse(data, context: '회원가입'),
     );

--- a/test/features/login/data/datasources/auth_remote_data_source_test.dart
+++ b/test/features/login/data/datasources/auth_remote_data_source_test.dart
@@ -1,0 +1,84 @@
+import 'dart:typed_data';
+
+import 'package:commonplant_frontend/features/login/data/datasources/auth_remote_data_source.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthRemoteDataSource.register', () {
+    test('register JSON part를 application/json multipart로 전송한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = AuthRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.register(
+        const RegisterRequest(signupToken: 'signup-token', name: '커먼'),
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+      final registerPart = formData.files.singleWhere(
+        (file) => file.key == 'register',
+      );
+
+      expect(adapter.latestOptions.method, 'POST');
+      expect(adapter.latestOptions.path, '/auth/register');
+      expect(
+        adapter.latestOptions.contentType,
+        startsWith('multipart/form-data'),
+      );
+      expect(registerPart.value.contentType?.mimeType, 'application/json');
+      expect(formData.files.map((file) => file.key), isNot(contains('image')));
+    });
+
+    test('선택한 image를 별도 multipart part로 전달한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = AuthRemoteDataSource(_dioWith(adapter));
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'profile.png',
+      );
+
+      await dataSource.register(
+        const RegisterRequest(signupToken: 'signup-token', name: '커먼'),
+        image: image,
+      );
+
+      final formData = adapter.latestOptions.data as FormData;
+      final imagePart = formData.files.singleWhere(
+        (file) => file.key == 'image',
+      );
+
+      expect(imagePart.value, same(image));
+    });
+  });
+}
+
+Dio _dioWith(HttpClientAdapter adapter) {
+  return Dio(BaseOptions(baseUrl: 'https://example.com'))
+    ..httpClientAdapter = adapter;
+}
+
+class _CapturingAdapter implements HttpClientAdapter {
+  late RequestOptions latestOptions;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    latestOptions = options;
+
+    return ResponseBody.fromString(
+      '{"result":{"accessToken":"access-token",'
+      '"refreshToken":"refresh-token","newUser":false}}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}

--- a/test/features/login/data/dtos/auth_requests_test.dart
+++ b/test/features/login/data/dtos/auth_requests_test.dart
@@ -1,0 +1,26 @@
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RegisterRequest', () {
+    test('Swagger 회원가입 JSON 필드만 직렬화한다', () {
+      const request = RegisterRequest(
+        signupToken: 'signup-token',
+        name: '커먼',
+        introduction: '식물을 함께 키워요.',
+      );
+
+      expect(request.toJson(), {
+        'signupToken': 'signup-token',
+        'name': '커먼',
+        'introduction': '식물을 함께 키워요.',
+      });
+    });
+
+    test('선택값인 introduction이 없으면 JSON에서 생략한다', () {
+      const request = RegisterRequest(signupToken: 'signup-token', name: '커먼');
+
+      expect(request.toJson(), {'signupToken': 'signup-token', 'name': '커먼'});
+    });
+  });
+}

--- a/test/features/login/data/repositories/auth_repository_test.dart
+++ b/test/features/login/data/repositories/auth_repository_test.dart
@@ -1,0 +1,79 @@
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/datasources/auth_remote_data_source.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/data/repositories/auth_repository.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthRepository.register', () {
+    test('선택한 image를 전달하고 성공 응답 token을 저장한다', () async {
+      final dataSource = _RegisterAuthRemoteDataSource();
+      final tokenStore = _MemoryAuthTokenStore();
+      final repository = AuthRepository(dataSource, tokenStore);
+      final image = MultipartFile.fromString(
+        'image-bytes',
+        filename: 'profile.png',
+      );
+
+      final result = await repository.register(
+        const RegisterRequest(signupToken: 'signup-token', name: '커먼'),
+        image: image,
+      );
+
+      expect(dataSource.latestImage, same(image));
+      expect(result, isA<AuthenticatedResult>());
+      expect(tokenStore.accessToken, 'access-token');
+      expect(tokenStore.refreshToken, 'refresh-token');
+    });
+  });
+}
+
+class _RegisterAuthRemoteDataSource extends AuthRemoteDataSource {
+  _RegisterAuthRemoteDataSource() : super(Dio());
+
+  MultipartFile? latestImage;
+
+  @override
+  Future<Object?> register(
+    RegisterRequest request, {
+    MultipartFile? image,
+  }) async {
+    latestImage = image;
+
+    return {
+      'result': {
+        'accessToken': 'access-token',
+        'refreshToken': 'refresh-token',
+        'newUser': false,
+      },
+    };
+  }
+}
+
+class _MemoryAuthTokenStore implements AuthTokenStore {
+  String? accessToken;
+  String? refreshToken;
+
+  @override
+  Future<void> clear() async {
+    accessToken = null;
+    refreshToken = null;
+  }
+
+  @override
+  Future<String?> readAccessToken() async => accessToken;
+
+  @override
+  Future<String?> readRefreshToken() async => refreshToken;
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}


### PR DESCRIPTION
## 변경 내용

- `RegisterRequest`에서 Swagger request에 없는 `imgUrl`을 제거했습니다.
- `POST /auth/register`를 JSON body에서 `multipart/form-data`로 전환했습니다.
- required `register` JSON part에 `Content-Type: application/json`을 지정했습니다.
- optional `image` part를 datasource와 repository 경계에 추가했습니다.
- DTO, datasource, repository unit test 5개를 추가했습니다.
- API 문서와 후속 체크리스트에서 API-AUTH 상태를 `Done`으로 갱신했습니다.

## 범위 경계

- 프로필 설정 화면의 샘플 이미지 상태를 실제 `MultipartFile`로 바꾸지 않습니다.
- 화면 submit과 AuthRepository 연결은 포함하지 않습니다.
- dev signup token이 필요한 실제 API 호출과 remote integration test는 포함하지 않습니다.
- response example `isNewUser`와 schema `newUser`의 호환 파싱은 기존 경계를 유지합니다.

## 검증

- `fvm dart format --output=none --set-exit-if-changed .` — 260개 파일, 변경 없음
- `fvm flutter analyze` — 통과
- Auth DTO/datasource/repository 및 response 대상 테스트 7개 — 통과
- `fvm flutter test` — 263개 통과, golden 1개 skip
- `git diff --check` — 통과
- dev OpenAPI: register JSON `application/json`, image `application/octet-stream`, image optional 재확인

Closes #216
