### PR TITLE
Feat: 식물 등록·수정 API 폼 상태 완성 #229

### DIFF
--- a/docs/work-history/plant-form-api-state-229.md
+++ b/docs/work-history/plant-form-api-state-229.md
@@ -29,11 +29,21 @@
 
 | 순서 | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- | --- |
-| 1 | 이 문서의 최초 커밋 | 작업 계약과 병렬 작업 파일 경계 기록 | `git diff --check` |
-| 2 | 예정 | 날짜 상태·Controller·API 요청과 unit test | 관련 Plant provider test |
-| 3 | 예정 | 등록·수정 날짜 선택 UI와 widget test | Plant form page test |
-| 4 | 예정 | 전체 검증 결과와 최종 이력 | format, analyze, 전체 test, `git diff --check` |
+| 1 | `3816e05` | 작업 계약과 병렬 작업 파일 경계 기록 | `git diff --check` |
+| 2 | `97d6e3c` | 폼의 초기·현재 물주기 날짜 상태, 변경 감지, create/update 요청 전달과 unit test | Plant form state/controller/edit provider test 13개 통과 |
+| 3 | `9eeae52` | 등록·수정 날짜 선택 UI, API 날짜 표시와 widget test | Plant form page/provider test 18개 통과 |
+| 4 | `f689495` | 원격 등록의 submitting/failure/retry와 Swagger 날짜 fixture 보강 | Plant form page/edit provider test 15개 통과 |
+| 5 | 이 문서의 최종 커밋 | 전체 검증 결과와 최종 이력 | format, analyze, 전체 test, `git diff --check` |
 
 ## 최종 검증
 
-작업 완료 후 기록한다.
+- `fvm dart format --output=none --set-exit-if-changed .`: 270개 파일 변경 없음
+- `fvm flutter analyze`: 문제 없음
+- `fvm flutter test --reporter compact`: 284개 통과, 기존 golden skip 1개
+- `git diff --check origin/develop...HEAD`: 통과
+
+## 남은 후속 작업
+
+- 식물 검색 결과의 한글 학명, 영문 학명, 사용자가 정할 애칭을 구분하는 API·화면 계약이 필요하다.
+- Plant create/update의 optional image part에 전달할 실제 파일 선택 정책과 picker 도입은 별도 이슈로 진행한다.
+- Swagger에 식물 검색 endpoint가 추가되기 전까지 현재 fixture 검색과 remote API 모델을 섞지 않는다.

--- a/docs/work-history/plant-form-api-state-229.md
+++ b/docs/work-history/plant-form-api-state-229.md
@@ -1,0 +1,39 @@
+# Plant 등록·수정 API 폼 상태 작업 이력
+
+## 작업 기준
+
+- 이슈: #229
+- 브랜치: `feature/plant-form-api-state-229`
+- 기준 브랜치: `develop`
+- 도메인: Plant
+
+## 목표
+
+- 등록 화면의 고정 물주기 날짜를 제거하고 사용자가 선택한 날짜를 폼 상태로 관리한다.
+- 수정 정보 API의 `lastWateredDate`를 폼 상태에 복원한다.
+- 등록·수정 요청에 현재 폼의 `lastWateredDate`를 Swagger 형식인 `yyyy-MM-dd`로 전달한다.
+- API 사용 여부와 관계없이 loading, failure, submitting, retry 동작을 유지한다.
+
+## 범위와 경계
+
+| 구분 | 처리 |
+| --- | --- |
+| Plant form state/controller | 이름과 마지막 물 준 날짜의 초기값·현재값·변경 여부 관리 |
+| Plant create/edit page | 날짜 선택 UI와 제출 상태 연결 |
+| Plant repository 호출 | `POST /plants`, `PUT /plants/{plantId}`에 현재 날짜 전달 |
+| 식물 학명 | 검색 결과가 한글명·영문명·애칭을 구분하지 않아 임의 매핑하지 않음 |
+| 이미지 | 파일 선택 정책과 picker 의존성이 없어 기존 multipart 경계만 유지 |
+| 검색 | Swagger에 식물 검색 API가 없어 fixture 교체 범위에서 제외 |
+
+## 커밋 계획과 이력
+
+| 순서 | 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- | --- |
+| 1 | 이 문서의 최초 커밋 | 작업 계약과 병렬 작업 파일 경계 기록 | `git diff --check` |
+| 2 | 예정 | 날짜 상태·Controller·API 요청과 unit test | 관련 Plant provider test |
+| 3 | 예정 | 등록·수정 날짜 선택 UI와 widget test | Plant form page test |
+| 4 | 예정 | 전체 검증 결과와 최종 이력 | format, analyze, 전체 test, `git diff --check` |
+
+## 최종 검증
+
+작업 완료 후 기록한다.

