### PR TITLE
Feat: Auth 화면·API 상태 연결 #227

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ tool/
 | [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md) | 1차 완료 후 남은 Place 중심 대형 화면, 라우팅 파라미터, detail action, mapper 경계 개선 계획 |
 | [코드 가독성 리팩토링 3차 계획](docs/code-readability-refactoring-round-3-plan.md) | Riverpod-first 화면 상태, ViewData, feature/repository 경계를 정리하는 실행 계획 |
 | [코드 가독성 리팩토링 검증 기준](docs/code-readability-refactoring-validation.md) | 리팩토링 구조 감사, 회귀 테스트, 플랫폼 빌드, 실제 기기/API smoke 판정 기준과 검증 기록 |
+| [화면·모델·API 실연동 전환 계획](docs/screen-api-integration-plan.md) | mock 화면을 사용자 동선별 상태·모델·dev API 수직 슬라이스로 전환하는 우선순위와 완료 기준 |
 | [API Swagger 연계 참고 문서](docs/api-swagger-reference.md) | 서버 Swagger 변경사항, API 계층 반영 가능 항목, 백엔드 확인 필요 항목 |
 | [백엔드 API 확인 질문 목록](docs/backend-api-open-questions.md) | Swagger와 API 계층 기준으로 분리한 백엔드 확인 질문 목록 |
 | [후속 결정 체크리스트](docs/follow-up-decision-checklist.md) | 계획된 작업 완료 후 새 이슈로 분리할 결정/확인 항목 목록 |
@@ -239,7 +240,7 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 기존 [남은 작업 진행 계획](docs/remaining-work-plan.md)의 0~15번 항목은 2026-06-28 기준 모두 완료되었습니다.
 완료된 항목은 작업 기록 보존용으로 남기고, 코드 가독성 리팩토링 1차 라운드는 [코드 가독성 리팩토링 실행 계획](docs/code-readability-refactoring-plan.md)의 Task 1~7 기준으로 완료되었습니다. 2차 라운드도 2026-08-04에 [코드 가독성 리팩토링 2차 계획](docs/code-readability-refactoring-round-2-plan.md)의 Task 1~8 기준으로 완료되었습니다. 3차 라운드는 2026-08-12에 [코드 가독성 리팩토링 3차 계획](docs/code-readability-refactoring-round-3-plan.md)의 Task 1~11과 코드 수준 검증을 완료했습니다.
 
-이후 새 작업은 아래 기준으로 범위를 다시 정합니다.
+이후 새 작업은 아래 기준으로 범위를 다시 정합니다. 2026-08-25부터 배포 자동화보다 [화면·모델·API 실연동 전환 계획](docs/screen-api-integration-plan.md)을 MVP 최우선으로 진행합니다.
 
 - 후속 결정/확인 항목은 [후속 결정 체크리스트](docs/follow-up-decision-checklist.md)를 기준으로 새 이슈로 분리합니다.
 - 구조 개선 후보는 [lib 구조 리팩토링 개선 방향](docs/lib-refactoring-direction.md)의 남은 진단 항목을 기준으로 재평가합니다.
@@ -248,8 +249,9 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 
 우선순위:
 
-1. [x] 기존 남은 작업 계획 0~15번 완료 상태를 확인합니다.
-2. [x] 코드 가독성 리팩토링 1차 라운드의 상위 범위와 완료 기준을 문서화합니다.
-3. [x] 코드 가독성 리팩토링 2차 라운드 Task 1~8을 완료합니다.
-4. [x] 코드 가독성 리팩토링 3차 Task 1~11과 최종 코드 수준 검증을 완료합니다.
-5. [ ] 백엔드 확인, 테스트, 릴리즈처럼 결정이 필요한 항목을 개별 이슈로 분리합니다.
+1. [ ] Epic #226에서 화면, 상태·모델, dev API를 사용자 동선별 수직 슬라이스로 연결합니다.
+2. [ ] #227 Auth 로그인·회원가입·세션·라우팅 연결을 완료합니다.
+3. [ ] 로그인 직후 Home에 User와 Plant의 확인된 API 데이터를 연결합니다.
+4. [ ] Plant 목록·상세·생성·수정 동선을 실제 API로 전환합니다.
+5. [ ] Swagger가 불충분한 Place, Friend, Image, Memo는 확인된 범위만 구현하고 나머지는 백엔드 질문으로 유지합니다.
+6. [ ] 릴리즈와 원격 E2E는 기존 정책을 보존하되 외부 준비 조건이 충족될 때 재개합니다.

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -621,11 +621,12 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 
 ## 첫 API 연계 보강 우선순위 제안
 
-1. Auth register multipart datasource/repository는 #216에서 반영했다. profile image 파일 생성과 화면 submit 연결은 별도 구현 이슈로 진행한다.
-2. User 조회/검색/수정 datasource는 추가됐으므로, 화면 적용 시 상태 Provider와 UI 성공/실패 정책을 별도 작업으로 연결한다.
-3. Place update는 multipart 전송까지만 추가했으므로, response schema가 확정될 때까지 mapper는 넓히지 않는다.
-4. Friend API는 transport만 추가했으므로, 목록 response schema 확인 후 초대 요청 화면에 연결한다.
-5. Image API는 transport만 추가했으므로, 반환 image key/url schema와 에러 body가 보강되면 이미지 업로드 흐름을 연결한다.
+1. #227에서 Auth login/register repository를 로그인·프로필·약관 화면, 앱 세션, 인증 redirect까지 연결한다. 실제 소셜 SDK token 공급은 `SocialAuthCredentialGateway` 구현으로 분리한다.
+2. 로그인 직후 Home은 response schema가 있는 User 조회와 Plant 목록부터 상태 Provider와 loading/empty/error UI에 연결한다.
+3. Plant 목록·상세·생성·수정은 보강된 Swagger DTO를 기준으로 화면 동선을 순차 전환한다.
+4. Place는 multipart 전송 경계만 사용하고 response schema가 확정될 때까지 화면 mapper를 추정하지 않는다.
+5. Friend와 Image는 transport만 유지하며 성공 response schema 확인 후 화면에 연결한다.
+6. Memo는 Swagger endpoint가 추가되기 전까지 mock 화면 상태와 실제 API 코드를 섞지 않는다.
 
 ## DEV API 문서화 작업 이력
 
@@ -633,5 +634,6 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | --- | --- | --- | --- |
 | #213 | `6a9fbc9` | dev origin/API base, Swagger UI/OpenAPI/config, 현재 endpoint 차이와 환경별 Ready/Blocked 경계 문서화 | endpoint HTTP status, OpenAPI metadata, 19 paths·27 operations와 schema 대조, `git diff --check` |
 | #216 | `ae134d0` | Auth register JSON part와 optional image multipart datasource/repository, Swagger request DTO 반영 | Auth unit test 5개, macOS 전체 263개와 Ubuntu golden 포함 264개, format 260개 파일, analyze |
+| #227 | `111373a`, `a065188`, `e9543fc` | Auth 세션과 social credential 경계, 로그인·회원가입 화면 submit, 인증 route redirect 연결 | format 270개 파일, analyze, 전체 test 280개 통과·기존 skip 1개 |
 
 작업 이력만 갱신하는 후속 문서 커밋은 자기 자신의 해시를 생략할 수 있다.

--- a/docs/routing-guide.md
+++ b/docs/routing-guide.md
@@ -106,9 +106,9 @@ lib/app/router/
 
 ## 인증 라우팅 기준
 
-인증 기능이 들어오면 아래 방향으로 확장합니다.
+인증 기능은 아래 구조로 연결합니다.
 
-1. 인증 상태 Provider를 `appRouterProvider`에서 watch합니다.
+1. 인증 상태 Provider를 `appRouterProvider`에서 listen하고 router refresh에 연결합니다.
 2. 로그인 전 접근 가능한 route, 회원가입 진행 route, 로그인 후 route를 route policy로 분리합니다.
 3. 인증 토큰은 `flutter_secure_storage` 기반 저장소를 통해 관리하되, 라우터는 token storage에 직접 접근하지 않고 인증 Provider의 상태만 봅니다.
 4. access token 만료, refresh 실패, 로그아웃은 인증 Provider 상태를 `unauthenticated`로 바꾸고, 라우터 redirect에서 `/login`으로 이동시킵니다.
@@ -118,12 +118,13 @@ lib/app/router/
 
 ### Auth redirect Provider 설계
 
