### PR TITLE
Chore: 기본 Flutter CI 필수 게이트 설정 #224

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -2,7 +2,11 @@ name: Flutter CI
 
 on:
   pull_request:
+    branches:
+      - develop
   push:
+    branches:
+      - develop
 
 jobs:
   quality:

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 - `flutter analyze`
 - `flutter test`
 
-`Android Integration Smoke`는 Android emulator에서 API 비사용 앱 시작과 route 이동을 확인하는 수동 workflow입니다. #218에서 `develop` 수동 실행 3회가 재시도 없이 연속 성공했고 job 실행 시간은 5분 1초~7분 32초였습니다. 실행 시간·비용 수용과 팀 합의가 남아 있으므로 required check로 자동 승격하지 않고 수동 workflow로 유지합니다.
+기본 `Flutter CI / quality`는 `develop` 대상 PR에서 자동 실행되는 required check입니다. `develop` push에서도 병합 후 통합 상태를 다시 검증하며, feature branch push와 PR 이벤트의 중복 실행은 만들지 않습니다.
+
+`Android Integration Smoke`는 Android emulator에서 API 비사용 앱 시작과 route 이동을 확인하는 수동 workflow입니다. #218에서 `develop` 수동 실행 3회가 재시도 없이 연속 성공했고 job 실행 시간은 5분 1초~7분 32초였습니다. #224에서 기본 Flutter CI만 필수 게이트로 사용하고 Android smoke는 관련 변경과 release candidate에서 선택 실행하기로 결정했습니다.
 
 ## 진행해야 할 작업 내역
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -16,7 +16,7 @@
 | [x] | QA-01 | Figma 기준 해상도 외 QA 필수 디바이스 목록 | `docs/screen-publishing-rules.md`, `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | 네 QA profile을 적용한다. 확인된 compact overflow와 대상 회귀 테스트는 #197에서 완료했다. | Decided |
 | [x] | TEST-01 | full-screen golden test 기준 크기 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator와 workflow 기반 baseline 갱신 규칙을 적용한다. | Decided |
 | [x] | TEST-02-A | API 비사용 integration smoke와 runner | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #203에서 실제 앱의 Home → 장소 친구 요청 Android smoke와 수동 workflow를 도입했고, #218에서 `develop` 3회 연속 성공을 확인했다. | Decided |
-| [ ] | TEST-02-A-GATE | Android smoke의 PR required check 승격 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #218에서 재시도 없는 3회 성공과 5분 1초~7분 32초의 job 실행 시간을 확인했다. 팀이 시간·비용을 수용하고 승격에 동의한 뒤에만 repository 설정 변경을 별도 진행한다. | Ready |
+| [x] | TEST-02-A-GATE | Android smoke의 PR required check 승격 | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md` | #224에서 기본 `Flutter CI / quality`만 `develop` required check로 설정하고 Android smoke는 관련 변경과 release candidate에서 선택 실행하는 수동 workflow로 유지하기로 결정했다. | Decided |
 | [ ] | TEST-02-B | remote API integration 실행 환경과 workflow | `docs/testing-guide.md`, `docs/quality-testing-follow-up-plan.md`, `docs/remote-integration-test-readiness.md` | #220에서 준비 계약을 정리했다. 인증 bootstrap·token lifecycle·fixture 격리/cleanup·GitHub Environment 승인 후 read-only probe부터 별도 구현한다. | Blocked |
 
 ## 릴리즈와 환경

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -44,6 +44,18 @@ git switch -c feature/place-list
 
 `develop` 브랜치는 다음 배포를 준비하는 통합 브랜치이며, 모든 기능 브랜치는 `develop`에서 시작합니다.
 
+## develop 품질 게이트
+
+`develop` branch protection은 GitHub Actions app이 생성하는 `Flutter CI / quality` check를 필수로 요구하며 관리자에게도 같은 기준을 적용합니다. 이 check는 `develop` 대상 PR에서 아래 검증을 실행합니다.
+
+- `flutter pub get`
+- `flutter analyze`
+- `flutter test`
+
+feature branch의 단순 push에서는 기본 CI를 별도로 실행하지 않습니다. PR을 열거나 새 commit을 push하면 `pull_request` 이벤트로 검증하고, `develop` 병합 후에는 `push` 이벤트로 통합 상태를 다시 확인합니다. 최신 `develop` 반영 강제, 리뷰 승인 수, 대화 해결 같은 병합 정책은 이번 품질 게이트 설정에 포함하지 않습니다.
+
+`Android Integration Smoke`는 required check가 아니며 관련 Android/app shell/route 변경과 release candidate에서 수동 실행합니다. required check나 branch protection 범위를 바꿀 때는 권한을 가진 팀 구성원의 승인을 받은 뒤 저장소 변경 이슈와 분리해 적용 결과를 기록합니다.
+
 ## GitHub 이슈 기반 작업 흐름
 
 코드, 문서, 설정 등 저장소 변경이 필요한 요구사항은 GitHub 이슈를 기준으로 추적합니다. 단순 질의, 현황 확인, 명시적으로 보류된 요청은 이슈 생성 없이 답변할 수 있습니다.