--- a/docs/work-history/plant-form-api-state-229.md
+++ b/docs/work-history/plant-form-api-state-229.md
@@ -33,14 +33,22 @@
 | 2 | `97d6e3c` | 폼의 초기·현재 물주기 날짜 상태, 변경 감지, create/update 요청 전달과 unit test | Plant form state/controller/edit provider test 13개 통과 |
 | 3 | `9eeae52` | 등록·수정 날짜 선택 UI, API 날짜 표시와 widget test | Plant form page/provider test 18개 통과 |
 | 4 | `f689495` | 원격 등록의 submitting/failure/retry와 Swagger 날짜 fixture 보강 | Plant form page/edit provider test 15개 통과 |
-| 5 | 이 문서의 최종 커밋 | 전체 검증 결과와 최종 이력 | format, analyze, 전체 test, `git diff --check` |
+| 5 | `a4c960f` | 최초 전체 검증 결과와 이력 기록 | format, analyze, 전체 test, `git diff --check` |
+| 6 | `c0c9348` | 마지막 물 준 날짜의 미래 선택 차단, 범위 밖 서버 날짜 초기 위치 보정과 상태 보존 테스트 | Plant form page test 12개 통과 |
+| 7 | 이 문서의 후속 커밋 | 리뷰 반영 결과와 최종 검증 갱신 | format, analyze, 전체 test, `git diff --check` |
 
 ## 최종 검증
 
 - `fvm dart format --output=none --set-exit-if-changed .`: 270개 파일 변경 없음
 - `fvm flutter analyze`: 문제 없음
-- `fvm flutter test --reporter compact`: 284개 통과, 기존 golden skip 1개
+- `fvm flutter test --reporter compact`: 285개 통과, 기존 golden skip 1개
 - `git diff --check origin/develop...HEAD`: 통과