-현재 `appRouterProvider`는 `createAppRouter()`만 반환하며 인증 상태를 watch하지 않습니다. 인증 redirect 구현 PR에서는 아래 파일 경계를 목표로 둡니다.
+`appRouterProvider`는 인증 세션 변경을 listen하고 `RouterRefreshNotifier`로 GoRouter redirect를 다시 평가합니다. 현재 파일 경계는 아래와 같습니다.
 
 | 파일 | 역할 |
 | --- | --- |
-| `features/login/presentation/providers/auth_state_provider.dart` | 앱 전역 인증 상태를 `checking`, `unauthenticated`, `signupRequired`, `authenticated`처럼 표현합니다. |
-| `app/router/route_access_policy.dart` | route name별 접근 정책을 공개, 회원가입 진행, 인증 필요로 분류합니다. |
+| `features/login/presentation/providers/auth_session_controller.dart` | 앱 시작 token 복원과 로그인/회원가입 결과에 따른 세션 전환을 담당합니다. |
+| `features/login/presentation/providers/auth_session_state.dart` | 앱 전역 인증 상태를 `unauthenticated`, `signupRequired`, `authenticated`로 표현합니다. Provider loading을 `checking`으로 사용합니다. |
+| `app/router/auth_route_policy.dart` | 현재 URI와 인증 상태를 기준으로 redirect location을 계산합니다. |
 | `app/router/redirect_notifier.dart` | 인증 Provider 변경을 `GoRouter.refreshListenable`로 연결합니다. |
 | `app/router/app_router.dart` | 인증 상태와 현재 location을 기준으로 redirect target을 계산합니다. |
 

--- a/docs/screen-api-integration-plan.md
+++ b/docs/screen-api-integration-plan.md
@@ -1,0 +1,68 @@
+# 화면·모델·API 실연동 전환 계획
+
+이 문서는 화면 퍼블리싱 이후 남아 있는 mock 흐름을 실제 상태와 API 계층으로 전환하는 순서와 완료 기준을 관리합니다. 배포 자동화와 원격 E2E 준비는 필요한 외부 조건이 충족될 때까지 유지하되, 현재 MVP 최우선 작업은 사용자 동선별 수직 슬라이스 완성입니다.
+
+## 목표
+
+각 작업은 하나의 사용자 동선을 아래 순서까지 끊김 없이 연결합니다.
+
+```text
+화면 입력/상태 UI
+  -> Riverpod Controller
+  -> 화면용 상태·도메인 모델
+  -> Repository/DataSource
+  -> dev Swagger API
+  -> unit/widget/router test
+```
+
+- 화면 위젯은 JSON 파싱이나 Dio 호출을 직접 수행하지 않습니다.
+- API 사용 여부는 기존 `COMMONPLANT_USE_API` 환경값으로 분리합니다.
+- API 비사용 모드는 화면 개발과 Android smoke의 결정적 mock 흐름을 유지합니다.
+- Swagger에 response schema가 없는 기능은 화면 모델을 추측해 연결하지 않습니다.
+- loading, success, empty, error 상태를 해당 화면과 Controller 테스트에서 함께 검증합니다.
+
+## 우선순위
+
+| 순서 | 수직 슬라이스 | 범위 | 상태 |
+| --- | --- | --- | --- |
+| P0 | Auth 로그인·회원가입 | 로그인 화면, 인증 세션, 프로필 등록, route redirect, `/auth/login`, `/auth/register` | #227 구현 및 리뷰 |
+| P1 | Home 초기 데이터 | 인증 사용자 정보와 장소·식물 요약을 화면 상태로 연결 | 다음 작업 후보 |
+| P2 | Plant 핵심 동선 | 목록, 상세, 생성, 수정 API와 각 화면 상태 연결 | Auth 이후 진행 |
+| P3 | User 프로필 | 내 정보 조회·수정과 프로필 화면 연결 | 이미지 파일 선택 정책과 분리 가능 |
+| 제한 | Place | response schema가 확인된 동선부터 연결 | 목록·상세 schema 확인 필요 |
+| 보류 | Friend, Image, Memo | 성공 response 또는 endpoint가 불충분한 영역 | 백엔드 확인 필요 |
+
+P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기준으로 합니다. 다만 Place 성공 response schema가 없으므로, 먼저 schema가 있는 `GET /users`와 `GET /plants`를 사용하고 Place 데이터는 확인된 필드만 별도 작업으로 추가합니다.
+
+## Auth 첫 수직 슬라이스
+
+#227은 기존 #216의 Auth datasource/repository를 실제 화면과 앱 세션에 연결합니다.
+
+- 소셜 로그인 버튼은 `LoginController`를 통해 provider credential과 `/auth/login`을 연결합니다.
+- 실제 Kakao/Google/Apple SDK가 준비되지 않은 현재는 `SocialAuthCredentialGateway` 기본 구현이 설정 안내 오류를 반환합니다. SDK 도입 시 이 gateway 구현만 교체합니다.
+- 신규 사용자는 `signupToken`, 추천 이름, 추천 이미지 URL을 세션에 보존하고 프로필·약관 화면으로 이동합니다.
+- 약관 동의 후 프로필 이름과 `signupToken`으로 `/auth/register`를 호출하고 인증 세션으로 전환합니다.
+- 프로필 샘플 이미지는 로컬 UI 상태이므로 서버 multipart 이미지로 임의 전송하지 않습니다. 실제 파일 선택 결과가 준비될 때 optional image 경계에 연결합니다.
+- API 모드는 secure storage의 access/refresh token 쌍으로 세션을 복원합니다. refresh와 서버 로그아웃은 endpoint 확정 전까지 추가하지 않습니다.
+- 라우터는 `unauthenticated`, `signupRequired`, `authenticated` 세션에 따라 접근을 제어하고 로그인 전 target을 보존합니다.
+
+## 완료 기준
+
+각 수직 슬라이스는 아래 항목을 모두 충족해야 완료로 판단합니다.
+
+1. 화면이 Controller 상태만 관찰하고 loading/error/empty/success를 구분합니다.
+2. DTO와 화면 모델 변환이 data/domain 경계에 있습니다.
+3. API 비사용 mock 흐름과 API 사용 흐름이 섞이지 않습니다.
+4. Swagger와 다른 필드를 추정하지 않고 불명확한 항목을 문서에 남깁니다.
+5. Controller unit test와 핵심 widget/router test를 추가합니다.
+6. `fvm dart format`, `fvm flutter analyze`, `fvm flutter test`를 통과합니다.
+
+## 작업 이력
+
+| 이슈 | 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- | --- |
+| #227 | `111373a` | Auth 세션 상태, secure token 복원, 소셜 credential gateway 경계 | Auth session/controller test |
+| #227 | `a065188` | 로그인·프로필·약관 화면 상태와 login/register repository 연결 | login/profile unit·widget test |
+| #227 | `e9543fc` | 인증 상태 기반 route 접근 정책과 redirect target 복원 | router redirect test |
+
+문서 이력만 갱신하는 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/docs/state-management-guide.md
+++ b/docs/state-management-guide.md
@@ -136,24 +136,26 @@ Controller 책임:
 
 ## 인증 상태 기준
 
-인증 기능은 `authStateProvider`와 보안 토큰 저장소를 분리합니다.
+인증 기능은 `authSessionControllerProvider`와 보안 토큰 저장소를 분리합니다.
 
 ```text
 lib/features/login/
   data/
     datasources/
-      auth_local_data_source.dart
       auth_remote_data_source.dart
+    gateways/
+      social_auth_credential_gateway.dart
     repositories/
   presentation/
     providers/
-      auth_state_provider.dart
+      auth_session_controller.dart
+      auth_session_state.dart
 ```
 
-- 토큰 저장은 `flutter_secure_storage`를 기본으로 사용합니다.
-- access token과 refresh token의 읽기/쓰기는 local datasource로 캡슐화합니다.
+- 토큰 저장은 `core/network/auth_token_store.dart`의 `AuthTokenStore`와 `flutter_secure_storage` 구현으로 관리합니다.
+- access token과 refresh token의 읽기/쓰기/삭제는 token store로 캡슐화합니다.
 - 라우터는 인증 Provider의 결과만 보고 redirect하며, storage에 직접 접근하지 않습니다.
