### PR TITLE
[Task] remote integration 준비 계약 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ tool/
 - 인증 토큰은 `flutter_secure_storage` 기반 보관을 기본 방향으로 합니다.
 - 백엔드 에러 코드는 아직 미정이므로, 확정 전까지는 공통 에러 타입으로 감쌀 수 있는 구조를 우선합니다.
 - Golden test는 `OnboardingPage`의 `375×812`, DPR 1 pilot과 Ubuntu canonical baseline을 기준으로 사용합니다.
-- Integration test는 remote API를 사용하지 않는 Home 진입과 장소 친구 요청 이동을 Android smoke pilot으로 사용합니다. dev API URL은 준비됐지만 테스트 계정, seed/cleanup과 secret 정책이 필요한 end-to-end 범위는 준비 전까지 `Blocked`입니다.
+- Integration test는 remote API를 사용하지 않는 Home 진입과 장소 친구 요청 이동을 Android smoke pilot으로 사용합니다. dev API URL은 준비됐지만 [remote integration test 준비 계약](docs/remote-integration-test-readiness.md)의 인증, 데이터 격리, cleanup, secret 승인 gate가 충족되기 전까지 end-to-end 범위는 `Blocked`입니다.
 
 ## 프로젝트 문서
 
@@ -180,6 +180,7 @@ tool/
 | [폼 검증 및 에러 메시지 작성 기준](docs/form-validation-error-guide.md) | 입력 검증 위치, helper/error 메시지, 서버 에러 처리 기준 |
 | [테스트 작성 기준](docs/testing-guide.md) | unit/widget test 작성 기준, 실행 명령, CI/pre-commit 연계 |
 | [품질·테스트 후속 작업 계획](docs/quality-testing-follow-up-plan.md) | QA 필수 viewport, golden/integration test 도입 순서, Ready/Blocked 경계 |
+| [Remote integration test 준비 계약](docs/remote-integration-test-readiness.md) | dev API E2E의 인증, fixture, cleanup, secret과 단계별 도입 gate |
 | [lib 구조 리팩토링 개선 방향](docs/lib-refactoring-direction.md) | `lib` 구조, Riverpod, 라우팅, feature 경계 리팩토링 진단과 단계별 개선안 |
 | [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md) | 사람이 읽기 쉬운 코드로 개선하기 위한 파일 분해, 우선순위, PR 단위, 리뷰 기준 |
 | [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md) | 1차 완료 후 남은 Place 중심 대형 화면, 라우팅 파라미터, detail action, mapper 경계 개선 계획 |

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -52,6 +52,9 @@
 | Place | `GET /place/{code}/members` 추가 | 친구 관리 화면 후보지만 성공 response schema가 없어 mapper 구현 보류 |
 | Auth register | request/response가 `RegisterRequest`/`RegisterResponse`로 분리 | #216에서 JSON part와 optional image multipart datasource 반영 |
 | Multipart encoding | Auth/User/Plant JSON part에 `application/json` 명시 | 해당 도메인 전송 기준 확인, Place는 encoding 미표기로 추가 확인 유지 |
+| Test environment | 19개 path에 test/seed/fixture/cleanup 전용 endpoint가 없고 login은 소셜 SDK token을 요구 | #220 준비 계약의 인증, 데이터 격리·cleanup gate가 해결되기 전 TEST-02-B 유지 |
+
+TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 `docs/remote-integration-test-readiness.md`에서 관리한다. 이 문서의 endpoint inventory만으로 테스트 계정이나 cleanup 정책이 제공된 것으로 해석하지 않는다.
 
 아래의 추가/삭제/변경 표는 2026-05-25 상세 비교 기록이며, 위 표는 2026-08-23 재확인에서 달라진 항목입니다.
 

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -38,6 +38,11 @@
 | MEMO-01 | Memo | 메모 생성, 목록, 수정, 삭제 API 제공 계획은 무엇인가? | 메모 화면 실데이터 연결 보류 | Open |
 | MEMO-02 | Memo | 메모 이미지 첨부는 어떤 API와 필드로 연결하는가? | 메모 사진 업로드 흐름 보류 | Open |
 | MEMO-03 | Memo | 메모 목록 response의 작성자, 이미지, 작성일, pagination 구조는 무엇인가? | 메모 목록 mapper와 카드 상태 보류 | Open |