+
+## 리뷰 반영
+
+- 마지막 물 준 날짜 선택기의 최대 날짜를 실행 당일로 제한해 미래 날짜를 새로 선택할 수 없게 했다.
+- 서버의 기존 날짜가 선택 범위보다 이전이거나 미래이면 picker의 초기 위치만 범위 안으로 보정한다.
+- 범위 밖 서버 값은 사용자가 새 날짜를 확정하기 전까지 폼 상태와 화면 표시에서 그대로 보존한다.
 
 ## 남은 후속 작업
 

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -64,9 +64,14 @@ class PlantFormPage extends ConsumerWidget {
       return PlantCreateScaffold(
         places: formState.places,
         selectedPlaceId: formState.selectedPlaceId,
-        wateringDate: '2023. 01. 30',
+        lastWateredDate: formState.currentLastWateredDate,
         isSubmitting: formState.isSubmitting,
         onPlaceSelected: controller.selectPlace,
+        onWateringDateTap: () => _selectLastWateredDate(
+          context,
+          ref,
+          formState.currentLastWateredDate,
+        ),
         onCancel: () => _cancelCreate(context),
         onSubmit: () => _submit(context, ref),
       );
@@ -74,11 +79,39 @@ class PlantFormPage extends ConsumerWidget {
 
     return PlantEditScaffold(
       name: formState.currentName,
+      lastWateredDate: formState.currentLastWateredDate,
       canSubmit: formState.canSubmit,
       isSubmitting: formState.isSubmitting,
       onChanged: controller.updateName,
+      onWateringDateTap: () => _selectLastWateredDate(
+        context,
+        ref,
+        formState.currentLastWateredDate,
+      ),
       onSubmit: () => _submit(context, ref),
     );
+  }
+
+  Future<void> _selectLastWateredDate(
+    BuildContext context,
+    WidgetRef ref,
+    String? currentDate,
+  ) async {
+    final today = DateUtils.dateOnly(DateTime.now());
+    final selectedDate = await showDatePicker(
+      context: context,
+      initialDate: DateTime.tryParse(currentDate ?? '') ?? today,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100),
+    );
+
+    if (selectedDate == null || !context.mounted) {
+      return;
+    }
+
+    ref
+        .read(plantFormControllerProvider(_args).notifier)
+        .updateLastWateredDate(selectedDate);
   }
 
   void _cancelCreate(BuildContext context) {

--- a/lib/features/plant/presentation/pages/plant_form_page.dart
+++ b/lib/features/plant/presentation/pages/plant_form_page.dart
@@ -98,11 +98,16 @@ class PlantFormPage extends ConsumerWidget {
     String? currentDate,
   ) async {
     final today = DateUtils.dateOnly(DateTime.now());
+    final firstDate = DateTime(1900);
     final selectedDate = await showDatePicker(
       context: context,
-      initialDate: DateTime.tryParse(currentDate ?? '') ?? today,
-      firstDate: DateTime(1900),
-      lastDate: DateTime(2100),
+      initialDate: _clampWateringDatePickerInitialDate(
+        currentDate: currentDate,
+        firstDate: firstDate,
+        lastDate: today,
+      ),
+      firstDate: firstDate,
+      lastDate: today,
     );
 
     if (selectedDate == null || !context.mounted) {
@@ -155,4 +160,28 @@ class PlantFormPage extends ConsumerWidget {
         }
     }
   }
+}
+
+DateTime _clampWateringDatePickerInitialDate({
+  required String? currentDate,
+  required DateTime firstDate,
+  required DateTime lastDate,
+}) {
+  final parsedDate = DateTime.tryParse(currentDate ?? '');
+
+  if (parsedDate == null) {
+    return lastDate;
+  }
+
+  final date = DateUtils.dateOnly(parsedDate);
+
+  if (date.isBefore(firstDate)) {
+    return firstDate;
+  }
+
+  if (date.isAfter(lastDate)) {
+    return lastDate;
+  }
+
+  return date;
 }

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -65,6 +65,9 @@ class PlantFormController extends Notifier<PlantFormState> {
                 plantId: plantId,
                 placeId: args.placeId,
                 name: info.name.trim(),
+                lastWateredDate: _normalizedLastWateredDate(
+                  info.lastWateredDate,
+                ),
               );
             },
             error: (error, stackTrace) => PlantFormState.failure(
@@ -104,6 +107,17 @@ class PlantFormController extends Notifier<PlantFormState> {
 
     state = state.copyWith(
       currentName: name,
+      submitState: const FormSubmitState.idle(),
+    );
+  }
+
+  void updateLastWateredDate(DateTime date) {
+    if (state.loadStatus != PlantFormLoadStatus.ready) {
+      return;
+    }
+
+    state = state.copyWith(
+      currentLastWateredDate: _formatPlantWateringDate(date),
       submitState: const FormSubmitState.idle(),
     );
   }
@@ -164,7 +178,7 @@ class PlantFormController extends Notifier<PlantFormState> {
           .createPlant(
             placeCode: selectedPlace.id,
             nickname: plantName,
-            scientificNameKo: plantName,
+            lastWateredDate: state.currentLastWateredDate,
           );
       ref.invalidate(remotePlantListProvider);
     }
@@ -192,6 +206,7 @@ class PlantFormController extends Notifier<PlantFormState> {
             plantId: plantId,
             placeCode: placeId,
             nickname: plantName,
+            lastWateredDate: state.currentLastWateredDate,
           );
       ref.invalidate(remotePlantListProvider);
     }
@@ -233,4 +248,17 @@ String _normalizedInitialPlantName(String? initialPlantName) {
   }
 
   return plantName;
+}
+
+String? _normalizedLastWateredDate(String? lastWateredDate) {
+  final normalized = lastWateredDate?.trim();
+
+  return normalized == null || normalized.isEmpty ? null : normalized;
+}
+
+String _formatPlantWateringDate(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+
+  return '${date.year}-$month-$day';
 }