-- refresh 실패 또는 로그아웃 시 인증 상태를 unauthenticated로 전환합니다.
+- 로그아웃 또는 token clear 시 인증 상태를 unauthenticated로 전환합니다.
 
 ### Auth state Provider 설계
 
@@ -172,11 +174,12 @@ Provider 책임은 아래처럼 나눕니다.
 | --- | --- |
 | `AuthTokenStore` | access token, refresh token의 저장/읽기/삭제만 담당합니다. UI나 라우터 상태를 알지 않습니다. |
 | `AuthInterceptor` | 요청 직전 access token을 `Authorization: Bearer ...` header에 첨부합니다. redirect를 직접 수행하지 않습니다. |
-| `authStateProvider` | token store와 로그인/회원가입 결과를 바탕으로 앱 인증 상태를 노출합니다. |
+| `authSessionControllerProvider` | token store와 로그인/회원가입 결과를 바탕으로 앱 인증 상태를 노출합니다. |
+| `SocialAuthCredentialGateway` | Kakao/Google/Apple SDK에서 받은 provider token을 로그인 Controller에 전달합니다. SDK 미설정 기본 구현은 설정 안내 오류를 반환합니다. |
 | 로그인/회원가입 Controller | repository 호출, token 저장, `signupRequired` 또는 `authenticated` 전환을 담당합니다. |
 | 로그아웃 Controller | 로컬 token clear 후 `unauthenticated`로 전환합니다. 서버 로그아웃 API는 `TOKEN-02` 답변 후 추가합니다. |
 
-`authStateProvider`는 테스트에서 override할 수 있어야 하며, router test는 `unauthenticated`, `signupRequired`, `authenticated` 상태별 redirect를 직접 검증합니다.
+`authSessionControllerProvider`와 `socialAuthCredentialGatewayProvider`는 테스트에서 override할 수 있으며, router test는 `unauthenticated`, `signupRequired`, `authenticated` 상태별 redirect를 직접 검증합니다.
 
 `TOKEN-01` refresh API가 확정되기 전까지 access token 만료 자동 복구는 구현하지 않습니다. 401 응답을 받은 뒤 token을 갱신하는 interceptor 재시도 정책은 백엔드 endpoint와 error code가 확정된 뒤 별도 이슈에서 다룹니다.
 
@@ -188,7 +191,7 @@ Provider 책임은 아래처럼 나눕니다.
 | 상세 조회 | `plantDetailProvider` |
 | 생성 controller | `placeCreateControllerProvider` |
 | 수정 controller | `memoEditControllerProvider` |
-| 전역 인증 | `authStateProvider` |
+| 전역 인증 | `authSessionControllerProvider` |
 
 Provider 이름은 feature와 역할을 함께 드러냅니다.
 

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -1,10 +1,50 @@
 import 'package:commonplant_frontend/app/router/app_routes.dart';
+import 'package:commonplant_frontend/app/router/auth_route_policy.dart';
+import 'package:commonplant_frontend/app/router/redirect_notifier.dart';
 import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-final appRouterProvider = Provider<GoRouter>((ref) => createAppRouter());
+typedef AuthSessionReader = AsyncValue<AuthSessionState> Function();
 