+| TESTENV-01 | 테스트 환경 | CI가 개인 소셜 계정 없이 매 run 인증을 발급받는 방법은 무엇인가? | authenticated probe와 UI E2E 보류 | Open |
+| TESTENV-02 | 테스트 환경 | 테스트 token의 TTL, 갱신·재발급·폐기 정책은 무엇인가? | 장시간 run과 만료 복구 보류 | Open |
+| TESTENV-03 | 테스트 환경 | backend 소유 fixture 사용자와 run별 데이터 격리 기준은 무엇인가? | 병렬 실행과 CRUD E2E 보류 | Open |
+| TESTENV-04 | 테스트 환경 | 정상·실패 cleanup과 중단된 run의 TTL 정리 방법은 무엇인가? | dev 데이터 오염 방지 불가 | Open |
+| TESTENV-05 | 테스트 환경 | CI 접근 권한, rate limit, 허용 실행 범위는 무엇인가? | GitHub Environment와 재시도 정책 보류 | Open |
 | ENV-01-A | 환경 | dev backend와 Swagger endpoint는 무엇인가? | 로컬 remote API URL 확정 | Answered |
 | ENV-01-B | 환경 | 백엔드 staging/prod full base URL과 API versioning 정책은 무엇인가? | 배포 환경값 주입 검증 필요 | Open |
 
@@ -281,6 +286,55 @@
 - 프론트 영향: 메모 카드 mapper와 pagination 정책을 정할 수 없다.
 - 확인 질문: 메모 id, 작성자, 작성일, 이미지 url/key, 권한, pagination 필드는 무엇인가?
 - 프론트 반영: 답변 후 memo list provider와 삭제/수정 액션을 API mode로 연결한다.
