### PR TITLE
[Task] Android smoke 연속 안정성 검증

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 - `flutter analyze`
 - `flutter test`
 
-`Android Integration Smoke`는 Android emulator에서 API 비사용 앱 시작과 route 이동을 확인하는 수동 workflow입니다. 안정성과 실행 비용을 확인하는 pilot 동안에는 PR 필수 게이트와 분리합니다.
+`Android Integration Smoke`는 Android emulator에서 API 비사용 앱 시작과 route 이동을 확인하는 수동 workflow입니다. #218에서 `develop` 수동 실행 3회가 재시도 없이 연속 성공했고 job 실행 시간은 5분 1초~7분 32초였습니다. 실행 시간·비용 수용과 팀 합의가 남아 있으므로 required check로 자동 승격하지 않고 수동 workflow로 유지합니다.
 
 ## 진행해야 할 작업 내역
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -15,7 +15,8 @@
 | --- | --- | --- | --- | --- | --- |
 | [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | 네 QA profile을 적용한다. 확인된 compact overflow와 대상 회귀 테스트는 #197에서 완료했다. | Decided |
 | [x] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator와 workflow 기반 baseline 갱신 규칙을 적용한다. | Decided |
-| [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke, 명시적 device 실행, 수동 workflow와 required check 승격 조건을 적용한다. | Decided |
+| [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke와 수동 workflow를 도입했고, #218에서 `develop` 3회 연속 성공을 확인했다. | Decided |
+| [ ] | TEST-02-A-GATE | Android smoke의 PR required check 승격 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #218에서 재시도 없는 3회 성공과 5분 1초~7분 32초의 job 실행 시간을 확인했다. 팀이 시간·비용을 수용하고 승격에 동의한 뒤에만 repository 설정 변경을 별도 진행한다. | Ready |
 | [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #213에서 dev API URL은 확인했다. 테스트 계정, seed/cleanup, secret과 데이터 격리 정책이 준비될 때까지 remote end-to-end workflow를 보류한다. | Blocked |
 
 ## 릴리즈와 환경

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -20,7 +20,7 @@
 | Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer의 exact 비교와 수동 baseline workflow run `31811426737` 성공 확인 |
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
-| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke run `32243828623` 성공, 연속 3회 기준 전이라 아직 required check가 아님 |
+| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke `develop` 수동 run 3회 연속 성공. 시간·비용 수용과 팀 합의 전까지 required check가 아님 |
 | 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 통과 | Ubuntu PR run `32627288004`에서 canonical golden 포함 결과 확인 |
 | Remote API 환경 | dev API `https://commonplant-dev.okbear.dev/api/v1`과 환경값 주입 지점 확인 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책은 Blocked |
 
@@ -33,7 +33,8 @@
 | 3 | TEST-01 폰트 선행 | 한글 Pretendard asset과 라이선스 정리 | QA-01 적용 후속 | Done (#200) |
 | 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | Done (#199) |
 | 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | Done (#203) |
-| 6 | TEST-02-B | dev API 기반 integration workflow와 핵심 CRUD flow 연결 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책 | Blocked |
+| 6 | TEST-02-A-GATE | Android smoke를 PR required check로 승격할지 결정 | 3회 연속 성공, 로그 구분, 실행 시간 측정 | Ready (#218, 팀 결정 대기) |
+| 7 | TEST-02-B | dev API 기반 integration workflow와 핵심 CRUD flow 연결 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책 | Blocked |
 
 TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
 
@@ -135,8 +136,15 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 - `integration_test/app_smoke_test.dart`에서 production `main()`을 실행하고 `COMMONPLANT_USE_API=false`를 assertion으로 고정한다.
 - Home의 기본 콘텐츠를 확인한 뒤 `장소 요청 3건`을 탭해 장소 친구 요청 화면까지 이동한다.
 - 로컬 명령은 Android device ID를 명시하고, GitHub Actions는 Android API 35 Google APIs x86_64 Pixel 6 emulator의 수동 workflow로 실행한다.
-- `develop`의 첫 수동 run `32243828623`은 성공했다.
-- `develop` 수동 run이 assertion 실패나 재시도 없이 3회 연속 성공하고 로그 구분, 실행 시간·비용, 팀 동의를 확인한 뒤에만 required check 승격을 검토한다.
+- `develop` 수동 run 3회가 assertion 실패나 재시도 없이 연속 성공했다.
+- emulator 준비와 Flutter test 실행이 로그에서 구분되며, 측정된 job 실행 시간은 5분 1초~7분 32초다.
+- 연속 성공과 로그 구분 조건은 충족했다. 팀이 실행 시간·비용을 수용하고 required check 승격에 동의한 뒤에만 repository 설정 변경을 별도 진행한다.
+
+| 순서 | run | `develop` head | smoke job | 결과 | 재시도 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | [`32243828623`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32243828623) | `3a8781b` | 6분 36초 | Success | 없음 |
+| 2 | [`32628473811`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628473811) | `34845e9` | 7분 32초 | Success | 없음 |
+| 3 | [`32628815566`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628815566) | `34845e9` | 5분 1초 | Success | 없음 |
 
 ### 백엔드 준비 전 Blocked 범위
 

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -182,6 +182,7 @@ Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게
 | TEST-02-A smoke | `61fd571` | `integration_test` 의존성과 API 비사용 Home → 장소 친구 요청 실제 앱 smoke 추가 | Android API 36.1 `emulator-5554` target test, `fvm flutter analyze` 통과 |
 | TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
 | TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
+| TEST-02-A 안정성 | `256e029` | `develop` 수동 run 3회 연속 성공 근거와 required check 결정 경계 정리 | run `32243828623`, `32628473811`, `32628815566` 최초 시도 성공, `git diff --check` |
 | TEST-02-B dev 환경 | `6a9fbc9` | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -227,6 +227,16 @@ gh run view <run-id> --log
 3. 실행 시간과 GitHub Actions 비용이 팀이 수용할 수 있는 범위입니다.
 4. 팀이 required check 승격에 동의합니다.
 
+#218에서 아래 `develop` 수동 run을 겹치지 않게 순차 실행했고, 모두 최초 시도에서 성공했습니다.
+
+| 순서 | run | `develop` head | smoke job | 결과 | 재시도 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | [`32243828623`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32243828623) | `3a8781b` | 6분 36초 | Success | 없음 |
+| 2 | [`32628473811`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628473811) | `34845e9` | 7분 32초 | Success | 없음 |
+| 3 | [`32628815566`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628815566) | `34845e9` | 5분 1초 | Success | 없음 |
+
+연속 3회 성공과 로그 구분 조건은 충족했습니다. emulator 설치·cold boot와 실제 `flutter test` 명령이 같은 smoke step 안에서도 구분되어 runner 인프라와 앱 assertion의 실패 지점을 판별할 수 있습니다. 다만 job 하나가 5분 1초~7분 32초 걸리므로, 팀이 이 피드백 시간과 Actions 비용을 수용하고 required check 승격에 동의하기 전까지는 수동 workflow를 유지합니다. 승격 결정과 repository 설정 변경은 별도 작업으로 진행합니다.
+
 ### TEST-02-B remote API end-to-end
 
 remote API를 사용하는 핵심 사용자 흐름은 아래 조건이 준비된 뒤 추가합니다.
@@ -283,7 +293,7 @@ feature 구조와 test 구조를 비슷하게 맞추면 찾기 쉽습니다.
 
 로컬에 `.fvmrc`와 FVM이 있으면 lefthook도 `fvm` 명령을 우선 사용합니다.
 
-GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. API 비사용 Android integration smoke는 별도 수동 workflow로 검증하며 승격 조건을 충족하기 전에는 required check가 아닙니다. Remote integration test는 백엔드 실행 환경이 준비된 뒤 release candidate 검증 또는 별도 CI job으로 연결합니다.
+GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. API 비사용 Android integration smoke는 3회 연속 성공과 로그 구분을 확인했지만, 실행 시간·비용 수용과 팀 합의 전까지 별도 수동 workflow로 유지합니다. Remote integration test는 백엔드 실행 환경이 준비된 뒤 release candidate 검증 또는 별도 CI job으로 연결합니다.
 
 ## 체크리스트
 
@@ -300,5 +310,5 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 ## 후속 결정 필요
 
 - TEST-01 pilot은 #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator로 확정했습니다. 추가 화면과 viewport baseline은 회귀 위험과 유지 비용을 확인해 별도 이슈로 확장합니다.
-- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고 `develop` run `32243828623`이 성공했습니다. 연속 3회 성공 기준을 충족하기 전에는 PR 필수 게이트로 승격하지 않습니다.
+- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고, #218에서 `develop` run 3회의 연속 성공과 로그 구분을 확인했습니다. required check 승격은 실행 시간·비용 수용과 팀 합의가 남아 있어 `Ready` 상태로 별도 결정합니다.
 - TEST-02-B의 dev API URL은 #213에서 확인했습니다. 테스트 계정, seed/cleanup, secret 정책이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결하며, 그전 상태는 `Blocked`입니다.


### PR DESCRIPTION
## 작업 내용
- Android integration smoke를 최신 `develop`에서 두 차례 순차 실행했습니다.
- 기존 run을 포함한 3회 연속 성공, head SHA, job 실행 시간, 재시도 여부를 문서화했습니다.
- required check 승격을 `TEST-02-A-GATE`로 분리해 팀 결정 대기 상태로 정리했습니다.
- README, 테스트 가이드, 품질 계획, 후속 결정 체크리스트와 커밋별 작업 이력을 갱신했습니다.

## 검증 결과
- run `32243828623`: Success, 6분 36초, 재시도 없음
- run `32628473811`: Success, 7분 32초, 재시도 없음
- run `32628815566`: Success, 5분 1초, 재시도 없음
- emulator 준비와 실제 Flutter test 실행 로그 구분 확인
- `git diff --check` 통과

## 결정 경계
- 연속 성공과 로그 구분 조건은 충족했습니다.
- 실행 시간·Actions 비용 수용 및 팀 합의 전까지 수동 workflow를 유지합니다.
- branch protection 또는 required check 설정은 이번 PR에서 변경하지 않습니다.

Closes #218
