### PR TITLE
Feat: Home 사용자 실데이터 연결 #232

### DIFF
--- a/docs/work-history/home-user-api-state-232.md
+++ b/docs/work-history/home-user-api-state-232.md
@@ -1,0 +1,58 @@
+# Home 사용자 실데이터 상태 연결 이력
+
+## 작업 기준
+
+- 이슈: #232 `[Feature] Home 사용자 실데이터 상태 연결`
+- 작업일: 2026-08-25
+- 참고 문서:
+  - `README.md`
+  - `docs/feature-development-guide.md`
+  - `docs/state-management-guide.md`
+  - `docs/api-swagger-reference.md`
+  - `docs/testing-guide.md`
+  - `docs/git-workflow.md`
+
+## 목표와 범위
+
+Home hero의 고정 사용자명을 현재 사용자 상태로 교체하고, API 사용 모드에서 기존 `UserRepository.fetchMe()`가 `GET /users`를 호출하도록 연결했다. Place·Plant 목록 상태와 Friend 데이터는 범위에 포함하지 않았다.
+
+| 모드 | 사용자 데이터 | Home 표시 |
+| --- | --- | --- |
+| API 비사용 | 로컬 `UserProfile` fixture | 기존 `커먼(유저 네임` 표시 계약 보존 |
+| API 사용 | `UserRepository.fetchMe()` | `GET /users` 결과의 `name` 표시 |
+| API 최초 조회 중 | `AsyncLoading` | 진행 표시와 접근성 label 노출 |
+| API 조회 실패 | `AsyncError` | 오류 안내와 `다시 시도` 제공 |
+| API 재시도 성공 | `AsyncData<UserProfile>` | 복구된 사용자명 표시 |
+
+## 구현 경계
+
+- `currentUserProvider`는 환경 설정을 확인한 뒤 API 사용 모드에서만 repository를 호출한다.
+- Home 위젯은 repository와 JSON 구조를 알지 않고 `AsyncValue<UserProfile>` 상태만 표시한다.
+- 재시도는 `currentUserProvider`만 invalidate하여 Place·Plant 목록을 다시 조회하지 않는다.
+- API 비사용 Home과 Android smoke의 결정적 텍스트는 유지한다.
+
+## 보류 항목
+
+Home의 `요청 3건`은 기존 고정값을 유지한다. Swagger의 `GET /friends/requests`에 성공 response schema가 없어 목록 wrapper, 식별자, 상태, 초대 요청 판별 기준을 안전하게 mapping할 수 없다. response schema와 갱신 정책이 확정되면 Friend 전용 이슈에서 목록·count·수락·거절 상태를 함께 연결한다.
+
+## 커밋별 작업 이력
+
+| 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- |
+| `1480c59` | API on/off 분기와 `UserRepository.fetchMe()`를 사용하는 `currentUserProvider`, Provider 단위 테스트 | Provider 테스트 3개, `git diff --check` |
+| `90e46c6` | Home hero 사용자명·loading·error·retry UI, Reference/Compact width 위젯 테스트 | Home/widget 테스트 8개, `fvm flutter analyze`, `git diff --check` |
+| 이 문서 커밋 | 작업 경계, Friend count blocker, 전체 검증 결과 기록 | `git diff --check` |
+
+## 최종 검증
+
+```bash
+fvm dart format --output=none --set-exit-if-changed .
+fvm flutter analyze
+fvm flutter test
+git diff --check
+```
+
+- format: 273개 파일 변경 없음
+- analyze: issue 없음
+- test: 286개 통과, 기존 golden 1개 skip
+- diff check: 통과

--- a/docs/work-history/home-user-api-state-232.md
+++ b/docs/work-history/home-user-api-state-232.md
@@ -28,6 +28,7 @@ Home hero의 고정 사용자명을 현재 사용자 상태로 교체하고, API
 
 - `currentUserProvider`는 환경 설정을 확인한 뒤 API 사용 모드에서만 repository를 호출한다.
 - Home 위젯은 repository와 JSON 구조를 알지 않고 `AsyncValue<UserProfile>` 상태만 표시한다.