+- 답변: 미확인
+- 상태: Open
+
+## 테스트 환경
+
+TESTENV 질문의 상세 수용 조건과 단계별 도입 범위는 `docs/remote-integration-test-readiness.md`에서 관리한다. 실제 credential이나 secret 값은 이 문서의 답변에 기록하지 않는다.
+
+### TESTENV-01. CI 인증 bootstrap
+
+- 현재 근거: Swagger `POST /auth/login`은 Google/Kakao/Apple SDK token을 요구하며 test auth endpoint는 없다.
+- 프론트 영향: 개인 계정이나 수동 복사 token 없이 authenticated probe를 반복 실행할 수 없다.
+- 확인 질문: dev CI가 실행마다 기존 테스트 사용자의 짧은 수명 token을 얻을 수 있는 방식은 무엇인가?
+- 프론트 반영: 답변 후 실제 값이 아닌 필요한 secret 종류와 workflow 호출 계약만 문서화한다.
+- 답변: 미확인
+- 상태: Open
+
+### TESTENV-02. 테스트 token lifecycle
+
+- 현재 근거: 로그인은 access/refresh token을 반환하지만 Swagger에는 refresh 재발급과 logout endpoint가 없다.
+- 프론트 영향: token 만료가 앱 실패인지 환경 실패인지 구분할 수 없고 장기 고정 token은 재현성이 없다.
+- 확인 질문: 테스트 token의 TTL, 갱신 또는 재발급, 폐기 방법과 관련 오류 코드는 무엇인가?
+- 프론트 반영: 답변 후 probe timeout, 만료 판정, 재시도 금지 범위를 정한다.
+- 답변: 미확인
+- 상태: Open
+
+### TESTENV-03. Fixture와 run별 데이터 격리
+
+- 현재 근거: 19개 OpenAPI path에 seed/fixture 전용 endpoint가 없고 일부 CRUD endpoint만 있다.
+- 프론트 영향: 공유 사용자와 장소를 수정하면 병렬 run이 충돌하고 실제 dev 데이터를 오염시킬 수 있다.
+- 확인 질문: backend 소유 테스트 사용자, 초기 fixture 범위, run별 소유권 또는 격리 key는 어떻게 제공하는가?
+- 프론트 반영: 답변 후 첫 단계는 공유 fixture의 `GET /users` read-only probe로 제한하고 mutation 범위를 별도 확정한다.
+- 답변: 미확인
+- 상태: Open
+
+### TESTENV-04. Cleanup과 TTL fallback
+
+- 현재 근거: public API 일부에는 delete가 있지만 runner 강제 종료 시 cleanup 실행을 보장할 수 없고 전용 정리 API가 없다.
+- 프론트 영향: 실패 run이 남긴 Place, Plant, Image, Friend 데이터를 안전하게 식별·삭제할 수 없다.
+- 확인 질문: 정상·실패 cleanup 순서와 실행이 중단된 fixture를 정리할 TTL 또는 관리자 수단은 무엇인가?
+- 프론트 반영: 답변 후 `always` cleanup과 cleanup 실패 판정을 workflow에 반영한다.
+- 답변: 미확인
+- 상태: Open
+
+### TESTENV-05. CI 접근과 실행 제한
+
+- 현재 근거: dev Swagger는 공개 접근 가능하지만 authenticated test의 runner IP, rate limit, 허용 시간과 동시 실행 정책은 명시되지 않았다.
+- 프론트 영향: 일시적 429/5xx와 앱 회귀의 구분, concurrency와 재시도 범위를 정할 수 없다.
+- 확인 질문: GitHub-hosted runner 접근 허용 여부, rate limit, 허용 동시 실행 수, 점검 시간대 정책은 무엇인가?
+- 프론트 반영: 답변 후 GitHub Environment, 직렬/병렬 실행, 외부 장애 재시도 정책을 별도 이슈에서 적용한다.
 - 답변: 미확인
 - 상태: Open
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -17,7 +17,7 @@
 | [x] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator와 workflow 기반 baseline 갱신 규칙을 적용한다. | Decided |
 | [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke와 수동 workflow를 도입했고, #218에서 `develop` 3회 연속 성공을 확인했다. | Decided |
 | [ ] | TEST-02-A-GATE | Android smoke의 PR required check 승격 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #218에서 재시도 없는 3회 성공과 5분 1초~7분 32초의 job 실행 시간을 확인했다. 팀이 시간·비용을 수용하고 승격에 동의한 뒤에만 repository 설정 변경을 별도 진행한다. | Ready |
-| [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #213에서 dev API URL은 확인했다. 테스트 계정, seed/cleanup, secret과 데이터 격리 정책이 준비될 때까지 remote end-to-end workflow를 보류한다. | Blocked |
+| [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md`, `docs/remote-integration-test-readiness.md` | #220에서 준비 계약을 정리했다. 인증 bootstrap·token lifecycle·fixture 격리/cleanup·GitHub Environment 승인 후 read-only probe부터 별도 구현한다. | Blocked |
 
 ## 릴리즈와 환경
 
@@ -64,6 +64,7 @@
 | [ ] | API-SEARCH | 주소/식물/사용자 검색 정책 | SEARCH-01, SEARCH-02, SEARCH-03 | 주소 검색, 식물 검색, 친구 추가 검색 UX | Open |
 | [ ] | API-MEMO | Memo CRUD와 이미지 첨부 정책 | MEMO-01, MEMO-02, MEMO-03 | 메모 화면 실데이터 연결 | Open |
 | [x] | API-ENV-DEV | dev 서버 환경값과 Swagger | ENV-01-A | #213에서 dev origin, API base URL과 문서 endpoint를 확인했다. | Decided |
+| [ ] | API-TESTENV | remote integration 테스트 환경 | TESTENV-01~05 | #220에서 최소 준비 계약을 정리했다. 백엔드 인증·fixture·cleanup 답변과 저장소 설정 승인 전까지 TEST-02-B를 보류한다. | Blocked |
 | [ ] | API-ENV-RELEASE | staging/prod 환경값과 versioning | ENV-01-B | staging/prod release 검증은 백엔드 답변 전까지 미확정이다. | Open |
 
 ## 다음 이슈화 기준

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -14,7 +14,7 @@
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
-| 기준 브랜치 | `develop@37501b6` | RELEASE-02 #211, PR #212까지 병합 완료 |
+| 기준 브랜치 | `develop@55b0e1e` | Android smoke 안정성 #218, PR #219까지 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
 | Widget test viewport | `test/helpers/test_viewport.dart`에서 네 QA profile과 DPR 1 설정을 제공하고 compact gap 대상 화면에 적용 | 기존 raw viewport 설정은 관련 화면 수정 시 점진적으로 helper로 전환 |
 | Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer의 exact 비교와 수동 baseline workflow run `31811426737` 성공 확인 |
@@ -22,7 +22,7 @@
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
 | GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke `develop` 수동 run 3회 연속 성공. 시간·비용 수용과 팀 합의 전까지 required check가 아님 |
 | 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 통과 | Ubuntu PR run `32627288004`에서 canonical golden 포함 결과 확인 |
-| Remote API 환경 | dev API `https://commonplant-dev.okbear.dev/api/v1`과 환경값 주입 지점 확인 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책은 Blocked |
+| Remote API 환경 | dev API URL과 #220 준비 계약 확인 | 인증 bootstrap, token lifecycle, fixture 격리·cleanup, GitHub Environment 승인은 Blocked |
 
 ## 의존관계를 반영한 작업 순서
 
@@ -34,9 +34,11 @@
 | 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | Done (#199) |
 | 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | Done (#203) |
 | 6 | TEST-02-A-GATE | Android smoke를 PR required check로 승격할지 결정 | 3회 연속 성공, 로그 구분, 실행 시간 측정 | Ready (#218, 팀 결정 대기) |
-| 7 | TEST-02-B | dev API 기반 integration workflow와 핵심 CRUD flow 연결 | 테스트 계정, seed/cleanup, secret과 데이터 격리 정책 | Blocked |
+| 7 | TEST-02-B-READY | dev API integration의 backend/frontend/CI 준비 계약 정리 | dev URL과 Swagger, 현재 auth 연결 상태 | Done (#220) |
+| 8 | TEST-02-B-PROBE | authenticated `GET /users` read-only readiness probe | 인증 bootstrap, token lifecycle, GitHub Environment 승인 | Blocked |
+| 9 | TEST-02-B-E2E | 실제 auth UI와 도메인별 CRUD flow | frontend auth 연결, 데이터 격리·cleanup, endpoint schema | Blocked |
 
-TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B의 외부 조건이 준비되지 않아도 TEST-02-A의 API 비사용 smoke와 runner 검토는 별도 이슈로 진행할 수 있다.
+TEST-01과 TEST-02-A 사이에 기술적 의존은 없지만 테스트 도입 범위를 한 번에 넓히지 않도록 QA-01, compact-width 회귀 수정, TEST-01, TEST-02 순서를 유지한다. TEST-02-B는 준비 계약, read-only probe, 실제 UI/CRUD E2E로 나눠 외부 조건과 프론트 미구현을 분리한다.
 
 ## QA-01 필수 기준
 
@@ -148,13 +150,14 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 
 ### 백엔드 준비 전 Blocked 범위
 
-- `COMMONPLANT_USE_API=true`인 로그인과 CRUD end-to-end flow
-- 확인된 dev API URL을 CI에 주입할 variable/secret 정책
-- 테스트 전용 계정과 인증 갱신 정책
-- seed 데이터, 중복 방지, 테스트 후 cleanup 정책
-- secret 접근 권한과 외부 API 장애 시 재시도/판정 정책
+- 개인 계정 없이 run마다 유효한 인증을 얻는 bootstrap과 token lifecycle
+- backend 소유 테스트 사용자, run별 데이터 격리 key와 병렬 실행 정책
+- 정상·실패 cleanup과 runner 중단 시 TTL fallback
+- GitHub Environment와 secret 등록 주체의 승인
+- 로그인/프로필 화면의 Auth repository 연결
+- pilot endpoint의 성공 schema와 도메인별 식별자 계약
 
-Blocked 조건이 해소되기 전에는 remote integration job을 PR 필수 게이트에 추가하지 않는다.
+상세 계약과 단계별 도입 범위는 `docs/remote-integration-test-readiness.md`에서 관리한다. Blocked 조건이 해소되기 전에는 remote workflow를 만들거나 PR 필수 게이트에 추가하지 않는다.
 
 ## 외부 기준
 

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -187,5 +187,6 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 | TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
 | TEST-02-A 안정성 | `256e029` | `develop` 수동 run 3회 연속 성공 근거와 required check 결정 경계 정리 | run `32243828623`, `32628473811`, `32628815566` 최초 시도 성공, `git diff --check` |
 | TEST-02-B dev 환경 | `6a9fbc9` | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
+| TEST-02-B 준비 계약 | `1b15325` | backend/frontend/CI gate, read-only probe와 UI/CRUD E2E 경계, TESTENV 질문 정리 | OpenAPI 19개 path와 `GET /users` schema, 현재 Auth 화면 연결 대조, `git diff --check` |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/remote-integration-test-readiness.md
+++ b/docs/remote-integration-test-readiness.md
@@ -1,0 +1,124 @@
+# Remote integration test 준비 계약
+
+이 문서는 dev API를 사용하는 TEST-02-B를 재현 가능한 방식으로 실행하기 위해 백엔드, 프론트엔드, GitHub Actions가 각각 준비해야 할 조건을 정의한다. 실제 계정, secret 값, endpoint 이름은 임의로 만들지 않으며, 조건이 충족되기 전에는 remote workflow를 구현하거나 dev 데이터를 변경하지 않는다.
+
+## 현재 판정
+
+- 기준일: 2026-08-23
+- 추적 이슈: #220
+- dev API 문서 상태: Ready
+- 인증·데이터 준비 상태: Blocked
+- 첫 authenticated probe: Blocked
+- 실제 앱 UI/CRUD end-to-end: Blocked
+
+`Blocked`는 dev 서버가 없다는 의미가 아니다. 서버와 Swagger는 사용할 수 있지만 CI가 매번 새 인증을 얻고, 충돌 없는 데이터를 사용하고, 실패하더라도 정리할 수 있다는 계약이 아직 없다는 뜻이다.
+
+## 확인된 근거
+
+| 영역 | 확인된 사실 | 판정 |
+| --- | --- | --- |
+| dev 환경 | `https://commonplant-dev.okbear.dev/api/v1`과 OpenAPI JSON에 접근 가능 | Ready |
+| endpoint inventory | OpenAPI 19개 path에 test, seed, fixture, cleanup 전용 endpoint가 없음 | Blocked 조건 유지 |
+| 로그인 | `POST /auth/login`은 Google/Kakao/Apple SDK token을 요구 | CI 인증 방식 미확정 |
+| 회원가입 | 신규 사용자 `signupToken`은 10분 동안만 유효 | 장기 fixture 생성 수단으로 사용 불가 |
+| token lifecycle | access token 재발급과 logout endpoint가 Swagger에 없음 | 만료·폐기 대응 미확정 |
+| 앱 인증 계층 | Auth repository, secure token store, bearer interceptor는 구현됨 | data 계층 준비 |
+| 앱 화면 연결 | 로그인 버튼은 repository를 호출하지 않고 `/profile/setup`으로 이동하며 프로필 제출도 local state만 사용 | 실제 UI E2E 선행 구현 필요 |
+| 데이터 API | Place/Plant 삭제 endpoint는 있으나 Place 성공 schema와 multipart 일부가 미확정 | CRUD pilot 보류 |
+| Memo | OpenAPI inventory에 Memo endpoint가 없음 | Memo E2E 불가 |
+
+## Ready gate
+
+아래 gate는 하나라도 충족되지 않으면 다음 단계로 넘어가지 않는다.
+
+| Gate | Ready 조건 | 현재 상태 | 책임 범위 |
+| --- | --- | --- | --- |
+| AUTH-BOOTSTRAP | 개인 계정 없이 CI가 실행마다 유효한 기존 사용자 인증을 얻을 수 있음 | Blocked | Backend/협의 |
+| TOKEN-LIFECYCLE | token TTL, 갱신 또는 재발급, 폐기 방법과 실패 코드가 문서화됨 | Blocked | Backend |
+| DATA-ISOLATION | run별 fixture owner 또는 격리 key가 있고 병렬 실행 충돌이 없음 | Blocked | Backend/Workflow |
+| DATA-CLEANUP | 정상·실패 경로 cleanup과 중단된 run을 위한 TTL fallback이 있음 | Blocked | Backend/Workflow |
+| FRONT-AUTH | 소셜 token 획득, repository 호출, token 저장, 신규·기존 사용자 route가 화면에 연결됨 | Blocked | Frontend |
+| ENDPOINT-SCHEMA | pilot이 사용하는 성공 response와 식별자 계약이 Swagger에 있음 | 부분 Ready | Backend |
+| CI-AUTHORITY | GitHub Environment, secret 등록 주체와 사용 권한을 팀이 승인함 | Blocked | Repository owner/team |
+
+## CI 인증 계약
+
+구현 방식은 백엔드가 아래 중 하나를 선택할 수 있다. 프론트 문서는 특정 endpoint 이름을 먼저 정하지 않는다.
+
+1. dev에서만 활성화되는 테스트 인증 bootstrap이 짧은 수명의 access/refresh token을 발급한다.
+2. 개인 소유가 아닌 소셜 테스트 계정과 자동화 가능한 token 발급·갱신 절차를 제공한다.
+3. CI 전용 credential 교환으로 실행마다 짧은 수명의 사용자 token을 발급한다.
+
+어떤 방식을 선택하더라도 아래 조건은 공통으로 만족해야 한다.
+
+- production에서는 사용할 수 없어야 한다.
+- 개인의 소셜 계정, 브라우저 세션, 수동 복사 token에 의존하지 않아야 한다.
+- 새 workflow run이 이전 run의 access token에 의존하지 않아야 한다.
+- 발급된 token의 TTL이 한 번의 테스트와 cleanup을 마칠 만큼 충분해야 한다.
+- credential과 token이 로그, artifact, screenshot, 앱 binary에 남지 않아야 한다.
+- 권한은 테스트 fixture에 필요한 최소 범위여야 한다.
+
+고정 access token 하나를 GitHub secret에 장기간 저장하는 방식은 만료·폐기·소유권을 재현할 수 없으므로 단독 해결책으로 채택하지 않는다. token을 `--dart-define`으로 전달하는 방식도 빌드 인자와 산출물에 값이 남을 수 있어 사용하지 않는다.
+
+## 데이터 격리와 cleanup 계약
+
+- 테스트 사용자는 실제 사용자와 분리된 backend 소유 fixture여야 한다.
+- 각 run은 GitHub run id와 attempt처럼 충돌하지 않는 실행 식별자를 가져야 한다.
+- 생성 데이터에는 실행 소유권을 추적할 방법이 있어야 하며, 화면 필드 길이 같은 도메인 제약 안에서 표현 방법은 백엔드와 합의한다.
+- 초기 pilot은 공유 fixture를 읽기만 하고 데이터를 수정하지 않는다.
+- CRUD 단계에서는 생성한 resource id를 run 동안 보존하고 자신이 만든 데이터만 역순으로 삭제한다.
+- cleanup은 성공 여부와 무관하게 실행하되, runner 강제 종료로 실행되지 못한 경우를 위한 서버 TTL 또는 관리자 정리 수단이 필요하다.
+- cleanup 실패는 테스트 성공으로 숨기지 않고 별도 실패 유형으로 기록한다.
+- 격리가 검증되기 전에는 workflow를 직렬화하고, 병렬 실행은 backend가 충돌 없음을 보장한 뒤 허용한다.
+
+## 단계별 도입 범위
+
+| 단계 | 범위 | 데이터 변경 | 시작 조건 | TEST-02-B 완료로 계산 |
+| --- | --- | --- | --- | --- |
+| 0 | Swagger/OpenAPI reachability | 없음 | dev URL | 아니오. #213 완료 |
+| 1 | 인증 후 `GET /users` read-only readiness probe | 없음 | AUTH-BOOTSTRAP, TOKEN-LIFECYCLE, CI-AUTHORITY | 아니오. 환경 검증 |
+| 2 | 기존 사용자 로그인 → token 저장 → 인증 route UI smoke | 없음 | FRONT-AUTH와 단계 1 성공 | 부분 완료 |
+| 3 | Place 또는 Plant 단일 CRUD flow | 있음 | DATA-ISOLATION, DATA-CLEANUP, endpoint schema | 도메인별 완료 |
+| 4 | Friend, Image, Memo 확장 | 있음 | 각 도메인 schema와 cleanup | 도메인별 완료 |
+
+첫 remote pilot은 단계 1로 제한한다. `GET /users`는 성공 schema가 있고 데이터 변경이 없으므로 인증과 dev 연결을 가장 작은 범위에서 검증할 수 있다. 이 probe는 Flutter 화면 E2E를 대신하지 않으며, 단계 2 전에는 TEST-02-B를 완료로 표시하지 않는다.
+
+신규 사용자 회원가입은 10분 `signupToken`과 영구 사용자 생성이 결합되므로 첫 pilot으로 사용하지 않는다. Place/Plant CRUD도 인증, 식별자, cleanup이 모두 준비된 뒤 한 도메인씩 추가한다. Memo는 endpoint가 Swagger에 추가되기 전까지 대상에서 제외한다.
+
+## Workflow 도입 기준
+
+외부 조건이 해결되면 첫 workflow는 아래 순서로 도입한다.
+
+1. 팀이 승인한 GitHub Environment와 최소 secret만 사용한다.
+2. `workflow_dispatch` 수동 실행으로 시작하고 fork PR에는 secret을 제공하지 않는다.
+3. 초기에는 dev 환경 run을 직렬화하고 전체 job timeout을 둔다.
+4. 인증 발급, readiness probe, cleanup을 로그 step으로 구분한다.
+5. response body, header, command line에 credential이나 token을 출력하지 않는다.
+6. 앱 assertion 실패를 재실행으로 덮지 않으며, 429/5xx 같은 외부 장애 재시도 정책은 백엔드 합의 후 별도로 둔다.
+7. 안정성과 비용을 검증하기 전에는 PR required check로 승격하지 않는다.
+
+repository Environment 생성, secret 등록, branch protection 변경은 권한을 가진 팀 구성원의 명시적 승인 후 별도 작업으로 진행한다.
+
+## 실패 판정
+
+| 실패 | 분류 | 기본 처리 |
+| --- | --- | --- |
+| 인증 발급 401/403 | 인증 계약 실패 | 재시도 없이 실패, token 원문 미출력 |
+| authenticated probe 401 | token TTL/전달 실패 | 재시도 없이 실패 |
+| 429 또는 일시적 5xx | 외부 환경 후보 | 합의된 횟수만 재시도하고 원인 기록 |
+| response schema/assertion 불일치 | 앱/API 계약 실패 | 재시도 없이 실패 |
+| cleanup 실패 | 데이터 위생 실패 | run 실패 처리 후 fixture owner에게 알림 |
+| runner/emulator provisioning 실패 | CI 인프라 실패 | 앱 실패와 구분해 기록 |
+
+## Blocked 해제 체크리스트
+
+- [ ] CI가 개인 계정 없이 실행마다 인증을 발급받을 수 있다.
+- [ ] token TTL, 갱신/재발급, 폐기와 오류 코드가 문서화되어 있다.
+- [ ] backend 소유 테스트 사용자와 데이터 사용 범위가 정해져 있다.
+- [ ] run별 격리 key와 정상·실패 cleanup, TTL fallback이 준비되어 있다.
+- [ ] GitHub Environment와 secret 등록 주체가 승인되었다.
+- [ ] 단계 1 read-only probe의 request/response와 성공 기준이 합의되었다.
+- [ ] 단계 2 전에 로그인/프로필 화면의 Auth repository 연결이 완료되었다.
+- [ ] 실제 credential이나 secret 값은 저장소 문서와 이슈에 기록하지 않았다.
+
+모든 항목이 확인되면 TEST-02-B를 `Ready`로 바꾸고, 단계 1 workflow와 단계 2 프론트 구현을 각각 별도 이슈로 진행한다.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -239,29 +239,21 @@ gh run view <run-id> --log
 
 ### TEST-02-B remote API end-to-end
 
-remote API를 사용하는 핵심 사용자 흐름은 아래 조건이 준비된 뒤 추가합니다.
+remote API의 상세 준비 조건은 [Remote integration test 준비 계약](remote-integration-test-readiness.md)에서 관리합니다. dev API URL은 준비됐지만 아래 단계는 서로 다른 검증으로 취급합니다.
 
-- dev API base URL `https://commonplant-dev.okbear.dev/api/v1`은 확정되어 있습니다.
-- 테스트 전용 계정과 seed 데이터 또는 테스트 후 정리 방식이 준비되어 있습니다.
-- Android emulator, iOS simulator, 실제 기기, 또는 GitHub Actions runner 중 실행 환경이 정해져 있습니다.
-- 네트워크 실패, 인증 만료, 데이터 중복이 테스트 결과를 불안정하게 만들지 않도록 격리 전략이 있습니다.
+| 단계 | 범위 | 현재 상태 |
+| --- | --- | --- |
+| Swagger/OpenAPI reachability | dev 문서와 base URL 접근 | Done (#213) |
+| authenticated read-only probe | 실행마다 발급한 token으로 `GET /users` 확인 | Blocked |
+| 실제 앱 auth UI smoke | 소셜 로그인, repository, token 저장, route 연결 | Blocked |
+| Place/Plant CRUD | run별 격리 데이터 생성과 항상 실행되는 cleanup | Blocked |
+| Friend/Image/Memo 확장 | schema와 도메인별 cleanup 확보 | Blocked |
 
-우선 도입 대상은 아래 흐름으로 제한합니다.
+첫 remote pilot은 데이터 변경이 없는 authenticated read-only probe로 제한합니다. 이는 인증과 dev 연결 준비를 확인하는 workflow-level probe이며 Flutter 화면 E2E 완료로 계산하지 않습니다. 실제 앱 smoke는 로그인/프로필 화면이 Auth repository에 연결된 뒤 별도 이슈로 추가합니다.
 
-- 로그인과 프로필 설정 smoke flow
-- 장소 생성/수정/삭제 flow
-- 식물 등록/수정/삭제 flow
-- 메모 작성/삭제 flow
+고정 access token이나 개인 소셜 계정을 장기 secret으로 사용하지 않습니다. credential/token을 `--dart-define`으로 전달하거나 앱 binary, 로그, artifact에 남기는 방식도 사용하지 않습니다. 팀이 승인한 인증 bootstrap, token lifecycle, fixture 격리와 cleanup, GitHub Environment가 모두 준비되기 전에는 실행 가능한 remote 명령이나 workflow를 저장소에 추가하지 않습니다.
 
-테스트 파일은 `integration_test/` 아래에 플로우 단위로 둡니다. remote API를 사용하는 경우 실행 명령은 환경값을 명시합니다.
-
-```bash
-fvm flutter test integration_test \
-  --dart-define=COMMONPLANT_USE_API=true \
-  --dart-define=COMMONPLANT_API_BASE_URL=https://commonplant-dev.okbear.dev/api/v1
-```
-
-dev API URL 조건은 해소됐습니다. 테스트 계정, seed/cleanup, secret과 데이터 격리 정책이 필요한 end-to-end flow는 나머지 조건이 준비될 때까지 `Blocked`입니다. 준비 전 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다.
+Blocked 기간의 회귀 검증은 unit/widget test와 feature별 Provider override를 사용합니다. 환경 조건이 해결되면 read-only probe, 실제 auth UI, 단일 도메인 CRUD 순서로 각각 별도 이슈에서 진행합니다.
 
 ## 테스트 파일 네이밍
 
@@ -311,4 +303,4 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 
 - TEST-01 pilot은 #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator로 확정했습니다. 추가 화면과 viewport baseline은 회귀 위험과 유지 비용을 확인해 별도 이슈로 확장합니다.
 - TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고, #218에서 `develop` run 3회의 연속 성공과 로그 구분을 확인했습니다. required check 승격은 실행 시간·비용 수용과 팀 합의가 남아 있어 `Ready` 상태로 별도 결정합니다.
-- TEST-02-B의 dev API URL은 #213에서 확인했습니다. 테스트 계정, seed/cleanup, secret 정책이 준비되면 remote integration test workflow를 release 검증 또는 별도 CI job으로 연결하며, 그전 상태는 `Blocked`입니다.
+- TEST-02-B의 dev API URL은 #213에서 확인했고 #220에서 인증, token lifecycle, 데이터 격리·cleanup, secret 승인 gate를 구체화했습니다. 첫 단계는 authenticated read-only probe이며, 외부 조건이 준비되기 전 상태는 `Blocked`입니다.


### PR DESCRIPTION
## 작업 내용
- TEST-02-B의 backend/frontend/CI 준비 계약을 새 문서로 정리했습니다.
- Swagger 19개 path와 현재 Auth 화면·repository 연결 상태를 대조했습니다.
- 인증 bootstrap, token lifecycle, fixture 격리, cleanup, CI 승인 gate를 분리했습니다.
- 첫 remote pilot을 authenticated `GET /users` read-only probe로 제한했습니다.
- 환경 probe, 실제 auth UI smoke, 도메인별 CRUD E2E를 서로 다른 단계로 구분했습니다.
- README, 테스트 가이드, 품질 계획, Swagger 참고, 백엔드 질문, 후속 체크리스트와 커밋별 이력을 갱신했습니다.

## 판정
- dev API와 `GET /users` 성공 schema: Ready
- CI 인증 발급·갱신: Blocked
- fixture 격리·cleanup: Blocked
- 로그인/프로필 Auth repository 화면 연결: Blocked
- GitHub Environment/secret 등록 승인: Blocked
- TEST-02-B 전체: Blocked 유지

## 제외 사항
- dev 서버 데이터 생성·수정·삭제 없음
- 실제 계정, credential, secret 생성·등록 없음
- remote workflow 추가 없음
- repository Environment나 branch protection 변경 없음
- 로그인/프로필 UI 구현 없음

## 검증
- dev OpenAPI 19개 path 재확인
- `GET /users` bearer security, `UserJsonResponse`, 401 계약 확인
- 현재 LoginPage, AuthRepository, token store/interceptor 연결 상태 대조
- `git diff develop...HEAD --check` 통과

Closes #220