--- a/lib/features/plant/presentation/providers/plant_form_state.dart
+++ b/lib/features/plant/presentation/providers/plant_form_state.dart
@@ -33,6 +33,8 @@ class PlantFormState {
     required this.mode,
     required this.initialName,
     required this.currentName,
+    required this.initialLastWateredDate,
+    required this.currentLastWateredDate,
     required this.places,
     required this.selectedPlaceId,
     required this.loadStatus,
@@ -49,6 +51,8 @@ class PlantFormState {
          mode: PlantFormMode.create,
          initialName: plantName,
          currentName: plantName,
+         initialLastWateredDate: null,
+         currentLastWateredDate: null,
          places: List.unmodifiable(places),
          selectedPlaceId: places.isEmpty ? null : places.first.id,
          loadStatus: PlantFormLoadStatus.ready,
@@ -64,6 +68,8 @@ class PlantFormState {
          mode: PlantFormMode.edit,
          initialName: '',
          currentName: '',
+         initialLastWateredDate: null,
+         currentLastWateredDate: null,
          places: const [],
          selectedPlaceId: null,
          loadStatus: PlantFormLoadStatus.loading,
@@ -74,12 +80,15 @@ class PlantFormState {
     required String plantId,
     required String? placeId,
     required String name,
+    required String? lastWateredDate,
   }) : this(
          plantId: plantId,
          placeId: placeId,
          mode: PlantFormMode.edit,
          initialName: name,
          currentName: name,
+         initialLastWateredDate: lastWateredDate,
+         currentLastWateredDate: lastWateredDate,
          places: const [],
          selectedPlaceId: null,
          loadStatus: PlantFormLoadStatus.ready,
@@ -95,6 +104,8 @@ class PlantFormState {
          mode: PlantFormMode.edit,
          initialName: '',
          currentName: '',
+         initialLastWateredDate: null,
+         currentLastWateredDate: null,
          places: const [],
          selectedPlaceId: null,
          loadStatus: PlantFormLoadStatus.notFound,
@@ -111,6 +122,8 @@ class PlantFormState {
          mode: PlantFormMode.edit,
          initialName: '',
          currentName: '',
+         initialLastWateredDate: null,
+         currentLastWateredDate: null,
          places: const [],
          selectedPlaceId: null,
          loadStatus: PlantFormLoadStatus.failure,
@@ -123,6 +136,8 @@ class PlantFormState {
   final PlantFormMode mode;
   final String initialName;
   final String currentName;
+  final String? initialLastWateredDate;
+  final String? currentLastWateredDate;
   final List<PlantRegistrationPlace> places;
   final String? selectedPlaceId;
   final PlantFormLoadStatus loadStatus;
@@ -135,7 +150,9 @@ class PlantFormState {
 
   String? get submitErrorMessage => submitState.errorMessage;
 
-  bool get hasChanges => currentName.trim() != initialName;
+  bool get hasChanges =>
+      currentName.trim() != initialName ||
+      currentLastWateredDate != initialLastWateredDate;
 
   PlantRegistrationPlace? get selectedPlace {
     final selectedPlaceId = this.selectedPlaceId;
@@ -167,6 +184,7 @@ class PlantFormState {
 
   PlantFormState copyWith({
     String? currentName,
+    Object? currentLastWateredDate = _unset,
     List<PlantRegistrationPlace>? places,
     Object? selectedPlaceId = _unset,
     FormSubmitState? submitState,
@@ -177,6 +195,10 @@ class PlantFormState {
       mode: mode,
       initialName: initialName,
       currentName: currentName ?? this.currentName,
+      initialLastWateredDate: initialLastWateredDate,
+      currentLastWateredDate: identical(currentLastWateredDate, _unset)
+          ? this.currentLastWateredDate
+          : currentLastWateredDate as String?,
       places: places == null ? this.places : List.unmodifiable(places),
       selectedPlaceId: identical(selectedPlaceId, _unset)
           ? this.selectedPlaceId

--- a/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
+++ b/lib/features/plant/presentation/widgets/plant_form_scaffold.dart
@@ -14,17 +14,21 @@ import 'package:flutter/material.dart';
 class PlantEditScaffold extends StatelessWidget {
   const PlantEditScaffold({
     required this.name,
+    required this.lastWateredDate,
     required this.canSubmit,
     required this.isSubmitting,
     required this.onChanged,
+    required this.onWateringDateTap,
     required this.onSubmit,
     super.key,
   });
 
   final String name;
+  final String? lastWateredDate;
   final bool canSubmit;
   final bool isSubmitting;
   final ValueChanged<String> onChanged;
+  final VoidCallback onWateringDateTap;
   final VoidCallback onSubmit;
 
   @override
@@ -57,6 +61,11 @@ class PlantEditScaffold extends StatelessWidget {
                       const PlantEditPhotoButton(),
                       const SizedBox(height: AppSpacing.x32),
                       PlantNameField(name: name, onChanged: onChanged),
+                      const SizedBox(height: AppSpacing.x32),
+                      PlantWateringDateField(
+                        lastWateredDate: lastWateredDate,
+                        onTap: onWateringDateTap,
+                      ),
                     ],
                   ),
                 ),
@@ -86,9 +95,10 @@ class PlantCreateScaffold extends StatelessWidget {
   const PlantCreateScaffold({
     required this.places,
     required this.selectedPlaceId,
-    required this.wateringDate,
+    required this.lastWateredDate,
     required this.isSubmitting,
     required this.onPlaceSelected,
+    required this.onWateringDateTap,
     required this.onCancel,
     required this.onSubmit,
     super.key,
@@ -96,9 +106,10 @@ class PlantCreateScaffold extends StatelessWidget {
 
   final List<PlantRegistrationPlace> places;
   final String? selectedPlaceId;
-  final String wateringDate;
+  final String? lastWateredDate;
   final bool isSubmitting;
   final ValueChanged<PlantRegistrationPlace> onPlaceSelected;
+  final VoidCallback onWateringDateTap;
   final VoidCallback onCancel;
   final VoidCallback onSubmit;
 
@@ -136,7 +147,10 @@ class PlantCreateScaffold extends StatelessWidget {
                         onPlaceSelected: onPlaceSelected,
                       ),
                       const SizedBox(height: AppSpacing.x32),
-                      PlantWateringDateField(date: wateringDate),
+                      PlantWateringDateField(
+                        lastWateredDate: lastWateredDate,
+                        onTap: onWateringDateTap,
+                      ),
                     ],
                   ),
                 ),

--- a/lib/features/plant/presentation/widgets/plant_watering_date_field.dart
+++ b/lib/features/plant/presentation/widgets/plant_watering_date_field.dart
@@ -5,58 +5,72 @@ import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
 import 'package:flutter/material.dart';
 
 class PlantWateringDateField extends StatelessWidget {
-  const PlantWateringDateField({required this.date, super.key});
+  const PlantWateringDateField({
+    required this.lastWateredDate,
+    required this.onTap,
+    super.key,
+  });
 
-  final String date;
+  final String? lastWateredDate;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        DecoratedBox(
-          decoration: const BoxDecoration(
-            border: Border(
-              bottom: BorderSide(color: AppColorPrimitives.grayGray2),
-            ),
-          ),
-          child: SizedBox(
-            width: double.infinity,
-            height: AppSizes.addressOrPlaceFieldHeight,
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '마지막으로 물 준 날짜',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTextStyles.size18Medium.copyWith(
-                      color: AppColors.textStrong,
-                    ),
-                  ),
+        Semantics(
+          button: true,
+          label: '마지막으로 물 준 날짜 선택',
+          child: InkWell(
+            onTap: onTap,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: AppColorPrimitives.grayGray2),
                 ),
-                const SizedBox(width: AppSpacing.x12),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: AppColors.surfaceDisabled,
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: AppSpacing.x8,
-                    ),
-                    child: Text(
-                      date,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTextStyles.size18Medium.copyWith(
-                        color: AppColors.textStrong,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                height: AppSizes.addressOrPlaceFieldHeight,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '마지막으로 물 준 날짜',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTextStyles.size18Medium.copyWith(
+                          color: AppColors.textStrong,
+                        ),
                       ),
                     ),
-                  ),
+                    const SizedBox(width: AppSpacing.x12),
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: AppColors.surfaceDisabled,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: AppSpacing.x8,
+                        ),
+                        child: Text(
+                          _displayDate(lastWateredDate),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTextStyles.size18Medium.copyWith(
+                            color: lastWateredDate == null
+                                ? AppColors.textBody
+                                : AppColors.textStrong,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),
@@ -72,4 +86,18 @@ class PlantWateringDateField extends StatelessWidget {
       ],
     );
   }
+}
+
+String _displayDate(String? date) {
+  if (date == null) {
+    return '날짜 선택';
+  }
+
+  final parts = date.split('-');
+
+  if (parts.length != 3) {
+    return date;
+  }
+
+  return '${parts[0]}. ${parts[1]}. ${parts[2]}';
 }

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -20,7 +20,8 @@ void main() {
     expect(find.text('스윗 홈_거실'), findsOneWidget);
     expect(find.text('낫 스윗 회사_가든'), findsOneWidget);
     expect(find.text('마지막으로 물 준 날짜'), findsOneWidget);
-    expect(find.text('2023. 01. 30'), findsOneWidget);
+    expect(find.text('날짜 선택'), findsOneWidget);
+    expect(find.text('2023. 01. 30'), findsNothing);
     expect(find.text('선택하지 않을 시, 등록일을 기준으로 설정합니다'), findsOneWidget);
     expect(find.text('취소'), findsOneWidget);
     expect(find.text('등록'), findsOneWidget);
@@ -42,6 +43,48 @@ void main() {
       find.widgetWithText(FilledButton, '완료'),
     );
     expect(completeButton.onPressed, isNull);
+  });
+
+  testWidgets('식물 등록 화면에서 선택한 날짜를 폼에 표시한다', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PlantFormPage())),
+    );
+
+    await tester.tap(find.text('날짜 선택'));
+    await tester.pumpAndSettle();
+
+    final calendar = tester.widget<CalendarDatePicker>(
+      find.byType(CalendarDatePicker),
+    );
+    calendar.onDateChanged(DateTime(2026, 8, 25));
+    await tester.pump();
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2026. 08. 25'), findsOneWidget);
+    expect(find.text('날짜 선택'), findsNothing);
+  });
+
+  testWidgets('식물 수정 화면은 API에서 불러온 마지막 물 준 날짜를 복원한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(
+            _StaticEditInfoPlantRepository(
+              const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026-05-25'),
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: PlantFormPage(plantId: 'plant-1', placeId: 'place-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('2026. 05. 25'), findsOneWidget);
+    expect(find.text('필로덴드론'), findsOneWidget);
   });
 
   testWidgets('식물 수정 화면은 원격 제출 중 완료 버튼을 잠근다', (tester) async {

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -89,6 +89,47 @@ void main() {
     expect(find.text('필로덴드론'), findsOneWidget);
   });
 
+  testWidgets('미래 API 날짜는 보존하되 날짜 선택기는 오늘 이후를 허용하지 않는다', (tester) async {
+    final today = DateUtils.dateOnly(DateTime.now());
+    final futureDate = DateTime(today.year + 1, today.month, today.day);
+    final apiDate = _apiDate(futureDate);
+    final displayDate = _displayDate(futureDate);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(
+            _StaticEditInfoPlantRepository(
+              PlantEditInfo(name: '필로덴드론', lastWateredDate: apiDate),
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: PlantFormPage(plantId: 'plant-1', placeId: 'place-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(displayDate), findsOneWidget);
+
+    await tester.tap(find.text(displayDate));
+    await tester.pumpAndSettle();
+
+    final calendar = tester.widget<CalendarDatePicker>(
+      find.byType(CalendarDatePicker),
+    );
+    expect(calendar.initialDate, today);
+    expect(calendar.lastDate, today);
+
+    await tester.tapAt(const Offset(4, 4));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CalendarDatePicker), findsNothing);
+    expect(find.text(displayDate), findsOneWidget);
+  });
+
   testWidgets('식물 등록 화면은 원격 제출 중 등록 버튼을 잠근다', (tester) async {
     final repository = _PendingPlantCreateRepository();
 
@@ -273,6 +314,20 @@ void main() {
     expect(find.text('필로덴드론'), findsOneWidget);
     expect(find.text('식물 수정 정보를 불러오지 못했어요'), findsNothing);
   });
+}
+
+String _apiDate(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+
+  return '${date.year}-$month-$day';
+}
+
+String _displayDate(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+
+  return '${date.year}. $month. $day';
 }
 
 class _PendingPlantCreateRepository extends Fake implements PlantRepository {

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -4,7 +4,9 @@ import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
 import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
+import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -85,6 +87,65 @@ void main() {
 
     expect(find.text('2026. 05. 25'), findsOneWidget);
     expect(find.text('필로덴드론'), findsOneWidget);
+  });
+
+  testWidgets('식물 등록 화면은 원격 제출 중 등록 버튼을 잠근다', (tester) async {
+    final repository = _PendingPlantCreateRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+          plantRegistrationPlaceProvider.overrideWith(
+            (ref) => [plantRegistrationPlaceFallbacks.first],
+          ),
+        ],
+        child: const MaterialApp(home: PlantFormPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, '등록'));
+    await tester.pump();
+
+    expect(repository.createCalls, 1);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    final submitButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '등록'),
+    );
+    expect(submitButton.onPressed, isNull);
+  });
+
+  testWidgets('식물 등록 실패는 사용자 오류를 표시하고 재시도할 수 있다', (tester) async {
+    final repository = _FailingPlantCreateRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+          plantRegistrationPlaceProvider.overrideWith(
+            (ref) => [plantRegistrationPlaceFallbacks.first],
+          ),
+        ],
+        child: const MaterialApp(home: PlantFormPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, '등록'));
+    await tester.pumpAndSettle();
+
+    expect(repository.createCalls, 1);
+    expect(find.text('식물 등록에 실패했어요'), findsOneWidget);
+    expect(find.textContaining('raw failure'), findsNothing);
+
+    final submitButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, '등록'),
+    );
+    expect(submitButton.onPressed, isNotNull);
   });
 
   testWidgets('식물 수정 화면은 원격 제출 중 완료 버튼을 잠근다', (tester) async {
@@ -212,6 +273,41 @@ void main() {
     expect(find.text('필로덴드론'), findsOneWidget);
     expect(find.text('식물 수정 정보를 불러오지 못했어요'), findsNothing);
   });
+}
+
+class _PendingPlantCreateRepository extends Fake implements PlantRepository {
+  final Completer<void> _completer = Completer<void>();
+  int createCalls = 0;
+
+  @override
+  Future<void> createPlant({
+    required String placeCode,
+    required String nickname,
+    String? scientificNameKo,
+    String? scientificNameEn,
+    String? lastWateredDate,
+    String? description,
+  }) {
+    createCalls++;
+    return _completer.future;
+  }
+}
+
+class _FailingPlantCreateRepository extends Fake implements PlantRepository {
+  int createCalls = 0;
+
+  @override
+  Future<void> createPlant({
+    required String placeCode,
+    required String nickname,
+    String? scientificNameKo,
+    String? scientificNameEn,
+    String? lastWateredDate,
+    String? description,
+  }) async {
+    createCalls++;
+    throw StateError('raw failure');
+  }
 }
 
 class _PendingPlantRepository extends Fake implements PlantRepository {

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -28,6 +28,7 @@ void main() {
         plantFormControllerProvider(args).notifier,
       );
       controller.selectPlace(plantRegistrationPlaceFallbacks[1]);
+      controller.updateLastWateredDate(DateTime(2026, 8, 25));
 
       final result = await controller.submit();
       final plants = container.read(plantListProvider);
@@ -66,16 +67,19 @@ void main() {
       await container.read(plantRegistrationPlaceProvider.future);
       await Future<void>.delayed(Duration.zero);
 
-      final result = await container
-          .read(plantFormControllerProvider(args).notifier)
-          .submit();
+      final controller = container.read(
+        plantFormControllerProvider(args).notifier,
+      );
+      controller.updateLastWateredDate(DateTime(2026, 8, 5));
+      final result = await controller.submit();
       final plants = container.read(plantListProvider);
 
       expect(result?.destination, PlantFormSubmitDestination.home);
       expect(repository.createCalls, 1);
       expect(repository.latestCreatePlaceCode, 'place-1');
       expect(repository.latestCreateNickname, '몬스테라');
-      expect(repository.latestCreateScientificNameKo, '몬스테라');
+      expect(repository.latestCreateScientificNameKo, isNull);
+      expect(repository.latestCreateLastWateredDate, '2026-08-05');
       expect(plants.single.name, '몬스테라');
     });
 