+- Provider 자동 재시도를 비활성화하여 오류 표시와 재시도 호출 횟수를 Home의 명시적 재시도 UI가 소유한다.
 - 재시도는 `currentUserProvider`만 invalidate하여 Place·Plant 목록을 다시 조회하지 않는다.
 - API 비사용 Home과 Android smoke의 결정적 텍스트는 유지한다.
 
@@ -41,7 +42,9 @@ Home의 `요청 3건`은 기존 고정값을 유지한다. Swagger의 `GET /frie
 | --- | --- | --- |
 | `1480c59` | API on/off 분기와 `UserRepository.fetchMe()`를 사용하는 `currentUserProvider`, Provider 단위 테스트 | Provider 테스트 3개, `git diff --check` |
 | `90e46c6` | Home hero 사용자명·loading·error·retry UI, Reference/Compact width 위젯 테스트 | Home/widget 테스트 8개, `fvm flutter analyze`, `git diff --check` |
-| 이 문서 커밋 | 작업 경계, Friend count blocker, 전체 검증 결과 기록 | `git diff --check` |
+| `00a36b8` | 작업 경계, Friend count blocker, 최초 전체 검증 결과 기록 | `git diff --check` |
+| `5d2cdad` | `currentUserProvider` 자동 재시도 비활성화, 명시적 retry 정책 테스트 | Provider/Home 집중 테스트 7개, `fvm flutter analyze`, `git diff --check` |
+| 이 문서 후속 커밋 | 자동·명시적 retry 경계와 최종 검증 결과 갱신 | `git diff --check` |
 
 ## 최종 검증
 
@@ -54,5 +57,5 @@ git diff --check
 
 - format: 273개 파일 변경 없음
 - analyze: issue 없음
-- test: 286개 통과, 기존 golden 1개 skip
+- test: 287개 통과, 기존 golden 1개 skip
 - diff check: 통과

--- a/lib/features/home/presentation/widgets/home_hero.dart
+++ b/lib/features/home/presentation/widgets/home_hero.dart
@@ -1,10 +1,13 @@
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/current_user_provider.dart';
 import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HomeHero extends StatelessWidget {
   const HomeHero({
@@ -34,13 +37,9 @@ class HomeHero extends StatelessWidget {
         ),
         Positioned(
           left: AppSpacing.x20,
+          right: AppSpacing.x20,
           top: topInset + 48,
-          child: Text(
-            '커먼(유저 네임',
-            style: AppTextStyles.size16Bold.copyWith(
-              color: AppColorPrimitives.unspecifiedGreenGray,
-            ),
-          ),
+          child: const _HomeCurrentUserName(),
         ),
         Positioned(
           left: AppSpacing.x20,
@@ -106,6 +105,66 @@ class HomeHero extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _HomeCurrentUserName extends ConsumerWidget {
+  const _HomeCurrentUserName();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentUser = ref.watch(currentUserProvider);
+
+    return currentUser.when(
+      skipLoadingOnRefresh: false,
+      loading: () => Align(
+        alignment: Alignment.centerLeft,
+        child: Semantics(
+          label: '사용자 정보 불러오는 중',
+          child: const SizedBox.square(
+            dimension: AppSizes.iconSmall,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: AppColors.brandPrimary,
+            ),
+          ),
+        ),
+      ),
+      error: (_, _) => Row(
+        children: [
+          Flexible(
+            child: Text(
+              '사용자 정보를 불러오지 못했어요',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.size14Medium.copyWith(
+                color: AppColors.textBody,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.x8),
+          TextButton(
+            onPressed: () => ref.invalidate(currentUserProvider),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.brandPrimary,
+              minimumSize: const Size(0, AppSizes.iconSmall),
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x4),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              textStyle: AppTextStyles.size14Bold,
+            ),
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+      data: (user) => Text(
+        user.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: AppTextStyles.size16Bold.copyWith(
+          color: AppColorPrimitives.unspecifiedGreenGray,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/user/presentation/providers/current_user_provider.dart
+++ b/lib/features/user/presentation/providers/current_user_provider.dart
@@ -11,4 +11,4 @@ final currentUserProvider = FutureProvider<UserProfile>((ref) async {
   }
 
   return ref.watch(userRepositoryProvider).fetchMe();
-});
+}, retry: (retryCount, error) => null);

--- a/lib/features/user/presentation/providers/current_user_provider.dart
+++ b/lib/features/user/presentation/providers/current_user_provider.dart
@@ -1,0 +1,14 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const _localUserProfile = UserProfile(id: 'local-user', name: '커먼(유저 네임');
+
+final currentUserProvider = FutureProvider<UserProfile>((ref) async {
+  if (!ref.watch(useRemoteApiProvider)) {
+    return _localUserProfile;
+  }
+
+  return ref.watch(userRepositoryProvider).fetchMe();
+});

--- a/test/features/home/presentation/widgets/home_hero_test.dart
+++ b/test/features/home/presentation/widgets/home_hero_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/home/presentation/widgets/home_hero.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Home hero에 현재 사용자 이름을 표시한다', (tester) async {
+    final repository = _StaticUserRepository(
+      const UserProfile(id: 'user-232', name: '새싹집사'),
+    );
+
+    await tester.pumpWidget(_buildHero(repository));
+    await tester.pumpAndSettle();
+
+    expect(find.text('새싹집사'), findsOneWidget);
+    expect(repository.fetchMeCalls, 1);
+  });
+
+  testWidgets('현재 사용자 조회 중 loading 상태를 표시한다', (tester) async {
+    final repository = _PendingUserRepository();
+
+    await tester.pumpWidget(_buildHero(repository));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('사용자 정보 불러오는 중'), findsOneWidget);
+    repository.complete(const UserProfile(id: 'user-232', name: '새싹집사'));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('현재 사용자 조회 오류에서 재시도하여 복구한다', (tester) async {
+    final repository = _RetryUserRepository();
+
+    await tester.pumpWidget(_buildHero(repository, width: 320));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사용자 정보를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.tap(find.text('다시 시도'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('재시도 사용자'), findsOneWidget);
+    expect(repository.fetchMeCalls, 2);
+  });
+}
+
+Widget _buildHero(UserRepository repository, {double width = 375}) {
+  return ProviderScope(
+    overrides: [
+      useRemoteApiProvider.overrideWithValue(true),
+      userRepositoryProvider.overrideWithValue(repository),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: width,
+          height: 220,
+          child: const HomeHero(topInset: 0, contentHeight: 200),
+        ),
+      ),
+    ),
+  );
+}
+
+class _StaticUserRepository extends Fake implements UserRepository {
+  _StaticUserRepository(this.user);
+
+  final UserProfile user;
+  int fetchMeCalls = 0;
+
+  @override
+  Future<UserProfile> fetchMe() async {
+    fetchMeCalls++;
+    return user;
+  }
+}
+
+class _PendingUserRepository extends Fake implements UserRepository {
+  final Completer<UserProfile> _completer = Completer<UserProfile>();
+
+  void complete(UserProfile user) => _completer.complete(user);
+
+  @override
+  Future<UserProfile> fetchMe() => _completer.future;
+}
+
+class _RetryUserRepository extends Fake implements UserRepository {
+  int fetchMeCalls = 0;
+
+  @override
+  Future<UserProfile> fetchMe() async {
+    fetchMeCalls++;
+    if (fetchMeCalls == 1) {
+      throw StateError('첫 조회 실패');
+    }
+
+    return const UserProfile(id: 'user-232', name: '재시도 사용자');
+  }
+}

--- a/test/features/user/presentation/providers/current_user_provider_test.dart
+++ b/test/features/user/presentation/providers/current_user_provider_test.dart
@@ -1,0 +1,79 @@
+import 'package:commonplant_frontend/core/config/app_environment.dart';
+import 'package:commonplant_frontend/features/user/data/repositories/user_repository.dart';
+import 'package:commonplant_frontend/features/user/domain/entities/user_profile.dart';
+import 'package:commonplant_frontend/features/user/presentation/providers/current_user_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('API 비사용 모드에서 기존 Home 사용자명을 보존한다', () async {
+    final repository = _RecordingUserRepository();
+    final container = ProviderContainer(
+      overrides: [
+        useRemoteApiProvider.overrideWithValue(false),
+        userRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final user = await container.read(currentUserProvider.future);
+
+    expect(user.id, 'local-user');
+    expect(user.name, '커먼(유저 네임');
+    expect(repository.fetchMeCalls, 0);
+  });
+
+  test('API 사용 모드에서 UserRepository.fetchMe 결과를 반환한다', () async {
+    final repository = _RecordingUserRepository(
+      result: const UserProfile(id: 'user-232', name: '새싹집사'),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        useRemoteApiProvider.overrideWithValue(true),
+        userRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final user = await container.read(currentUserProvider.future);
+
+    expect(user.id, 'user-232');
+    expect(user.name, '새싹집사');
+    expect(repository.fetchMeCalls, 1);
+  });
+
+  test('repository 오류를 currentUserProvider 오류 상태로 전달한다', () async {
+    final repository = _RecordingUserRepository(error: StateError('조회 실패'));
+    final container = ProviderContainer(
+      overrides: [
+        useRemoteApiProvider.overrideWithValue(true),
+        userRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(currentUserProvider.future),
+      throwsA(isA<StateError>()),
+    );
+    expect(repository.fetchMeCalls, 1);
+  });
+}
+
+class _RecordingUserRepository extends Fake implements UserRepository {
+  _RecordingUserRepository({this.result, this.error});
+
+  final UserProfile? result;
+  final Object? error;
+  int fetchMeCalls = 0;
+
+  @override
+  Future<UserProfile> fetchMe() async {
+    fetchMeCalls++;
+    if (error != null) {
+      return Future<UserProfile>.error(error!);
+    }
+
+    return result ?? const UserProfile(id: 'unused', name: '미사용');
+  }
+}

--- a/test/features/user/presentation/providers/current_user_provider_test.dart
+++ b/test/features/user/presentation/providers/current_user_provider_test.dart
@@ -58,6 +58,13 @@ void main() {
     );
     expect(repository.fetchMeCalls, 1);
   });
+
+  test('Home의 명시적 재시도를 위해 Provider 자동 재시도를 끄는다', () {
+    final retry = currentUserProvider.retry;
+
+    expect(retry, isNotNull);
+    expect(retry!(0, StateError('조회 실패')), isNull);
+  });
 }
 
 class _RecordingUserRepository extends Fake implements UserRepository {


### PR DESCRIPTION
## 관련 이슈

- Closes #232
- Parent: #226

## 구현 범위

- API 모드에서 `UserRepository.fetchMe()`와 `GET /users`를 사용하는 `currentUserProvider` 추가
- API 비사용 Home의 기존 사용자명 fixture와 Android smoke 흐름 보존
- Home hero의 고정 사용자명을 사용자 상태의 `name`으로 교체
- 현재 사용자 loading, error, retry, success UI 추가
- Friend response schema가 없는 초대 수는 기존 고정값으로 유지하고 blocker 문서화

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .`
- `fvm flutter analyze`
- `fvm flutter test`: 286개 통과, 기존 golden 1개 skip
- `git diff --check`

## 리뷰 포인트

- 현재 사용자 재시도가 `currentUserProvider`만 갱신하여 Place·Plant 목록 재조회와 독립적인지 확인 부탁드립니다.
- API 비사용 모드가 기존 Home 사용자명과 smoke 텍스트를 그대로 보존합니다.
- `요청 3건`은 `GET /friends/requests` 성공 schema가 없어 이번 PR에서 추정 연결하지 않았습니다.

## 문서

- `docs/work-history/home-user-api-state-232.md`

## Breaking change

- 없음