--- a/docs/quality-testing-follow-up-plan.md
+++ b/docs/quality-testing-follow-up-plan.md
@@ -10,18 +10,18 @@
 - 새 테스트 종류를 PR 필수 게이트로 올리기 전 재현 가능한 로컬 실행 방법과 CI runner를 먼저 확보한다.
 - 각 항목은 별도 GitHub 이슈와 `develop` 기반 브랜치에서 진행한다.
 
-## 2026-08-23 현재 상태
+## 2026-08-25 현재 상태
 
 | 점검 항목 | 현재 상태 | 판단 |
 | --- | --- | --- |
-| 기준 브랜치 | `develop@55b0e1e` | Android smoke 안정성 #218, PR #219까지 병합 완료 |
+| 기준 브랜치 | `develop@5af4b9b` | production 제출 승인 경계 #222, PR #223까지 병합 완료 |
 | 화면 기준 크기 | `AppSizes.mobileWidth` 375, `AppSizes.mobileHeight` 812 | Figma 기준 viewport로 유지 |
 | Widget test viewport | `test/helpers/test_viewport.dart`에서 네 QA profile과 DPR 1 설정을 제공하고 compact gap 대상 화면에 적용 | 기존 raw viewport 설정은 관련 화면 수정 시 점진적으로 helper로 전환 |
 | Golden test | #199에서 `OnboardingPage` `375×812`, DPR 1 baseline과 Pretendard helper 구현 | Ubuntu canonical renderer의 exact 비교와 수동 baseline workflow run `31811426737` 성공 확인 |
 | Font/asset | 한글 포함 Pretendard v1.3.9 static OTF 4종과 OFL을 `pubspec.yaml` 및 저장소에 등록 | #200에서 Hangul glyph와 Android/iOS packaging 검증 완료 |
 | Integration test | #203에서 SDK 의존성, API 비사용 Home → 장소 친구 요청 smoke 추가 | Android API 36.1 `emulator-5554` 로컬 실행 통과 |
-| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | Android smoke `develop` 수동 run 3회 연속 성공. 시간·비용 수용과 팀 합의 전까지 required check가 아님 |
-| 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 통과 | Ubuntu PR run `32627288004`에서 canonical golden 포함 결과 확인 |
+| GitHub Actions | 기본 Flutter CI, 수동 `Golden Baseline`, 수동 `Android Integration Smoke` workflow 제공 | #224에서 기본 `Flutter CI / quality`를 `develop` required check로 설정하고 Android smoke는 수동 유지 |
+| 기본 품질 게이트 | #216 기준 macOS에서 unit/widget/asset 263개 통과와 golden 1개 skip, Ubuntu에서 golden 포함 264개 통과 | Ubuntu PR run `32627288004`에서 canonical golden 포함 결과를 확인했고 `quality` check를 branch protection에 연결 |
 | Remote API 환경 | dev API URL과 #220 준비 계약 확인 | 인증 bootstrap, token lifecycle, fixture 격리·cleanup, GitHub Environment 승인은 Blocked |
 
 ## 의존관계를 반영한 작업 순서