@@ -139,8 +143,10 @@ void main() {
       );
 
       expect(initialState.currentName, '몬테');
+      expect(initialState.currentLastWateredDate, '2026-05-25');
 
       controller.updateName('몬테라');
+      controller.updateLastWateredDate(DateTime(2026, 8, 24));
       final result = await controller.submit();
 
       expect(result?.destination, PlantFormSubmitDestination.plantDetail);
@@ -148,6 +154,7 @@ void main() {
       expect(repository.latestUpdatePlantId, 'plant-1');
       expect(repository.latestUpdatePlaceCode, 'place-1');
       expect(repository.latestUpdateNickname, '몬테라');
+      expect(repository.latestUpdateLastWateredDate, '2026-08-24');
     });
   });
 }
@@ -160,11 +167,13 @@ class _RecordingPlantRepository extends Fake implements PlantRepository {
   String? latestCreatePlaceCode;
   String? latestCreateNickname;
   String? latestCreateScientificNameKo;
+  String? latestCreateLastWateredDate;
   String? latestUpdateNickname;
+  String? latestUpdateLastWateredDate;
 
   @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
-    return const PlantEditInfo(name: '몬테');
+    return const PlantEditInfo(name: '몬테', lastWateredDate: '2026-05-25');
   }
 
   @override