-GoRouter createAppRouter({String initialLocation = AppRoutePaths.home}) {
-  return GoRouter(initialLocation: initialLocation, routes: buildAppRoutes());
+final appRouterProvider = Provider<GoRouter>((ref) {
+  final refreshNotifier = RouterRefreshNotifier();
+  ref.onDispose(refreshNotifier.dispose);
+  ref.listen(authSessionControllerProvider, (previous, next) {
+    refreshNotifier.refresh();
+  });
+
+  final router = createAppRouter(
+    authSessionReader: () => ref.read(authSessionControllerProvider),
+    refreshListenable: refreshNotifier,
+  );
+  ref.onDispose(router.dispose);
+
+  return router;
+});
+
+GoRouter createAppRouter({
+  String initialLocation = AppRoutePaths.home,
+  AuthSessionReader? authSessionReader,
+  Listenable? refreshListenable,
+}) {
+  return GoRouter(
+    initialLocation: initialLocation,
+    routes: buildAppRoutes(),
+    refreshListenable: refreshListenable,
+    redirect: authSessionReader == null
+        ? null
+        : (context, state) {
+            final authSession = authSessionReader();
+
+            return authRedirectLocation(
+              session: authSession.value,
+              isChecking: authSession.isLoading,
+              currentUri: state.uri,
+            );
+          },
+  );
 }

--- a/lib/app/router/auth_route_policy.dart
+++ b/lib/app/router/auth_route_policy.dart
@@ -1,0 +1,43 @@
+import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+
+String? authRedirectLocation({
+  required AuthSessionState? session,
+  required bool isChecking,
+  required Uri currentUri,
+}) {
+  if (isChecking) {
+    return null;
+  }
+
+  final currentPath = currentUri.path;
+  final isPublicRoute =
+      currentPath == AppRoutePaths.onboarding ||
+      currentPath == AppRoutePaths.login;
+  final isSignupRoute =
+      currentPath == AppRoutePaths.profileSetup ||
+      currentPath == AppRoutePaths.terms;
+  final resolvedSession = session ?? const AuthSessionState.unauthenticated();
+
+  return switch (resolvedSession.status) {
+    AuthSessionStatus.unauthenticated =>
+      isPublicRoute
+          ? null
+          : AppRoutePaths.loginLocation(redirect: currentUri.toString()),
+    AuthSessionStatus.signupRequired =>
+      isSignupRoute ? null : AppRoutePaths.profileSetup,
+    AuthSessionStatus.authenticated =>
+      isPublicRoute || isSignupRoute ? _authenticatedTarget(currentUri) : null,
+  };
+}
+
+String _authenticatedTarget(Uri currentUri) {
+  if (currentUri.path == AppRoutePaths.login) {
+    final redirect = currentUri.queryParameters['redirect'];
+    if (redirect != null && redirect.startsWith('/')) {
+      return redirect;
+    }
+  }
+
+  return AppRoutePaths.home;
+}

--- a/lib/app/router/redirect_notifier.dart
+++ b/lib/app/router/redirect_notifier.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+class RouterRefreshNotifier extends ChangeNotifier {
+  void refresh() {
+    notifyListeners();
+  }
+}

--- a/lib/app/router/route_paths.dart
+++ b/lib/app/router/route_paths.dart
@@ -43,6 +43,14 @@ abstract final class AppRoutePaths {
   static const String memoWrite = '/plants/:plantId/memos/new';
   static const String memoList = '/plants/:plantId/memos';
 
+  static String loginLocation({String? redirect}) {
+    if (redirect == null || redirect.isEmpty) {
+      return login;
+    }
+
+    return Uri(path: login, queryParameters: {'redirect': redirect}).toString();
+  }
+
   static String termsLocation({String? next}) {
     if (next == null) {
       return terms;

--- a/lib/features/login/data/gateways/social_auth_credential_gateway.dart
+++ b/lib/features/login/data/gateways/social_auth_credential_gateway.dart
@@ -1,0 +1,17 @@
+import 'package:commonplant_frontend/features/login/domain/models/social_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final socialAuthCredentialGatewayProvider =
+    Provider<SocialAuthCredentialGateway>(
+      (ref) => const UnconfiguredSocialAuthCredentialGateway(),
+    );
+
+class UnconfiguredSocialAuthCredentialGateway
+    implements SocialAuthCredentialGateway {
+  const UnconfiguredSocialAuthCredentialGateway();
+
+  @override
+  Future<SocialAuthCredential> authorize(SocialAuthProvider provider) {
+    throw const SocialAuthNotConfiguredException();
+  }
+}

--- a/lib/features/login/domain/models/social_auth.dart
+++ b/lib/features/login/domain/models/social_auth.dart
@@ -1,0 +1,24 @@
+enum SocialAuthProvider {
+  kakao('KAKAO'),
+  google('GOOGLE'),
+  apple('APPLE');
+
+  const SocialAuthProvider(this.apiValue);
+
+  final String apiValue;
+}
+
+class SocialAuthCredential {
+  const SocialAuthCredential({required this.provider, required this.token});
+
+  final SocialAuthProvider provider;
+  final String token;
+}
+
+abstract interface class SocialAuthCredentialGateway {
+  Future<SocialAuthCredential> authorize(SocialAuthProvider provider);
+}
+
+class SocialAuthNotConfiguredException implements Exception {
+  const SocialAuthNotConfiguredException();
+}

--- a/lib/features/login/presentation/pages/login_page.dart
+++ b/lib/features/login/presentation/pages/login_page.dart
@@ -7,8 +7,11 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/login/domain/models/social_auth.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/login_controller.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 const double _figmaFrameWidth = 375;
@@ -23,15 +26,34 @@ const double _heroSize = 186;
 const double _buttonTop = 582;
 const double _buttonHeight = 44;
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends ConsumerWidget {
   const LoginPage({super.key});
 
-  void _goNext(BuildContext context) {
-    context.go(AppRoutePaths.profileSetup);
+  Future<void> _handleLogin(
+    BuildContext context,
+    WidgetRef ref,
+    SocialAuthProvider provider,
+  ) async {
+    final outcome = await ref
+        .read(loginControllerProvider.notifier)
+        .login(provider);
+
+    if (!context.mounted || outcome == null) {
+      return;
+    }
+
+    switch (outcome) {
+      case LoginOutcome.signupRequired:
+        context.go(AppRoutePaths.profileSetup);
+      case LoginOutcome.authenticated:
+        context.go(AppRoutePaths.home);
+    }
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final loginState = ref.watch(loginControllerProvider);
+
     return Scaffold(
       backgroundColor: AppColors.surfaceAlt,
       body: LayoutBuilder(
@@ -84,7 +106,16 @@ class LoginPage extends StatelessWidget {
                       logoWidth: 18,
                       logoHeight: 18,
                       logoTop: 11,
-                      onPressed: () => _goNext(context),
+                      isLoading:
+                          loginState.submittingProvider ==
+                          SocialAuthProvider.kakao,
+                      onPressed: loginState.isSubmitting
+                          ? null
+                          : () => _handleLogin(
+                              context,
+                              ref,
+                              SocialAuthProvider.kakao,
+                            ),
                     ),
                     const SizedBox(height: AppSpacing.x12),
                     _LoginSocialButton(
@@ -97,7 +128,16 @@ class LoginPage extends StatelessWidget {
                       logoWidth: 18,
                       logoHeight: 18,
                       logoTop: 10,
-                      onPressed: () => _goNext(context),
+                      isLoading:
+                          loginState.submittingProvider ==
+                          SocialAuthProvider.google,
+                      onPressed: loginState.isSubmitting
+                          ? null
+                          : () => _handleLogin(
+                              context,
+                              ref,
+                              SocialAuthProvider.google,
+                            ),
                     ),
                     const SizedBox(height: AppSpacing.x12),
                     _LoginSocialButton(
@@ -109,8 +149,28 @@ class LoginPage extends StatelessWidget {
                       logoWidth: 16.26,
                       logoHeight: 20,
                       logoTop: 12,
-                      onPressed: () => _goNext(context),
+                      isLoading:
+                          loginState.submittingProvider ==
+                          SocialAuthProvider.apple,
+                      onPressed: loginState.isSubmitting
+                          ? null
+                          : () => _handleLogin(
+                              context,
+                              ref,
+                              SocialAuthProvider.apple,
+                            ),
                     ),
+                    if (loginState.errorMessage != null) ...[
+                      const SizedBox(height: AppSpacing.x8),
+                      Text(
+                        loginState.errorMessage!,
+                        key: const ValueKey('loginErrorMessage'),
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.size12Medium.copyWith(
+                          color: AppColors.danger,
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -164,6 +224,7 @@ class _LoginSocialButton extends StatelessWidget {
     required this.logoHeight,
     required this.logoTop,
     required this.onPressed,
+    this.isLoading = false,
   });
 
   final String label;
@@ -174,12 +235,14 @@ class _LoginSocialButton extends StatelessWidget {
   final double logoWidth;
   final double logoHeight;
   final double logoTop;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
+      enabled: onPressed != null,
       label: label,
       child: Material(
         color: backgroundColor,
@@ -209,15 +272,24 @@ class _LoginSocialButton extends StatelessWidget {
                     excludeFromSemantics: true,
                   ),
                 ),
-                Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: AppTextStyles.size14Bold.copyWith(
-                    color: foregroundColor,
+                if (isLoading)
+                  SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: foregroundColor,
+                    ),
+                  )
+                else
+                  Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: AppTextStyles.size14Bold.copyWith(
+                      color: foregroundColor,
+                    ),
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/features/login/presentation/pages/profile_setup_page.dart
+++ b/lib/features/login/presentation/pages/profile_setup_page.dart
@@ -85,23 +85,39 @@ class ProfileSetupPage extends ConsumerWidget {
   }
 
   Future<void> _handleComplete(BuildContext context, WidgetRef ref) async {
+    final isTermsAccepted = ref
+        .read(profileSetupControllerProvider)
+        .isPrivacyTermsAccepted;
+    if (!isTermsAccepted) {
+      _openTerms(context, TermsReturnDestination.home);
+      return;
+    }
+
     final didSubmit = await ref
         .read(profileSetupControllerProvider.notifier)
         .submit();
 
-    if (!context.mounted || !didSubmit) {
+    if (!context.mounted) {
       return;
     }
 
-    final isTermsAccepted = ref
-        .read(profileSetupControllerProvider)
-        .isPrivacyTermsAccepted;
-    if (isTermsAccepted) {
-      context.go(AppRoutePaths.home);
+    if (!didSubmit) {
+      _showSubmitError(context, ref);
       return;
     }
 
-    _openTerms(context, TermsReturnDestination.home);
+    context.go(AppRoutePaths.home);
+  }
+
+  void _showSubmitError(BuildContext context, WidgetRef ref) {
+    final message = ref.read(profileSetupControllerProvider).errorMessage;
+    if (message == null) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override
@@ -112,6 +128,7 @@ class ProfileSetupPage extends ConsumerWidget {
     return ProfileSetupLayout(
       nickname: state.nickname,
       hasImage: state.hasImage,
+      profileImageUrl: state.profileImageUrl,
       isTermsAccepted: state.isPrivacyTermsAccepted,
       isCompleteEnabled: state.canSubmit,
       isSubmitting: state.isSubmitting,

--- a/lib/features/login/presentation/providers/auth_session_controller.dart
+++ b/lib/features/login/presentation/providers/auth_session_controller.dart
@@ -1,0 +1,56 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final authSessionControllerProvider =
+    AsyncNotifierProvider<AuthSessionController, AuthSessionState>(
+      AuthSessionController.new,
+    );
+
+class AuthSessionController extends AsyncNotifier<AuthSessionState> {
+  @override
+  Future<AuthSessionState> build() async {
+    if (!ref.watch(useRemoteApiProvider)) {
+      return const AuthSessionState.authenticated();
+    }
+
+    final tokenStore = ref.watch(authTokenStoreProvider);
+    final accessToken = await tokenStore.readAccessToken();
+    final refreshToken = await tokenStore.readRefreshToken();
+    final hasAccessToken = accessToken != null && accessToken.isNotEmpty;
+    final hasRefreshToken = refreshToken != null && refreshToken.isNotEmpty;
+
+    if (hasAccessToken && hasRefreshToken) {
+      return const AuthSessionState.authenticated();
+    }
+
+    if (hasAccessToken || hasRefreshToken) {
+      await tokenStore.clear();
+    }
+
+    return const AuthSessionState.unauthenticated();
+  }
+
+  void applyAuthResult(AuthResult result) {
+    state = AsyncData(switch (result) {
+      SignupRequiredResult(
+        :final signupToken,
+        :final suggestedName,
+        :final suggestedImgUrl,
+      ) =>
+        AuthSessionState.signupRequired(
+          signupToken: signupToken,
+          suggestedName: suggestedName,
+          suggestedImgUrl: suggestedImgUrl,
+        ),
+      AuthenticatedResult() => const AuthSessionState.authenticated(),
+    });
+  }
+
+  Future<void> clearSession() async {
+    await ref.read(authTokenStoreProvider).clear();
+    state = const AsyncData(AuthSessionState.unauthenticated());
+  }
+}

--- a/lib/features/login/presentation/providers/auth_session_state.dart
+++ b/lib/features/login/presentation/providers/auth_session_state.dart
@@ -1,0 +1,38 @@
+enum AuthSessionStatus { unauthenticated, signupRequired, authenticated }
+
+class AuthSessionState {
+  const AuthSessionState._({
+    required this.status,
+    this.signupToken,
+    this.suggestedName,
+    this.suggestedImgUrl,
+  });
+
+  const AuthSessionState.unauthenticated()
+    : this._(status: AuthSessionStatus.unauthenticated);
+
+  const AuthSessionState.signupRequired({
+    required String signupToken,
+    String? suggestedName,
+    String? suggestedImgUrl,
+  }) : this._(
+         status: AuthSessionStatus.signupRequired,
+         signupToken: signupToken,
+         suggestedName: suggestedName,
+         suggestedImgUrl: suggestedImgUrl,
+       );
+
+  const AuthSessionState.authenticated()
+    : this._(status: AuthSessionStatus.authenticated);
+
+  final AuthSessionStatus status;
+  final String? signupToken;
+  final String? suggestedName;
+  final String? suggestedImgUrl;
+
+  bool get isUnauthenticated => status == AuthSessionStatus.unauthenticated;
+
+  bool get isSignupRequired => status == AuthSessionStatus.signupRequired;
+
+  bool get isAuthenticated => status == AuthSessionStatus.authenticated;
+}

--- a/lib/features/login/presentation/providers/login_controller.dart
+++ b/lib/features/login/presentation/providers/login_controller.dart
@@ -1,0 +1,117 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/data/gateways/social_auth_credential_gateway.dart';
+import 'package:commonplant_frontend/features/login/data/repositories/auth_repository.dart';
+import 'package:commonplant_frontend/features/login/domain/models/social_auth.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const String socialLoginNotConfiguredMessage = '소셜 로그인 설정이 아직 준비되지 않았어요';
+const String socialLoginFailureMessage = '로그인에 실패했어요. 잠시 후 다시 시도해 주세요';
+
+enum LoginSubmitStatus { idle, submitting, success, failure }
+
+enum LoginOutcome { signupRequired, authenticated }
+
+class LoginState {
+  const LoginState({
+    this.submitStatus = LoginSubmitStatus.idle,
+    this.submittingProvider,
+    this.errorMessage,
+  });
+
+  final LoginSubmitStatus submitStatus;
+  final SocialAuthProvider? submittingProvider;
+  final String? errorMessage;
+
+  bool get isSubmitting => submitStatus == LoginSubmitStatus.submitting;
+
+  LoginState copyWith({
+    LoginSubmitStatus? submitStatus,
+    SocialAuthProvider? submittingProvider,
+    String? errorMessage,
+    bool clearSubmittingProvider = false,
+    bool clearErrorMessage = false,
+  }) {
+    return LoginState(
+      submitStatus: submitStatus ?? this.submitStatus,
+      submittingProvider: clearSubmittingProvider
+          ? null
+          : submittingProvider ?? this.submittingProvider,
+      errorMessage: clearErrorMessage
+          ? null
+          : errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+final loginControllerProvider =
+    NotifierProvider.autoDispose<LoginController, LoginState>(
+      LoginController.new,
+    );
+
+class LoginController extends Notifier<LoginState> {
+  @override
+  LoginState build() => const LoginState();
+
+  Future<LoginOutcome?> login(SocialAuthProvider provider) async {
+    if (state.isSubmitting) {
+      return null;
+    }
+
+    state = state.copyWith(
+      submitStatus: LoginSubmitStatus.submitting,
+      submittingProvider: provider,
+      clearErrorMessage: true,
+    );
+
+    try {
+      if (!ref.read(useRemoteApiProvider)) {
+        state = state.copyWith(
+          submitStatus: LoginSubmitStatus.success,
+          clearSubmittingProvider: true,
+        );
+        return LoginOutcome.signupRequired;
+      }
+
+      await ref.read(authSessionControllerProvider.future);
+      final credential = await ref
+          .read(socialAuthCredentialGatewayProvider)
+          .authorize(provider);
+      final result = await ref
+          .read(authRepositoryProvider)
+          .login(
+            LoginRequest(
+              provider: credential.provider.apiValue,
+              token: credential.token,
+            ),
+          );
+
+      ref.read(authSessionControllerProvider.notifier).applyAuthResult(result);
+      state = state.copyWith(
+        submitStatus: LoginSubmitStatus.success,
+        clearSubmittingProvider: true,
+      );
+
+      return switch (result) {
+        SignupRequiredResult() => LoginOutcome.signupRequired,
+        AuthenticatedResult() => LoginOutcome.authenticated,
+      };
+    } on SocialAuthNotConfiguredException {
+      state = state.copyWith(
+        submitStatus: LoginSubmitStatus.failure,
+        errorMessage: socialLoginNotConfiguredMessage,
+        clearSubmittingProvider: true,
+      );
+    } catch (_) {
+      state = state.copyWith(
+        submitStatus: LoginSubmitStatus.failure,
+        errorMessage: socialLoginFailureMessage,
+        clearSubmittingProvider: true,
+      );
+    }
+
+    return null;
+  }
+}

--- a/lib/features/login/presentation/providers/profile_setup_controller.dart
+++ b/lib/features/login/presentation/providers/profile_setup_controller.dart
@@ -1,3 +1,9 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/data/repositories/auth_repository.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
 import 'package:commonplant_frontend/features/login/presentation/providers/profile_setup_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,6 +17,19 @@ final profileSetupControllerProvider =
 class ProfileSetupController extends Notifier<ProfileSetupState> {
   @override
   ProfileSetupState build() {
+    final session = ref.read(authSessionControllerProvider).value;
+
+    if (session case AuthSessionState(
+      status: AuthSessionStatus.signupRequired,
+      :final suggestedName,
+      :final suggestedImgUrl,
+    )) {
+      return ProfileSetupState.initial(
+        nickname: suggestedName ?? '',
+        profileImageUrl: suggestedImgUrl,
+      );
+    }
+
     return const ProfileSetupState.initial();
   }
 
@@ -23,11 +42,11 @@ class ProfileSetupController extends Notifier<ProfileSetupState> {
   }
 
   void selectProfileImage() {
-    state = state.copyWith(hasImage: true);
+    state = state.copyWith(hasImage: true, clearProfileImageUrl: true);
   }
 
   void resetProfileImage() {
-    state = state.copyWith(hasImage: false);
+    state = state.copyWith(hasImage: false, clearProfileImageUrl: true);
   }
 
   void setPrivacyTermsAccepted(bool isAccepted) {
@@ -49,7 +68,11 @@ class ProfileSetupController extends Notifier<ProfileSetupState> {
     );
 
     try {
-      await action?.call();
+      if (action != null) {
+        await action();
+      } else if (ref.read(useRemoteApiProvider)) {
+        await _register();
+      }
       state = state.copyWith(submitStatus: ProfileSetupSubmitStatus.success);
       return true;
     } catch (_) {
@@ -59,5 +82,29 @@ class ProfileSetupController extends Notifier<ProfileSetupState> {
       );
       return false;
     }
+  }
+
+  Future<void> _register() async {
+    final session = await ref.read(authSessionControllerProvider.future);
+    final signupToken = session.signupToken;
+
+    if (!session.isSignupRequired || signupToken == null) {
+      throw StateError('회원가입 세션이 없습니다.');
+    }
+
+    final result = await ref
+        .read(authRepositoryProvider)
+        .register(
+          RegisterRequest(
+            signupToken: signupToken,
+            name: state.nickname.trim(),
+          ),
+        );
+
+    if (result is! AuthenticatedResult) {
+      throw StateError('회원가입 후 인증 결과가 없습니다.');
+    }
+
+    ref.read(authSessionControllerProvider.notifier).applyAuthResult(result);
   }
 }

--- a/lib/features/login/presentation/providers/profile_setup_state.dart
+++ b/lib/features/login/presentation/providers/profile_setup_state.dart
@@ -7,21 +7,26 @@ class ProfileSetupState {
   const ProfileSetupState({
     required this.nickname,
     required this.hasImage,
+    required this.profileImageUrl,
     required this.isPrivacyTermsAccepted,
     required this.submitStatus,
     this.errorMessage,
   });
 
-  const ProfileSetupState.initial()
-    : this(
-        nickname: '',
-        hasImage: false,
-        isPrivacyTermsAccepted: false,
-        submitStatus: ProfileSetupSubmitStatus.idle,
-      );
+  const ProfileSetupState.initial({
+    String nickname = '',
+    String? profileImageUrl,
+  }) : this(
+         nickname: nickname,
+         hasImage: profileImageUrl != null,
+         profileImageUrl: profileImageUrl,
+         isPrivacyTermsAccepted: false,
+         submitStatus: ProfileSetupSubmitStatus.idle,
+       );
 
   final String nickname;
   final bool hasImage;
+  final String? profileImageUrl;
   final bool isPrivacyTermsAccepted;
   final ProfileSetupSubmitStatus submitStatus;
   final String? errorMessage;
@@ -39,14 +44,19 @@ class ProfileSetupState {
   ProfileSetupState copyWith({
     String? nickname,
     bool? hasImage,
+    String? profileImageUrl,
     bool? isPrivacyTermsAccepted,
     ProfileSetupSubmitStatus? submitStatus,
     String? errorMessage,
     bool clearErrorMessage = false,
+    bool clearProfileImageUrl = false,
   }) {
     return ProfileSetupState(
       nickname: nickname ?? this.nickname,
       hasImage: hasImage ?? this.hasImage,
+      profileImageUrl: clearProfileImageUrl
+          ? null
+          : profileImageUrl ?? this.profileImageUrl,
       isPrivacyTermsAccepted:
           isPrivacyTermsAccepted ?? this.isPrivacyTermsAccepted,
       submitStatus: submitStatus ?? this.submitStatus,

--- a/lib/features/login/presentation/widgets/profile_avatar.dart
+++ b/lib/features/login/presentation/widgets/profile_avatar.dart
@@ -8,9 +8,15 @@ const double _profileAvatarBoxSize = 100;
 const double _profileAvatarImageSize = 83.33;
 
 class ProfileAvatar extends StatelessWidget {
-  const ProfileAvatar({required this.hasImage, required this.onTap, super.key});
+  const ProfileAvatar({
+    required this.hasImage,
+    required this.onTap,
+    this.imageUrl,
+    super.key,
+  });
 
   final bool hasImage;
+  final String? imageUrl;
   final VoidCallback onTap;
 
   @override
@@ -30,13 +36,30 @@ class ProfileAvatar extends StatelessWidget {
             children: [
               if (hasImage)
                 ClipOval(
-                  child: Image.asset(
-                    AppImageAssets.profileSetupSampleAvatar,
-                    width: _profileAvatarImageSize,
-                    height: _profileAvatarImageSize,
-                    fit: BoxFit.cover,
-                    excludeFromSemantics: true,
-                  ),
+                  child: imageUrl == null
+                      ? Image.asset(
+                          AppImageAssets.profileSetupSampleAvatar,
+                          width: _profileAvatarImageSize,
+                          height: _profileAvatarImageSize,
+                          fit: BoxFit.cover,
+                          excludeFromSemantics: true,
+                        )
+                      : Image.network(
+                          imageUrl!,
+                          width: _profileAvatarImageSize,
+                          height: _profileAvatarImageSize,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) {
+                            return Image.asset(
+                              AppImageAssets.profileSetupSampleAvatar,
+                              width: _profileAvatarImageSize,
+                              height: _profileAvatarImageSize,
+                              fit: BoxFit.cover,
+                              excludeFromSemantics: true,
+                            );
+                          },
+                          excludeFromSemantics: true,
+                        ),
                 )
               else
                 const CommonSvgIcon(

--- a/lib/features/login/presentation/widgets/profile_setup_layout.dart
+++ b/lib/features/login/presentation/widgets/profile_setup_layout.dart
@@ -22,6 +22,7 @@ class ProfileSetupLayout extends StatelessWidget {
   const ProfileSetupLayout({
     required this.nickname,
     required this.hasImage,
+    this.profileImageUrl,
     required this.isTermsAccepted,
     required this.isCompleteEnabled,
     required this.isSubmitting,
@@ -36,6 +37,7 @@ class ProfileSetupLayout extends StatelessWidget {
 
   final String nickname;
   final bool hasImage;
+  final String? profileImageUrl;
   final bool isTermsAccepted;
   final bool isCompleteEnabled;
   final bool isSubmitting;
@@ -118,7 +120,11 @@ class ProfileSetupLayout extends StatelessWidget {
                 width: contentWidth,
                 child: Column(
                   children: [
-                    ProfileAvatar(hasImage: hasImage, onTap: onImagePressed),
+                    ProfileAvatar(
+                      hasImage: hasImage,
+                      imageUrl: profileImageUrl,
+                      onTap: onImagePressed,
+                    ),
                     const SizedBox(height: AppSpacing.x16),
                     ProfileNicknameField(
                       nickname: nickname,

--- a/lib/features/terms/presentation/pages/terms_page.dart
+++ b/lib/features/terms/presentation/pages/terms_page.dart
@@ -54,7 +54,7 @@ class TermsPage extends ConsumerWidget {
     context.go(AppRoutePaths.profileSetup);
   }
 
-  void _confirmAgreement(BuildContext context, WidgetRef ref) {
+  Future<void> _confirmAgreement(BuildContext context, WidgetRef ref) async {
     ref
         .read(profileSetupControllerProvider.notifier)
         .setPrivacyTermsAccepted(true);
@@ -67,6 +67,21 @@ class TermsPage extends ConsumerWidget {
           context.go(AppRoutePaths.profileSetup);
         }
       case TermsNextDestination.home:
+        final didSubmit = await ref
+            .read(profileSetupControllerProvider.notifier)
+            .submit();
+        if (!context.mounted) {
+          return;
+        }
+        if (!didSubmit) {
+          final message = ref.read(profileSetupControllerProvider).errorMessage;
+          if (message != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(message)));
+          }
+          return;
+        }
         context.go(AppRoutePaths.home);
     }
   }
@@ -77,6 +92,9 @@ class TermsPage extends ConsumerWidget {
       profileSetupControllerProvider.select(
         (state) => state.isPrivacyTermsAccepted,
       ),
+    );
+    final isSubmitting = ref.watch(
+      profileSetupControllerProvider.select((state) => state.isSubmitting),
     );
 
     return Scaffold(
@@ -178,7 +196,10 @@ class TermsPage extends ConsumerWidget {
                           label: '확인',
                           backgroundColor: AppColors.brandAccent,
                           foregroundColor: AppColors.white,
-                          onPressed: () => _confirmAgreement(context, ref),
+                          isLoading: isSubmitting,
+                          onPressed: isSubmitting
+                              ? null
+                              : () => _confirmAgreement(context, ref),
                         ),
                       ),
                     ],

--- a/test/app/router/auth_route_redirect_test.dart
+++ b/test/app/router/auth_route_redirect_test.dart
@@ -1,0 +1,137 @@
+import 'package:commonplant_frontend/app/common_plant_app.dart';
+import 'package:commonplant_frontend/app/router/app_router.dart';
+import 'package:commonplant_frontend/app/router/route_paths.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets('실제 앱 router는 API 모드의 빈 세션을 로그인으로 보낸다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          authTokenStoreProvider.overrideWithValue(_EmptyAuthTokenStore()),
+        ],
+        child: const CommonPlantApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('카카오로 로그인'), findsOneWidget);
+    expect(find.text('My place'), findsNothing);
+  });
+
+  testWidgets('비인증 사용자는 보호 route에서 로그인으로 이동한다', (tester) async {
+    final authSession = ValueNotifier<AsyncValue<AuthSessionState>>(
+      const AsyncData(AuthSessionState.unauthenticated()),
+    );
+    addTearDown(authSession.dispose);
+    final router = _routerWithAuth(authSession);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_routerApp(router));
+    await tester.pumpAndSettle();
+
+    expect(find.text('카카오로 로그인'), findsOneWidget);
+    expect(
+      router.routeInformationProvider.value.uri.queryParameters['redirect'],
+      AppRoutePaths.home,
+    );
+  });
+
+  testWidgets('회원가입 필요 사용자는 프로필 설정으로 이동한다', (tester) async {
+    final authSession = ValueNotifier<AsyncValue<AuthSessionState>>(
+      const AsyncData(
+        AuthSessionState.signupRequired(signupToken: 'signup-token'),
+      ),
+    );
+    addTearDown(authSession.dispose);
+    final router = _routerWithAuth(authSession);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_routerApp(router));
+    await tester.pumpAndSettle();
+
+    expect(find.text('닉네임을 입력해 주세요'), findsOneWidget);
+    expect(
+      router.routeInformationProvider.value.uri.path,
+      AppRoutePaths.profileSetup,
+    );
+  });
+
+  testWidgets('인증 사용자는 로그인 route의 보존 위치로 복귀한다', (tester) async {
+    final authSession = ValueNotifier<AsyncValue<AuthSessionState>>(
+      const AsyncData(AuthSessionState.authenticated()),
+    );
+    addTearDown(authSession.dispose);
+    final router = createAppRouter(
+      initialLocation: AppRoutePaths.loginLocation(
+        redirect: AppRoutePaths.placeCreate,
+      ),
+      authSessionReader: () => authSession.value,
+      refreshListenable: authSession,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_routerApp(router));
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routeInformationProvider.value.uri.path,
+      AppRoutePaths.placeCreate,
+    );
+  });
+
+  testWidgets('세션 확인 완료 시 router가 인증 상태를 다시 평가한다', (tester) async {
+    final authSession = ValueNotifier<AsyncValue<AuthSessionState>>(
+      const AsyncLoading(),
+    );
+    addTearDown(authSession.dispose);
+    final router = _routerWithAuth(authSession);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_routerApp(router));
+    await tester.pump();
+    expect(find.text('My place'), findsOneWidget);
+
+    authSession.value = const AsyncData(AuthSessionState.unauthenticated());
+    await tester.pumpAndSettle();
+
+    expect(find.text('카카오로 로그인'), findsOneWidget);
+  });
+}
+
+GoRouter _routerWithAuth(
+  ValueNotifier<AsyncValue<AuthSessionState>> authSession,
+) {
+  return createAppRouter(
+    authSessionReader: () => authSession.value,
+    refreshListenable: authSession,
+  );
+}
+
+Widget _routerApp(GoRouter router) {
+  return ProviderScope(child: MaterialApp.router(routerConfig: router));
+}
+
+class _EmptyAuthTokenStore implements AuthTokenStore {
+  @override
+  Future<void> clear() async {}
+
+  @override
+  Future<String?> readAccessToken() async => null;
+
+  @override
+  Future<String?> readRefreshToken() async => null;
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {}
+}

--- a/test/features/login/presentation/pages/login_page_test.dart
+++ b/test/features/login/presentation/pages/login_page_test.dart
@@ -1,5 +1,10 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/gateways/social_auth_credential_gateway.dart';
 import 'package:commonplant_frontend/features/login/presentation/pages/login_page.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/login_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -9,7 +14,7 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(const MaterialApp(home: LoginPage()));
+    await tester.pumpWidget(_loginPageApp());
 
     expect(find.text('9:41'), findsNothing);
     expect(find.bySemanticsLabel('Common'), findsOneWidget);
@@ -55,7 +60,7 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     addTearDown(tester.view.resetPhysicalSize);
 
-    await tester.pumpWidget(const MaterialApp(home: LoginPage()));
+    await tester.pumpWidget(_loginPageApp());
 
     final illustrationSize = tester.getSize(find.bySemanticsLabel('로그인 일러스트'));
     expect(illustrationSize.width, lessThan(186));
@@ -64,6 +69,48 @@ void main() {
     expect(find.text('구글로 로그인'), findsOneWidget);
     expect(find.text('Apple로 로그인'), findsOneWidget);
   });
+
+  testWidgets('API 모드에서 SDK adapter가 없으면 설정 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          authTokenStoreProvider.overrideWithValue(_EmptyAuthTokenStore()),
+          socialAuthCredentialGatewayProvider.overrideWithValue(
+            const UnconfiguredSocialAuthCredentialGateway(),
+          ),
+        ],
+        child: const MaterialApp(home: LoginPage()),
+      ),
+    );
+
+    await tester.tap(find.text('카카오로 로그인'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('loginErrorMessage')), findsOneWidget);
+    expect(find.text(socialLoginNotConfiguredMessage), findsOneWidget);
+  });
+}
+
+Widget _loginPageApp() {
+  return const ProviderScope(child: MaterialApp(home: LoginPage()));
+}
+
+class _EmptyAuthTokenStore implements AuthTokenStore {
+  @override
+  Future<void> clear() async {}
+
+  @override
+  Future<String?> readAccessToken() async => null;
+
+  @override
+  Future<String?> readRefreshToken() async => null;
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {}
 }
 
 Matcher closeToSize(Size expected, double delta) {

--- a/test/features/login/presentation/providers/auth_session_controller_test.dart
+++ b/test/features/login/presentation/providers/auth_session_controller_test.dart
@@ -1,0 +1,116 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('API 비사용 모드는 기존 화면 흐름을 위해 인증 상태로 시작한다', () async {
+    final container = ProviderContainer(
+      overrides: [useRemoteApiProvider.overrideWithValue(false)],
+    );
+    addTearDown(container.dispose);
+
+    final session = await container.read(authSessionControllerProvider.future);
+
+    expect(session.status, AuthSessionStatus.authenticated);
+  });
+
+  test('API 모드는 저장된 access와 refresh token이 모두 있으면 세션을 복원한다', () async {
+    final tokenStore = _MemoryAuthTokenStore(
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    );
+    final container = _remoteContainer(tokenStore);
+    addTearDown(container.dispose);
+
+    final session = await container.read(authSessionControllerProvider.future);
+
+    expect(session.status, AuthSessionStatus.authenticated);
+    expect(tokenStore.clearCalls, 0);
+  });
+
+  test('API 모드는 token이 없으면 비인증 상태로 시작한다', () async {
+    final container = _remoteContainer(_MemoryAuthTokenStore());
+    addTearDown(container.dispose);
+
+    final session = await container.read(authSessionControllerProvider.future);
+
+    expect(session.status, AuthSessionStatus.unauthenticated);
+  });
+
+  test('불완전한 token 쌍은 삭제하고 비인증 상태로 복구한다', () async {
+    final tokenStore = _MemoryAuthTokenStore(accessToken: 'access-token');
+    final container = _remoteContainer(tokenStore);
+    addTearDown(container.dispose);
+
+    final session = await container.read(authSessionControllerProvider.future);
+
+    expect(session.status, AuthSessionStatus.unauthenticated);
+    expect(tokenStore.clearCalls, 1);
+    expect(tokenStore.accessToken, isNull);
+  });
+
+  test('신규 사용자 로그인 결과에서 회원가입 진행 정보를 보존한다', () async {
+    final container = _remoteContainer(_MemoryAuthTokenStore());
+    addTearDown(container.dispose);
+    await container.read(authSessionControllerProvider.future);
+
+    container
+        .read(authSessionControllerProvider.notifier)
+        .applyAuthResult(
+          const SignupRequiredResult(
+            signupToken: 'signup-token',
+            suggestedName: '커먼',
+            suggestedImgUrl: 'https://example.com/profile.png',
+          ),
+        );
+
+    final session = container.read(authSessionControllerProvider).requireValue;
+    expect(session.status, AuthSessionStatus.signupRequired);
+    expect(session.signupToken, 'signup-token');
+    expect(session.suggestedName, '커먼');
+    expect(session.suggestedImgUrl, 'https://example.com/profile.png');
+  });
+}
+
+ProviderContainer _remoteContainer(AuthTokenStore tokenStore) {
+  return ProviderContainer(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      authTokenStoreProvider.overrideWithValue(tokenStore),
+    ],
+  );
+}
+
+class _MemoryAuthTokenStore implements AuthTokenStore {
+  _MemoryAuthTokenStore({this.accessToken, this.refreshToken});
+
+  String? accessToken;
+  String? refreshToken;
+  int clearCalls = 0;
+
+  @override
+  Future<void> clear() async {
+    clearCalls++;
+    accessToken = null;
+    refreshToken = null;
+  }
+
+  @override
+  Future<String?> readAccessToken() async => accessToken;
+
+  @override
+  Future<String?> readRefreshToken() async => refreshToken;
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/test/features/login/presentation/providers/login_controller_test.dart
+++ b/test/features/login/presentation/providers/login_controller_test.dart
@@ -1,0 +1,169 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/core/network/auth_token_store.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/data/gateways/social_auth_credential_gateway.dart';
+import 'package:commonplant_frontend/features/login/data/repositories/auth_repository.dart';
+import 'package:commonplant_frontend/features/login/domain/models/social_auth.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/login_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('API 비사용 모드는 repository 없이 기존 회원가입 화면 흐름을 유지한다', () async {
+    final container = ProviderContainer(
+      overrides: [useRemoteApiProvider.overrideWithValue(false)],
+    );
+    addTearDown(container.dispose);
+
+    final outcome = await container
+        .read(loginControllerProvider.notifier)
+        .login(SocialAuthProvider.kakao);
+
+    expect(outcome, LoginOutcome.signupRequired);
+    expect(
+      container.read(loginControllerProvider).submitStatus,
+      LoginSubmitStatus.success,
+    );
+  });
+
+  test('기존 사용자는 social token으로 로그인하고 인증 상태가 된다', () async {
+    final repository = _FakeAuthRepository(
+      const AuthenticatedResult(
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      ),
+    );
+    final container = _remoteContainer(
+      repository: repository,
+      gateway: const _StaticSocialAuthCredentialGateway(
+        SocialAuthCredential(
+          provider: SocialAuthProvider.google,
+          token: 'social-token',
+        ),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    final outcome = await container
+        .read(loginControllerProvider.notifier)
+        .login(SocialAuthProvider.google);
+
+    expect(outcome, LoginOutcome.authenticated);
+    expect(repository.latestRequest?.provider, 'GOOGLE');
+    expect(repository.latestRequest?.token, 'social-token');
+    expect(
+      container.read(authSessionControllerProvider).requireValue.status,
+      AuthSessionStatus.authenticated,
+    );
+  });
+
+  test('신규 사용자는 signup token과 추천 프로필을 세션에 보존한다', () async {
+    final repository = _FakeAuthRepository(
+      const SignupRequiredResult(
+        signupToken: 'signup-token',
+        suggestedName: '초록',
+      ),
+    );
+    final container = _remoteContainer(
+      repository: repository,
+      gateway: const _StaticSocialAuthCredentialGateway(
+        SocialAuthCredential(
+          provider: SocialAuthProvider.kakao,
+          token: 'social-token',
+        ),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    final outcome = await container
+        .read(loginControllerProvider.notifier)
+        .login(SocialAuthProvider.kakao);
+
+    expect(outcome, LoginOutcome.signupRequired);
+    final session = container.read(authSessionControllerProvider).requireValue;
+    expect(session.status, AuthSessionStatus.signupRequired);
+    expect(session.signupToken, 'signup-token');
+    expect(session.suggestedName, '초록');
+  });
+
+  test('SDK adapter가 없으면 사용자용 설정 안내를 제공한다', () async {
+    final container = _remoteContainer(
+      repository: _FakeAuthRepository(
+        const AuthenticatedResult(
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        ),
+      ),
+      gateway: const UnconfiguredSocialAuthCredentialGateway(),
+    );
+    addTearDown(container.dispose);
+
+    final outcome = await container
+        .read(loginControllerProvider.notifier)
+        .login(SocialAuthProvider.apple);
+
+    expect(outcome, isNull);
+    final state = container.read(loginControllerProvider);
+    expect(state.submitStatus, LoginSubmitStatus.failure);
+    expect(state.errorMessage, socialLoginNotConfiguredMessage);
+  });
+}
+
+ProviderContainer _remoteContainer({
+  required AuthRepository repository,
+  required SocialAuthCredentialGateway gateway,
+}) {
+  return ProviderContainer(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      authTokenStoreProvider.overrideWithValue(_EmptyAuthTokenStore()),
+      authRepositoryProvider.overrideWithValue(repository),
+      socialAuthCredentialGatewayProvider.overrideWithValue(gateway),
+    ],
+  );
+}
+
+class _StaticSocialAuthCredentialGateway
+    implements SocialAuthCredentialGateway {
+  const _StaticSocialAuthCredentialGateway(this.credential);
+
+  final SocialAuthCredential credential;
+
+  @override
+  Future<SocialAuthCredential> authorize(SocialAuthProvider provider) async {
+    return credential;
+  }
+}
+
+class _FakeAuthRepository extends Fake implements AuthRepository {
+  _FakeAuthRepository(this.result);
+
+  final AuthResult result;
+  LoginRequest? latestRequest;
+
+  @override
+  Future<AuthResult> login(LoginRequest request) async {
+    latestRequest = request;
+    return result;
+  }
+}
+
+class _EmptyAuthTokenStore implements AuthTokenStore {
+  @override
+  Future<void> clear() async {}
+
+  @override
+  Future<String?> readAccessToken() async => null;
+
+  @override
+  Future<String?> readRefreshToken() async => null;
+
+  @override
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {}
+}

--- a/test/features/login/presentation/providers/profile_setup_controller_test.dart
+++ b/test/features/login/presentation/providers/profile_setup_controller_test.dart
@@ -1,7 +1,14 @@
 import 'dart:async';
 
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_requests.dart';
+import 'package:commonplant_frontend/features/login/data/dtos/auth_result.dart';
+import 'package:commonplant_frontend/features/login/data/repositories/auth_repository.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_controller.dart';
+import 'package:commonplant_frontend/features/login/presentation/providers/auth_session_state.dart';
 import 'package:commonplant_frontend/features/login/presentation/providers/profile_setup_controller.dart';
 import 'package:commonplant_frontend/features/login/presentation/providers/profile_setup_state.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -102,4 +109,74 @@ void main() {
     );
     expect(container.read(profileSetupControllerProvider).canSubmit, isTrue);
   });
+
+  test('신규 로그인 추천 프로필로 초기 상태를 구성한다', () async {
+    final container = _remoteSignupContainer(_FakeAuthRepository());
+    addTearDown(container.dispose);
+    await container.read(authSessionControllerProvider.future);
+
+    final state = container.read(profileSetupControllerProvider);
+
+    expect(state.nickname, '초록');
+    expect(state.hasImage, isTrue);
+    expect(state.profileImageUrl, 'https://example.com/profile.png');
+  });
+
+  test('API 모드 제출은 signup token으로 회원가입하고 인증 상태를 전환한다', () async {
+    final repository = _FakeAuthRepository();
+    final container = _remoteSignupContainer(repository);
+    addTearDown(container.dispose);
+    await container.read(authSessionControllerProvider.future);
+    final controller = container.read(profileSetupControllerProvider.notifier);
+
+    controller.updateNickname('커먼');
+    final didSubmit = await controller.submit();
+
+    expect(didSubmit, isTrue);
+    expect(repository.latestRequest?.signupToken, 'signup-token');
+    expect(repository.latestRequest?.name, '커먼');
+    expect(
+      container.read(authSessionControllerProvider).requireValue.status,
+      AuthSessionStatus.authenticated,
+    );
+  });
+}
+
+ProviderContainer _remoteSignupContainer(AuthRepository repository) {
+  return ProviderContainer(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      authRepositoryProvider.overrideWithValue(repository),
+      authSessionControllerProvider.overrideWith(
+        _SignupAuthSessionController.new,
+      ),
+    ],
+  );
+}
+
+class _SignupAuthSessionController extends AuthSessionController {
+  @override
+  Future<AuthSessionState> build() async {
+    return const AuthSessionState.signupRequired(
+      signupToken: 'signup-token',
+      suggestedName: '초록',
+      suggestedImgUrl: 'https://example.com/profile.png',
+    );
+  }
+}
+
+class _FakeAuthRepository extends Fake implements AuthRepository {
+  RegisterRequest? latestRequest;
+
+  @override
+  Future<AuthResult> register(
+    RegisterRequest request, {
+    MultipartFile? image,
+  }) async {
+    latestRequest = request;
+    return const AuthenticatedResult(
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    );
+  }
 }


### PR DESCRIPTION
## 변경 내용

- Auth 세션을 `unauthenticated`, `signupRequired`, `authenticated`로 모델링하고 secure token 복원을 연결했습니다.
- 로그인 화면을 소셜 credential gateway와 기존 `/auth/login` repository에 연결했습니다.
- 프로필·약관 화면에서 `/auth/register`를 호출하고 인증 세션으로 전환합니다.
- 인증 상태 기반 route redirect와 로그인 전 target 복원을 추가했습니다.
- 화면·모델·API 수직 슬라이스 우선순위와 구현 이력을 문서화했습니다.

## 현재 제약

- Kakao/Google/Apple SDK와 앱 키가 아직 준비되지 않아 기본 gateway는 설정 안내 오류를 표시합니다. SDK 준비 시 gateway 구현만 교체합니다.
- 프로필 샘플 이미지는 실제 파일이 아니므로 register multipart image에는 임의 전송하지 않습니다.
- refresh와 서버 logout은 Swagger endpoint 확정 전까지 범위에서 제외했습니다.

## 검증

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test --reporter compact` — 280개 통과, 기존 skip 1개
- `git diff --check`

Closes #227