@@ -33,7 +33,7 @@
 | 3 | TEST-01 폰트 선행 | 한글 Pretendard asset과 라이선스 정리 | QA-01 적용 후속 | Done (#200) |
 | 4 | TEST-01 | full-screen golden 대상 화면, baseline, 갱신 규칙 도입 | TEST-01 폰트 선행 | Done (#199) |
 | 5 | TEST-02-A | remote API를 사용하지 않는 integration smoke와 수동 Android runner 도입 | 없음. 우선순위상 TEST-01 다음 | Done (#203) |
-| 6 | TEST-02-A-GATE | Android smoke를 PR required check로 승격할지 결정 | 3회 연속 성공, 로그 구분, 실행 시간 측정 | Ready (#218, 팀 결정 대기) |
+| 6 | TEST-02-A-GATE | Android smoke를 PR required check로 승격할지 결정 | 3회 연속 성공, 로그 구분, 실행 시간 측정 | Decided (#224, 기본 CI required·Android smoke 수동) |
 | 7 | TEST-02-B-READY | dev API integration의 backend/frontend/CI 준비 계약 정리 | dev URL과 Swagger, 현재 auth 연결 상태 | Done (#220) |
 | 8 | TEST-02-B-PROBE | authenticated `GET /users` read-only readiness probe | 인증 bootstrap, token lifecycle, GitHub Environment 승인 | Blocked |
 | 9 | TEST-02-B-E2E | 실제 auth UI와 도메인별 CRUD flow | frontend auth 연결, 데이터 격리·cleanup, endpoint schema | Blocked |
@@ -140,7 +140,7 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 - 로컬 명령은 Android device ID를 명시하고, GitHub Actions는 Android API 35 Google APIs x86_64 Pixel 6 emulator의 수동 workflow로 실행한다.
 - `develop` 수동 run 3회가 assertion 실패나 재시도 없이 연속 성공했다.
 - emulator 준비와 Flutter test 실행이 로그에서 구분되며, 측정된 job 실행 시간은 5분 1초~7분 32초다.
-- 연속 성공과 로그 구분 조건은 충족했다. 팀이 실행 시간·비용을 수용하고 required check 승격에 동의한 뒤에만 repository 설정 변경을 별도 진행한다.
+- 연속 성공과 로그 구분 조건은 충족했다. #224에서 기본 `Flutter CI / quality`만 `develop` required check로 설정하고 Android smoke는 관련 변경과 release candidate에서 선택 실행하는 수동 workflow로 유지하기로 결정했다.
 
 | 순서 | run | `develop` head | smoke job | 결과 | 재시도 |
 | --- | --- | --- | --- | --- | --- |
@@ -186,6 +186,7 @@ Compact width 적용 gap과 대상 화면 회귀 테스트는 #197에서 완료�
 | TEST-02-A runner | `fb1e7fd` | Android API 35 emulator 기반 수동 integration smoke workflow 추가 | workflow YAML parse 통과 |
 | TEST-02-A action | `92bd778` | 새 Android workflow의 checkout과 Java setup을 Node.js 24 기반 현재 major로 갱신 | 공식 release 확인, workflow YAML parse 통과 |
 | TEST-02-A 안정성 | `256e029` | `develop` 수동 run 3회 연속 성공 근거와 required check 결정 경계 정리 | run `32243828623`, `32628473811`, `32628815566` 최초 시도 성공, `git diff --check` |
+| TEST-02-A gate | `95999a4` | `quality` required check 설정과 `develop` PR·push 기준 기본 CI trigger 정리, Android smoke 수동 유지 결정 | branch protection API에서 GitHub Actions app의 `quality`, 관리자 적용, strict 비활성 확인; workflow YAML parse, `git diff --check` |
 | TEST-02-B dev 환경 | `6a9fbc9` | dev API URL 준비 완료와 계정·데이터·secret 정책 Blocked 경계 갱신 | dev Swagger/API endpoint와 OpenAPI schema 확인, `git diff --check` |
 | TEST-02-B 준비 계약 | `1b15325` | backend/frontend/CI gate, read-only probe와 UI/CRUD E2E 경계, TESTENV 질문 정리 | OpenAPI 19개 path와 `GET /users` schema, 현재 Auth 화면 연결 대조, `git diff --check` |
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -235,7 +235,7 @@ gh run view <run-id> --log
 | 2 | [`32628473811`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628473811) | `34845e9` | 7분 32초 | Success | 없음 |
 | 3 | [`32628815566`](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/actions/runs/32628815566) | `34845e9` | 5분 1초 | Success | 없음 |
 
-연속 3회 성공과 로그 구분 조건은 충족했습니다. emulator 설치·cold boot와 실제 `flutter test` 명령이 같은 smoke step 안에서도 구분되어 runner 인프라와 앱 assertion의 실패 지점을 판별할 수 있습니다. 다만 job 하나가 5분 1초~7분 32초 걸리므로, 팀이 이 피드백 시간과 Actions 비용을 수용하고 required check 승격에 동의하기 전까지는 수동 workflow를 유지합니다. 승격 결정과 repository 설정 변경은 별도 작업으로 진행합니다.
+연속 3회 성공과 로그 구분 조건은 충족했습니다. emulator 설치·cold boot와 실제 `flutter test` 명령이 같은 smoke step 안에서도 구분되어 runner 인프라와 앱 assertion의 실패 지점을 판별할 수 있습니다. #224에서 기본 `Flutter CI / quality`만 `develop` required check로 설정하고, 5분 1초~7분 32초가 걸리는 Android smoke는 관련 변경과 release candidate에서 선택 실행하는 수동 workflow로 유지하기로 결정했습니다.
 
 ### TEST-02-B remote API end-to-end
 
@@ -285,7 +285,7 @@ feature 구조와 test 구조를 비슷하게 맞추면 찾기 쉽습니다.
 
 로컬에 `.fvmrc`와 FVM이 있으면 lefthook도 `fvm` 명령을 우선 사용합니다.
 
-GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. API 비사용 Android integration smoke는 3회 연속 성공과 로그 구분을 확인했지만, 실행 시간·비용 수용과 팀 합의 전까지 별도 수동 workflow로 유지합니다. Remote integration test는 백엔드 실행 환경이 준비된 뒤 release candidate 검증 또는 별도 CI job으로 연결합니다.
+GitHub Actions의 기본 CI는 `develop` 대상 PR과 `develop` push에서 `flutter pub get`, `flutter analyze`, `flutter test`를 실행합니다. `Flutter CI / quality`는 `develop` branch protection의 required check이며 관리자에게도 적용됩니다. feature branch push는 별도로 실행하지 않아 열린 PR의 `pull_request` 실행과 중복되지 않습니다. Ubuntu에서는 Golden test가 일반 `flutter test`에 포함되고 non-Linux 로컬에서는 golden만 skip됩니다. API 비사용 Android integration smoke는 3회 연속 성공과 로그 구분을 확인했지만 #224 결정에 따라 별도 수동 workflow로 유지합니다. Remote integration test는 백엔드 실행 환경이 준비된 뒤 release candidate 검증 또는 별도 CI job으로 연결합니다.
 
 ## 체크리스트
 
@@ -302,5 +302,5 @@ GitHub Actions의 기본 CI는 PR과 push에서 `flutter pub get`, `flutter anal
 ## 후속 결정 필요
 
 - TEST-01 pilot은 #199에서 `OnboardingPage`, `375×812`, DPR 1, Ubuntu canonical, exact comparator로 확정했습니다. 추가 화면과 viewport baseline은 회귀 위험과 유지 비용을 확인해 별도 이슈로 확장합니다.
-- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고, #218에서 `develop` run 3회의 연속 성공과 로그 구분을 확인했습니다. required check 승격은 실행 시간·비용 수용과 팀 합의가 남아 있어 `Ready` 상태로 별도 결정합니다.
+- TEST-02-A는 #203에서 API 비사용 Home → 장소 친구 요청 Android smoke와 수동 workflow로 도입했고, #218에서 `develop` run 3회의 연속 성공과 로그 구분을 확인했습니다. #224에서 기본 `Flutter CI / quality`만 required check로 설정하고 Android smoke는 수동으로 유지하기로 결정했습니다.
 - TEST-02-B의 dev API URL은 #213에서 확인했고 #220에서 인증, token lifecycle, 데이터 격리·cleanup, secret 승인 gate를 구체화했습니다. 첫 단계는 authenticated read-only probe이며, 외부 조건이 준비되기 전 상태는 `Blocked`입니다.


### PR DESCRIPTION
## 관련 이슈
- Closes #224
- Parent: #78

## 구현 범위
- `develop` branch protection에 GitHub Actions의 `quality` required check 설정
- 관리자에게도 required check 적용
- Flutter CI를 `develop` 대상 PR과 `develop` push에서만 실행하도록 trigger 정리
- Android Integration Smoke의 수동 운영 결정 문서화

## 주요 변경사항
- feature branch push와 PR 이벤트에서 발생하던 기본 CI 중복 실행 제거
- TEST-02-A-GATE를 `기본 CI required / Android smoke 수동`으로 확정
- README, 테스트 가이드, 품질 계획, 후속 결정 체크리스트, Git workflow 갱신
- 품질 계획의 기준 브랜치를 `develop@5af4b9b`, PR #223 기준으로 최신화

## 저장소 설정
- required check: `Flutter CI / quality`
- source: GitHub Actions app
- admins enforced: yes
- strict up-to-date: no
- PR review/conversation 정책 변경: 없음
- Android smoke required 승격: 없음

## 테스트
- `git diff --check develop...HEAD`
- Ruby Psych workflow YAML parse
- GitHub API로 `quality`, GitHub Actions app, 관리자 적용, strict 비활성 확인
- Flutter 코드 변경이 없어 `fvm flutter analyze`, `fvm flutter test`는 생략

## 리뷰 포인트
- 기본 CI trigger가 feature push/PR에서 중복되지 않는지
- Android smoke 수동 유지 결정이 관련 문서에 일관되게 반영됐는지
- PR의 `Flutter CI / quality`가 required check로 표시되는지

## 문서 반영
- `README.md`
- `docs/testing-guide.md`
- `docs/quality-testing-follow-up-plan.md`
- `docs/follow-up-decision-checklist.md`
- `docs/git-workflow.md`

## Breaking change
- 없음