@@ -180,6 +189,7 @@ class _RecordingPlantRepository extends Fake implements PlantRepository {
     latestCreatePlaceCode = placeCode;
     latestCreateNickname = nickname;
     latestCreateScientificNameKo = scientificNameKo;
+    latestCreateLastWateredDate = lastWateredDate;
   }
 
   @override
@@ -194,5 +204,6 @@ class _RecordingPlantRepository extends Fake implements PlantRepository {
     latestUpdatePlantId = plantId;
     latestUpdatePlaceCode = placeCode;
     latestUpdateNickname = nickname;
+    latestUpdateLastWateredDate = lastWateredDate;
   }
 }

--- a/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_edit_provider_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('remote mode는 식물 수정 정보를 반환한다', () async {
       final repository = _StaticPlantRepository(
-        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026.05.25'),
+        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026-05-25'),
       );
       final container = ProviderContainer(
         overrides: [
@@ -39,13 +39,13 @@ void main() {
           .requireValue;
 
       expect(info?.name, '필로덴드론');
-      expect(info?.lastWateredDate, '2026.05.25');
+      expect(info?.lastWateredDate, '2026-05-25');
       expect(repository.fetchCalls, 1);
     });
 
     test('수정 정보 remote 조회를 repository에 위임한다', () async {
       final repository = _StaticPlantRepository(
-        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026.05.25'),
+        const PlantEditInfo(name: '필로덴드론', lastWateredDate: '2026-05-25'),
       );
       final container = ProviderContainer(
         overrides: [plantRepositoryProvider.overrideWithValue(repository)],

--- a/test/features/plant/presentation/providers/plant_form_state_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_state_test.dart
@@ -15,6 +15,7 @@ void main() {
 
       expect(state.isEdit, isFalse);
       expect(state.selectedPlace?.id, 'place-1');
+      expect(state.currentLastWateredDate, isNull);
       expect(state.canSubmit, isTrue);
     });
 
@@ -37,12 +38,17 @@ void main() {
         plantId: 'plant-1',
         placeId: 'place-1',
         name: '몬테',
+        lastWateredDate: '2026-05-25',
       );
 
       expect(state.isEdit, isTrue);
       expect(state.hasChanges, isFalse);
       expect(state.canSubmit, isFalse);
       expect(state.copyWith(currentName: '몬테라').canSubmit, isTrue);
+      expect(
+        state.copyWith(currentLastWateredDate: '2026-05-26').canSubmit,
+        isTrue,
+      );
     });
 
     test('로딩과 조회 실패 상태는 제출할 수 없다', () {


### PR DESCRIPTION
## 관련 이슈

- Closes #229
- Parent: #226

## 구현 범위

- Plant 등록·수정 폼의 마지막 물 준 날짜 상태 관리
- 날짜 선택 UI와 Swagger `yyyy-MM-dd` 요청 변환
- 수정 정보 API의 `lastWateredDate` 초기값 복원
- `POST /plants`, `PUT /plants/{plantId}`에 현재 폼 날짜 전달
- loading, not found, failure, submitting, retry 회귀 테스트
- API 비사용 로컬 흐름 유지

## 주요 변경사항

- 등록 화면의 고정 날짜 `2023. 01. 30`을 제거하고 `날짜 선택` 상태로 교체했습니다.
- 수정 화면에서도 기존 물주기 날짜를 표시하고 날짜만 변경해도 제출할 수 있습니다.
- 식물 검색 결과를 학명으로 임의 전송하던 매핑을 제거했습니다.

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test --reporter compact` — 284개 통과, 기존 golden skip 1개
- `git diff --check origin/develop...HEAD`

## 리뷰 포인트

- 화면 표시값은 `yyyy. MM. dd`, API 상태와 요청값은 `yyyy-MM-dd`입니다.
- image picker와 식물 검색/학명 구분은 API·화면 계약이 없어 이번 PR에서 제외했습니다.

## 문서

- `docs/work-history/plant-form-api-state-229.md`

## Breaking change

- 없음
