### PR TITLE
Feat: 식물 상세 API 표시 모델 완성 #231

### DIFF
--- a/docs/work-history/plant-detail-api-view-231.md
+++ b/docs/work-history/plant-detail-api-view-231.md
@@ -39,8 +39,18 @@
 
 | 커밋 | 변경 범위 | 검증 |
 | --- | --- | --- |
-| 작성 예정 | 작업 기준과 데이터 표시 계약 | `git diff --check` |
+| `fd8a1de` | 작업 기준과 데이터 표시 계약 | `git diff --check` |
+| `4aa5b01` | 원격 상세 ViewData·날짜 계산·미제공 상태 UI와 상세 전용 unit/widget test | 상세 관련 test 20개, `fvm flutter analyze` |
+| 이 문서의 최종 커밋 | 전체 검증 결과와 커밋별 이력 | format 270개, analyze, 전체 test 285개 통과·기존 skip 1개, `git diff --check` |
 
 ## 최종 검증
 
-작업 완료 후 갱신한다.
+- `fvm dart format --output=none --set-exit-if-changed .`: 270개 파일, 변경 없음
+- `fvm flutter analyze`: 통과
+- `fvm flutter test --reporter compact`: 285개 통과, 기존 golden skip 1개
+- `git diff --check develop...HEAD`: 통과
+
+## 남은 서버 의존 항목
+
+- 물주기 예정일과 주기는 상세 schema에 근거 필드가 없어 미제공 상태를 유지한다.
+- Memo CRUD endpoint가 추가되기 전에는 대표 메모 문자열만 읽고 목록·작성 액션을 원격 데이터 기능으로 노출하지 않는다.

--- a/docs/work-history/plant-detail-api-view-231.md
+++ b/docs/work-history/plant-detail-api-view-231.md
@@ -1,0 +1,46 @@
+# 식물 상세 API 표시 모델 작업 이력 (#231)
+
+## 목표
+
+`GET /plants/{plantId}`의 Swagger 확인 필드만 식물 상세 화면에 표시하고, 원격 API 응답과 로컬 fixture가 실제 데이터처럼 섞이지 않도록 분리한다.
+
+## 데이터 표시 계약
+
+| 화면 정보 | 원격 API 기준 | 로컬 API-off 기준 |
+| --- | --- | --- |
+| 식물 식별자·이름·학명·장소명 | `plantId`, `scientificNameKo`, `scientificNameEn`, `placeName` | 기존 fixture |
+| 식물 이미지 | `imageUrl` | 기존 asset |
+| 처음 함께한 날·함께한 일수 | `registeredAt`의 날짜를 기준으로 계산 | 기존 fixture |
+| 마지막으로 물 준 날짜 | `lastWateredDate` | 기존 fixture |
+| 물주기 예정 D-day·주기 | Swagger에 근거 필드가 없어 미제공 상태 표시 | 기존 fixture |
+| 대표 메모 | `memo`가 있으면 요약으로만 표시 | 기존 fixture 카드 목록 |
+| 메모 목록·작성 | Memo CRUD API가 없어 미지원 상태 표시 | 기존 로컬 화면 이동 유지 |
+| 식물 정보 | `plantInfo` | 기존 fixture |
+
+날짜 계산은 mapper에 기준 시각을 주입한다. `registeredAt`의 달력 날짜부터 기준 날짜까지를 양끝 포함으로 계산해 등록 당일은 1일로 표시하며, 미래 날짜는 잘못된 서버 값으로 보고 일수 계산을 제공하지 않는다.
+
+## 제외 범위
+
+- Plant 생성·수정 form
+- Memo API 또는 물주기 실행·주기 API 추정
+- `docs/screen-api-integration-plan.md` 수정
+- 백엔드 response schema 변경
+
+## 커밋 계획
+
+| 순서 | 범위 | 검증 |
+| --- | --- | --- |
+| 1 | 작업 기준과 데이터 표시 계약 기록 | `git diff --check` |
+| 2 | 상세 ViewData·mapper·Provider와 날짜 계산 단위 테스트 | 관련 unit/provider test |
+| 3 | 상세 page/widget의 원격 미제공 상태와 API-off 회귀 테스트 | 관련 widget test |
+| 4 | 전체 검증 결과와 커밋별 이력 기록 | format, analyze, 전체 test, `git diff --check` |
+
+## 커밋별 작업 이력
+
+| 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- |
+| 작성 예정 | 작업 기준과 데이터 표시 계약 | `git diff --check` |
+
+## 최종 검증
+
+작업 완료 후 갱신한다.

--- a/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
+++ b/lib/features/plant/presentation/fixtures/plant_detail_fixture.dart
@@ -7,11 +7,15 @@ PlantDetailViewData plantDetailFixture({String? placeCode}) {
     placeName: '스윗홈_거실',
     name: '몬테',
     species: 'Monstera deliciosa',
+    imageUrl: null,
+    imageAsset: AppImageAssets.plantEditMonstera,
     daysTogether: 1,
     dDayLabel: 'D-3',
     startDate: '2022.11.24',
     lastWateredDate: '2022.11.24',
     wateringCycleLabel: '10 Day',
+    representativeMemo: null,
+    plantInfo: null,
     memos: const [
       PlantDetailMemoItem(
         author: '커먼플랜트',
@@ -39,5 +43,6 @@ PlantDetailViewData plantDetailFixture({String? placeCode}) {
         dateLabel: '2022.11.20',
       ),
     ],
+    supportsMemoActions: true,
   );
 }

--- a/lib/features/plant/presentation/mappers/plant_detail_view_mapper.dart
+++ b/lib/features/plant/presentation/mappers/plant_detail_view_mapper.dart
@@ -2,23 +2,74 @@ import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail
 import 'package:commonplant_frontend/features/plant/presentation/models/plant_detail_view_data.dart';
 
 PlantDetailViewData? mapPlantDetailToViewData({
-  required PlantDetailViewData fallback,
   required PlantDetail detail,
+  required String? placeCode,
+  required DateTime now,
 }) {
   if (detail.name.trim().isEmpty) {
     return null;
   }
 
+  final registeredDate = _parseApiCalendarDate(detail.registeredAt);
+  final today = DateTime.utc(now.year, now.month, now.day);
+  final daysTogether = registeredDate == null || registeredDate.isAfter(today)
+      ? null
+      : today.difference(registeredDate).inDays + 1;
+
   return PlantDetailViewData(
-    placeCode: detail.placeId ?? fallback.placeCode,
-    placeName: detail.placeName ?? fallback.placeName,
-    name: detail.name,
-    species: detail.species ?? fallback.species,
-    daysTogether: fallback.daysTogether,
-    dDayLabel: fallback.dDayLabel,
-    startDate: fallback.startDate,
-    lastWateredDate: detail.lastWateredDate ?? fallback.lastWateredDate,
-    wateringCycleLabel: fallback.wateringCycleLabel,
-    memos: fallback.memos,
+    placeCode: _nonBlank(detail.placeId) ?? placeCode,
+    placeName: _nonBlank(detail.placeName) ?? '장소 정보 없음',
+    name: detail.name.trim(),
+    species: _nonBlank(detail.species) ?? '학명 정보 없음',
+    imageUrl: _nonBlank(detail.imageUrl),
+    imageAsset: null,
+    daysTogether: daysTogether,
+    dDayLabel: null,
+    startDate: registeredDate == null ? null : _formatDate(registeredDate),
+    lastWateredDate: _formatApiDate(detail.lastWateredDate),
+    wateringCycleLabel: null,
+    representativeMemo: _nonBlank(detail.memo),
+    plantInfo: _nonBlank(detail.description),
+    memos: const [],
+    supportsMemoActions: false,
   );
+}
+
+String? _nonBlank(String? value) {
+  final normalized = value?.trim();
+  return normalized == null || normalized.isEmpty ? null : normalized;
+}
+
+String? _formatApiDate(String? value) {
+  final date = _parseApiCalendarDate(value);
+  return date == null ? null : _formatDate(date);
+}
+
+DateTime? _parseApiCalendarDate(String? value) {
+  final normalized = _nonBlank(value);
+  if (normalized == null) {
+    return null;
+  }
+
+  final match = RegExp(r'^(\d{4})-(\d{2})-(\d{2})').firstMatch(normalized);
+  if (match == null) {
+    return null;
+  }
+
+  final year = int.parse(match.group(1)!);
+  final month = int.parse(match.group(2)!);
+  final day = int.parse(match.group(3)!);
+  final date = DateTime.utc(year, month, day);
+
+  if (date.year != year || date.month != month || date.day != day) {
+    return null;
+  }
+
+  return date;
+}
+
+String _formatDate(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '${date.year}.$month.$day';
 }

--- a/lib/features/plant/presentation/models/plant_detail_view_data.dart
+++ b/lib/features/plant/presentation/models/plant_detail_view_data.dart
@@ -4,24 +4,34 @@ class PlantDetailViewData {
     required this.placeName,
     required this.name,
     required this.species,
+    required this.imageUrl,
+    required this.imageAsset,
     required this.daysTogether,
     required this.dDayLabel,
     required this.startDate,
     required this.lastWateredDate,
     required this.wateringCycleLabel,
+    required this.representativeMemo,
+    required this.plantInfo,
     required this.memos,
+    required this.supportsMemoActions,
   });
 
   final String? placeCode;
   final String placeName;
   final String name;
   final String species;
-  final int daysTogether;
-  final String dDayLabel;
-  final String startDate;
-  final String lastWateredDate;
-  final String wateringCycleLabel;
+  final String? imageUrl;
+  final String? imageAsset;
+  final int? daysTogether;
+  final String? dDayLabel;
+  final String? startDate;
+  final String? lastWateredDate;
+  final String? wateringCycleLabel;
+  final String? representativeMemo;
+  final String? plantInfo;
   final List<PlantDetailMemoItem> memos;
+  final bool supportsMemoActions;
 }
 
 class PlantDetailMemoItem {

--- a/lib/features/plant/presentation/pages/plant_detail_page.dart
+++ b/lib/features/plant/presentation/pages/plant_detail_page.dart
@@ -68,7 +68,7 @@ class PlantDetailPage extends ConsumerWidget {
       loading: () => const PlantStateScaffold(
         title: 'My plant',
         statusTitle: '식물 정보를 불러오고 있어요',
-        message: '식물과 메모 정보를 준비하고 있어요',
+        message: '식물 상세 정보를 준비하고 있어요',
         isLoading: true,
       ),
     );
@@ -142,6 +142,8 @@ class PlantDetailPage extends ConsumerWidget {
                 placeName: detail.placeName,
                 name: detail.name,
                 species: detail.species,
+                imageUrl: detail.imageUrl,
+                imageAsset: detail.imageAsset,
               ),
             ),
             PlantCareSummary(
@@ -151,8 +153,16 @@ class PlantDetailPage extends ConsumerWidget {
               startDate: detail.startDate,
               lastWateredDate: detail.lastWateredDate,
             ),
-            MemoPreviewSection(plantId: plantId, memos: detail.memos),
-            PlantInfoSection(wateringCycleLabel: detail.wateringCycleLabel),
+            MemoPreviewSection(
+              plantId: plantId,
+              memos: detail.memos,
+              representativeMemo: detail.representativeMemo,
+              supportsActions: detail.supportsMemoActions,
+            ),
+            PlantInfoSection(
+              wateringCycleLabel: detail.wateringCycleLabel,
+              plantInfo: detail.plantInfo,
+            ),
             const SizedBox(height: 82),
           ],
         ),

--- a/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
+++ b/lib/features/plant/presentation/providers/plant_detail_view_provider.dart
@@ -7,6 +7,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef PlantDetailViewRequest = ({String plantId, String? placeCode});
 
+final plantDetailNowProvider = Provider<DateTime Function()>((ref) {
+  return DateTime.now;
+});
+
 final plantDetailViewProvider =
     Provider.family<AsyncValue<PlantDetailViewData?>, PlantDetailViewRequest>((
       ref,
@@ -32,12 +36,16 @@ final plantRemoteDetailViewProvider =
       ref,
       request,
     ) async {
-      final fallback = ref.watch(plantLocalDetailViewProvider(request));
+      final now = ref.watch(plantDetailNowProvider);
       final detail = await ref.watch(
         remotePlantDetailProvider(request.plantId).future,
       );
 
-      return mapPlantDetailToViewData(fallback: fallback, detail: detail);
+      return mapPlantDetailToViewData(
+        detail: detail,
+        placeCode: request.placeCode,
+        now: now(),
+      );
     }, retry: (retryCount, error) => null);
 
 void invalidatePlantDetailView(WidgetRef ref, PlantDetailViewRequest request) {

--- a/lib/features/plant/presentation/widgets/plant_care_summary.dart
+++ b/lib/features/plant/presentation/widgets/plant_care_summary.dart
@@ -21,10 +21,10 @@ class PlantCareSummary extends StatelessWidget {
   });
 
   final String name;
-  final int daysTogether;
-  final String dDayLabel;
-  final String startDate;
-  final String lastWateredDate;
+  final int? daysTogether;
+  final String? dDayLabel;
+  final String? startDate;
+  final String? lastWateredDate;
 
   @override
   Widget build(BuildContext context) {
@@ -36,25 +36,7 @@ class PlantCareSummary extends StatelessWidget {
           child: Column(
             children: [
               const SizedBox(height: AppSpacing.x24),
-              RichText(
-                textAlign: TextAlign.center,
-                text: TextSpan(
-                  style: AppTextStyles.size16Medium.copyWith(
-                    color: AppColors.textBody,
-                  ),
-                  children: [
-                    TextSpan(text: '$name와 함께한지 '),
-                    TextSpan(
-                      text: '$daysTogether일',
-                      style: AppTextStyles.size18Medium.copyWith(
-                        color: AppColors.textStrong,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const TextSpan(text: '이 지났어요!'),
-                  ],
-                ),
-              ),
+              _DaysTogetherLabel(name: name, daysTogether: daysTogether),
               const SizedBox(height: AppSpacing.x8),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -68,13 +50,17 @@ class PlantCareSummary extends StatelessWidget {
                   ),
                   const SizedBox(width: AppSpacing.x8),
                   Text(
-                    dDayLabel,
-                    style: AppTextStyles.size24Medium.copyWith(
-                      fontSize: 28,
-                      height: 36 / 28,
-                      color: AppColors.textStrong,
-                      fontWeight: FontWeight.w700,
-                    ),
+                    dDayLabel ?? '물주기 예정 정보 없음',
+                    style: dDayLabel == null
+                        ? AppTextStyles.size14Medium.copyWith(
+                            color: AppColors.iconInactive,
+                          )
+                        : AppTextStyles.size24Medium.copyWith(
+                            fontSize: 28,
+                            height: 36 / 28,
+                            color: AppColors.textStrong,
+                            fontWeight: FontWeight.w700,
+                          ),
                   ),
                 ],
               ),
@@ -92,14 +78,50 @@ class PlantCareSummary extends StatelessWidget {
   }
 }
 
+class _DaysTogetherLabel extends StatelessWidget {
+  const _DaysTogetherLabel({required this.name, required this.daysTogether});
+
+  final String name;
+  final int? daysTogether;
+
+  @override
+  Widget build(BuildContext context) {
+    if (daysTogether == null) {
+      return Text(
+        '$name와 함께한 기간 정보가 없어요',
+        textAlign: TextAlign.center,
+        style: AppTextStyles.size16Medium.copyWith(color: AppColors.textBody),
+      );
+    }
+
+    return RichText(
+      textAlign: TextAlign.center,
+      text: TextSpan(
+        style: AppTextStyles.size16Medium.copyWith(color: AppColors.textBody),
+        children: [
+          TextSpan(text: '$name와 함께한지 '),
+          TextSpan(
+            text: '$daysTogether일',
+            style: AppTextStyles.size18Medium.copyWith(
+              color: AppColors.textStrong,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const TextSpan(text: '이 지났어요!'),
+        ],
+      ),
+    );
+  }
+}
+
 class _PlantDateSummary extends StatelessWidget {
   const _PlantDateSummary({
     required this.startDate,
     required this.lastWateredDate,
   });
 
-  final String startDate;
-  final String lastWateredDate;
+  final String? startDate;
+  final String? lastWateredDate;
 
   @override
   Widget build(BuildContext context) {
@@ -133,8 +155,8 @@ class _PlantDateSummary extends StatelessWidget {
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(startDate, style: textStyle),
-                Text(lastWateredDate, style: textStyle),
+                Text(startDate ?? '정보 없음', style: textStyle),
+                Text(lastWateredDate ?? '정보 없음', style: textStyle),
               ],
             ),
           ],

--- a/lib/features/plant/presentation/widgets/plant_hero.dart
+++ b/lib/features/plant/presentation/widgets/plant_hero.dart
@@ -1,4 +1,3 @@
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
@@ -12,11 +11,15 @@ class PlantHero extends StatelessWidget {
     required this.placeName,
     required this.name,
     required this.species,
+    this.imageUrl,
+    this.imageAsset,
   });
 
   final String placeName;
   final String name;
   final String species;
+  final String? imageUrl;
+  final String? imageAsset;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +32,12 @@ class PlantHero extends StatelessWidget {
       ),
       child: Column(
         children: [
-          _PlantHeroImage(placeName: placeName),
+          _PlantHeroImage(
+            placeName: placeName,
+            name: name,
+            imageUrl: imageUrl,
+            imageAsset: imageAsset,
+          ),
           const SizedBox(height: AppSpacing.x8),
           Text(
             name,
@@ -57,9 +65,17 @@ class PlantHero extends StatelessWidget {
 }
 
 class _PlantHeroImage extends StatelessWidget {
-  const _PlantHeroImage({required this.placeName});
+  const _PlantHeroImage({
+    required this.placeName,
+    required this.name,
+    required this.imageUrl,
+    required this.imageAsset,
+  });
 
   final String placeName;
+  final String name;
+  final String? imageUrl;
+  final String? imageAsset;
 
   @override
   Widget build(BuildContext context) {
@@ -78,17 +94,7 @@ class _PlantHeroImage extends StatelessWidget {
               fit: StackFit.expand,
               children: [
                 const ColoredBox(color: AppColors.surfaceMuted),
-                Positioned(
-                  left: 0,
-                  top: -126 * scale,
-                  child: Image.asset(
-                    AppImageAssets.plantEditMonstera,
-                    width: 495 * scale,
-                    height: 369 * scale,
-                    fit: BoxFit.cover,
-                    semanticLabel: '몬테 식물 사진',
-                  ),
-                ),
+                _buildImage(scale),
                 Positioned(
                   top: AppSpacing.x8 * scale,
                   left: 0,
@@ -100,6 +106,49 @@ class _PlantHeroImage extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+
+  Widget _buildImage(double scale) {
+    if (imageUrl != null) {
+      return Image.network(
+        imageUrl!,
+        fit: BoxFit.cover,
+        semanticLabel: '$name 식물 사진',
+        errorBuilder: (context, error, stackTrace) => const _EmptyPlantImage(),
+      );
+    }
+
+    if (imageAsset != null) {
+      return Positioned(
+        left: 0,
+        top: -126 * scale,
+        child: Image.asset(
+          imageAsset!,
+          width: 495 * scale,
+          height: 369 * scale,
+          fit: BoxFit.cover,
+          semanticLabel: '$name 식물 사진',
+        ),
+      );
+    }
+
+    return const _EmptyPlantImage();
+  }
+}
+
+class _EmptyPlantImage extends StatelessWidget {
+  const _EmptyPlantImage();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Icon(
+        Icons.image_not_supported_outlined,
+        color: AppColors.iconInactive,
+        size: 40,
+        semanticLabel: '식물 이미지 없음',
+      ),
     );
   }
 }

--- a/lib/features/plant/presentation/widgets/plant_info_section.dart
+++ b/lib/features/plant/presentation/widgets/plant_info_section.dart
@@ -8,9 +8,14 @@ import 'package:commonplant_frontend/shared/widgets/common_svg_icon.dart';
 import 'package:flutter/material.dart';
 
 class PlantInfoSection extends StatelessWidget {
-  const PlantInfoSection({super.key, required this.wateringCycleLabel});
+  const PlantInfoSection({
+    super.key,
+    required this.wateringCycleLabel,
+    this.plantInfo,
+  });
 
-  final String wateringCycleLabel;
+  final String? wateringCycleLabel;
+  final String? plantInfo;
 
   @override
   Widget build(BuildContext context) {
@@ -49,21 +54,39 @@ class PlantInfoSection extends StatelessWidget {
                     width: double.infinity,
                     child: Padding(
                       padding: const EdgeInsets.all(AppSpacing.x16),
-                      child: Row(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          const CommonSvgIcon(
-                            AppIconAssets.watering,
-                            width: 24,
-                            height: 24,
-                            semanticsLabel: '물주기 주기',
+                          Row(
+                            children: [
+                              const CommonSvgIcon(
+                                AppIconAssets.watering,
+                                width: 24,
+                                height: 24,
+                                semanticsLabel: '물주기 주기',
+                              ),
+                              const SizedBox(width: AppSpacing.x8),
+                              Expanded(
+                                child: Text(
+                                  wateringCycleLabel ?? '물주기 주기 정보 없음',
+                                  style: AppTextStyles.size14Medium.copyWith(
+                                    color: wateringCycleLabel == null
+                                        ? AppColors.iconInactive
+                                        : AppColors.textStrong,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
-                          const SizedBox(width: AppSpacing.x8),
-                          Text(
-                            wateringCycleLabel,
-                            style: AppTextStyles.size14Medium.copyWith(
-                              color: AppColors.textStrong,
+                          if (plantInfo != null) ...[
+                            const SizedBox(height: AppSpacing.x12),
+                            Text(
+                              plantInfo!,
+                              style: AppTextStyles.size14Medium.copyWith(
+                                color: AppColors.textBody,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),

--- a/lib/features/plant/presentation/widgets/plant_memo_preview_section.dart
+++ b/lib/features/plant/presentation/widgets/plant_memo_preview_section.dart
@@ -1,6 +1,7 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
+import 'package:commonplant_frontend/core/theme/app_radius.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
@@ -17,10 +18,14 @@ class MemoPreviewSection extends StatelessWidget {
     super.key,
     required this.plantId,
     required this.memos,
+    this.representativeMemo,
+    this.supportsActions = true,
   });
 
   final String plantId;
   final List<PlantDetailMemoItem> memos;
+  final String? representativeMemo;
+  final bool supportsActions;
 
   @override
   Widget build(BuildContext context) {
@@ -33,37 +38,42 @@ class MemoPreviewSection extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               _MemoSectionHeader(
-                onPressed: () =>
-                    context.push(AppRoutePaths.memoListLocation(plantId)),
+                onPressed: supportsActions
+                    ? () =>
+                          context.push(AppRoutePaths.memoListLocation(plantId))
+                    : null,
               ),
-              SizedBox(
-                height: AppSizes.memoCardHeight,
-                child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.x20,
+              if (supportsActions) ...[
+                SizedBox(
+                  height: AppSizes.memoCardHeight,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.x20,
+                    ),
+                    scrollDirection: Axis.horizontal,
+                    itemBuilder: (context, index) =>
+                        _PlantMemoCard(memo: memos[index]),
+                    separatorBuilder: (_, _) =>
+                        const SizedBox(width: AppSpacing.x8),
+                    itemCount: memos.length,
                   ),
-                  scrollDirection: Axis.horizontal,
-                  itemBuilder: (context, index) =>
-                      _PlantMemoCard(memo: memos[index]),
-                  separatorBuilder: (_, _) =>
-                      const SizedBox(width: AppSpacing.x8),
-                  itemCount: memos.length,
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.x20,
-                  AppSpacing.x16,
-                  AppSpacing.x20,
-                  AppSpacing.x24,
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x20,
+                    AppSpacing.x16,
+                    AppSpacing.x20,
+                    AppSpacing.x24,
+                  ),
+                  child: CommonButton(
+                    label: '작성하기',
+                    size: CommonButtonSize.medium,
+                    onPressed: () =>
+                        context.push(AppRoutePaths.memoWriteLocation(plantId)),
+                  ),
                 ),
-                child: CommonButton(
-                  label: '작성하기',
-                  size: CommonButtonSize.medium,
-                  onPressed: () =>
-                      context.push(AppRoutePaths.memoWriteLocation(plantId)),
-                ),
-              ),
+              ] else
+                _RemoteMemoSummary(representativeMemo: representativeMemo),
             ],
           ),
         ),
@@ -72,10 +82,62 @@ class MemoPreviewSection extends StatelessWidget {
   }
 }
 
+class _RemoteMemoSummary extends StatelessWidget {
+  const _RemoteMemoSummary({required this.representativeMemo});
+
+  final String? representativeMemo;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.x20,
+        0,
+        AppSpacing.x20,
+        AppSpacing.x24,
+      ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.surfaceMuted,
+          borderRadius: BorderRadius.circular(AppRadius.medium),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.x16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                representativeMemo == null ? '대표 메모 없음' : '대표 메모',
+                style: AppTextStyles.size14Bold.copyWith(
+                  color: AppColors.textStrong,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.x8),
+              Text(
+                representativeMemo ?? '서버에서 제공한 대표 메모가 없어요.',
+                style: AppTextStyles.size14Medium.copyWith(
+                  color: AppColors.textBody,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.x12),
+              Text(
+                '메모 목록과 작성 API는 아직 제공되지 않아요.',
+                style: AppTextStyles.size14Medium.copyWith(
+                  color: AppColors.iconInactive,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _MemoSectionHeader extends StatelessWidget {
   const _MemoSectionHeader({required this.onPressed});
 
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -100,20 +162,21 @@ class _MemoSectionHeader extends StatelessWidget {
                 ),
               ),
             ),
-            Semantics(
-              button: true,
-              label: '메모 전체보기',
-              child: ExcludeSemantics(
-                child: IconButton(
-                  onPressed: onPressed,
-                  icon: const Icon(
-                    Icons.chevron_right,
-                    color: AppColors.textStrong,
-                    size: AppSizes.iconMedium,
+            if (onPressed != null)
+              Semantics(
+                button: true,
+                label: '메모 전체보기',
+                child: ExcludeSemantics(
+                  child: IconButton(
+                    onPressed: onPressed,
+                    icon: const Icon(
+                      Icons.chevron_right,
+                      color: AppColors.textStrong,
+                      size: AppSizes.iconMedium,
+                    ),
                   ),
                 ),
               ),
-            ),
           ],
         ),
       ),

--- a/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
+++ b/test/features/plant/presentation/fixtures/plant_detail_fixture_test.dart
@@ -10,10 +10,12 @@ void main() {
       expect(detail.placeName, '스윗홈_거실');
       expect(detail.name, '몬테');
       expect(detail.species, 'Monstera deliciosa');
+      expect(detail.imageAsset, isNotNull);
       expect(detail.dDayLabel, 'D-3');
       expect(detail.wateringCycleLabel, '10 Day');
       expect(detail.memos, hasLength(4));
       expect(detail.memos.first.author, '커먼플랜트');
+      expect(detail.supportsMemoActions, isTrue);
     });
   });
 }

--- a/test/features/plant/presentation/mappers/plant_detail_view_mapper_test.dart
+++ b/test/features/plant/presentation/mappers/plant_detail_view_mapper_test.dart
@@ -1,26 +1,91 @@
 import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail.dart';
-import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_detail_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/mappers/plant_detail_view_mapper.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('remote detail을 ViewData에 적용하고 없는 값은 fallback을 유지한다', () {
+  test('Swagger 상세 필드와 등록일을 원격 ViewData로 변환한다', () {
     final detail = mapPlantDetailToViewData(
-      fallback: plantDetailFixture(placeCode: 'fallback-place'),
       detail: const PlantDetail(
         id: 'plant-remote',
         name: '필로덴드론',
+        species: 'Philodendron erubescens',
         placeName: '거실 정원',
-        lastWateredDate: '2026.05.25',
+        description: '반양지에서 관리해 주세요.',
+        lastWateredDate: '2026-05-25',
+        imageUrl: 'https://example.com/plant.jpg',
+        memo: '새 잎이 자라고 있어요.',
+        registeredAt: '2026-05-12T19:30:00',
       ),
+      placeCode: 'fallback-place',
+      now: DateTime(2026, 5, 25, 23, 59),
     );
 
     expect(detail?.placeCode, 'fallback-place');
     expect(detail?.placeName, '거실 정원');
     expect(detail?.name, '필로덴드론');
-    expect(detail?.species, 'Monstera deliciosa');
+    expect(detail?.species, 'Philodendron erubescens');
+    expect(detail?.imageUrl, 'https://example.com/plant.jpg');
+    expect(detail?.startDate, '2026.05.12');
+    expect(detail?.daysTogether, 14);
     expect(detail?.lastWateredDate, '2026.05.25');
-    expect(detail?.dDayLabel, 'D-3');
-    expect(detail?.memos, hasLength(4));
+    expect(detail?.plantInfo, '반양지에서 관리해 주세요.');
+    expect(detail?.representativeMemo, '새 잎이 자라고 있어요.');
+    expect(detail?.dDayLabel, isNull);
+    expect(detail?.wateringCycleLabel, isNull);
+    expect(detail?.memos, isEmpty);
+    expect(detail?.supportsMemoActions, isFalse);
+  });
+
+  test('원격 응답에 없는 값은 fixture 대신 미제공 상태로 둔다', () {
+    final detail = mapPlantDetailToViewData(
+      detail: const PlantDetail(id: 'plant-remote', name: '알로카시아'),
+      placeCode: null,
+      now: DateTime(2026, 5, 25),
+    );
+
+    expect(detail?.placeName, '장소 정보 없음');
+    expect(detail?.species, '학명 정보 없음');
+    expect(detail?.imageAsset, isNull);
+    expect(detail?.daysTogether, isNull);
+    expect(detail?.startDate, isNull);
+    expect(detail?.lastWateredDate, isNull);
+    expect(detail?.representativeMemo, isNull);
+    expect(detail?.memos, isEmpty);
+  });
+
+  test('등록 당일은 1일이고 미래·잘못된 등록일은 계산하지 않는다', () {
+    final today = mapPlantDetailToViewData(
+      detail: const PlantDetail(
+        id: 'today',
+        name: '오늘 등록',
+        registeredAt: '2026-05-25',
+      ),
+      placeCode: null,
+      now: DateTime(2026, 5, 25, 18),
+    );
+    final future = mapPlantDetailToViewData(
+      detail: const PlantDetail(
+        id: 'future',
+        name: '미래 등록',
+        registeredAt: '2026-05-26',
+      ),
+      placeCode: null,
+      now: DateTime(2026, 5, 25),
+    );
+    final invalid = mapPlantDetailToViewData(
+      detail: const PlantDetail(
+        id: 'invalid',
+        name: '잘못된 등록일',
+        registeredAt: '2026-02-31',
+      ),
+      placeCode: null,
+      now: DateTime(2026, 5, 25),
+    );
+
+    expect(today?.daysTogether, 1);
+    expect(today?.startDate, '2026.05.25');
+    expect(future?.daysTogether, isNull);
+    expect(invalid?.daysTogether, isNull);
+    expect(invalid?.startDate, isNull);
   });
 }

--- a/test/features/plant/presentation/pages/plant_detail_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_detail_page_test.dart
@@ -6,6 +6,7 @@ import 'package:commonplant_frontend/features/plant/domain/entities/plant_detail
 import 'package:commonplant_frontend/features/plant/domain/repositories/plant_repository.dart';
 import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_detail_page.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_detail_view_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -166,6 +167,50 @@ void main() {
     expect(repository.detailFetchCalls, 2);
     expect(find.text('필로덴드론'), findsOneWidget);
     expect(find.text('식물 정보를 불러오지 못했어요'), findsNothing);
+  });
+
+  testWidgets('remote 상세는 Swagger 값과 미제공 상태만 표시한다', (tester) async {
+    final repository = _StaticPlantRepository(
+      detail: const PlantDetail(
+        id: 'plant-remote',
+        name: '필로덴드론',
+        placeName: '거실 정원',
+        species: 'Philodendron erubescens',
+        description: '반양지에서 관리해 주세요.',
+        lastWateredDate: '2026-05-25',
+        memo: '새 잎이 올라오고 있어요.',
+        registeredAt: '2026-05-12T19:30:00',
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+          plantDetailNowProvider.overrideWithValue(() => DateTime(2026, 5, 25)),
+        ],
+        child: const MaterialApp(
+          home: PlantDetailPage(plantId: 'plant-remote'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('거실 정원'), findsOneWidget);
+    expect(find.text('Philodendron erubescens'), findsOneWidget);
+    expect(find.textContaining('14일', findRichText: true), findsOneWidget);
+    expect(find.text('2026.05.12'), findsOneWidget);
+    expect(find.text('2026.05.25'), findsOneWidget);
+    expect(find.text('물주기 예정 정보 없음'), findsOneWidget);
+    expect(find.text('물주기 주기 정보 없음'), findsOneWidget);
+    expect(find.text('새 잎이 올라오고 있어요.'), findsOneWidget);
+    expect(find.text('반양지에서 관리해 주세요.'), findsOneWidget);
+    expect(find.text('D-3'), findsNothing);
+    expect(find.text('10 Day'), findsNothing);
+    expect(find.text('커먼플랜트'), findsNothing);
+    expect(find.text('작성하기'), findsNothing);
+    expect(find.bySemanticsLabel('메모 전체보기'), findsNothing);
   });
 
   testWidgets('remote 식물 삭제 확인은 삭제 API를 호출하고 홈으로 이동한다', (tester) async {

--- a/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
+++ b/test/features/plant/presentation/providers/plant_detail_view_provider_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(detail?.placeName, '스윗홈_거실');
     });
 
-    test('remote mode는 PlantDetail을 fixture 상세에 병합한다', () async {
+    test('remote mode는 PlantDetail을 원격 전용 ViewData로 변환한다', () async {
       final repository = _StaticPlantRepository(
         const PlantDetail(
           id: 'remote-plant',
@@ -30,13 +30,15 @@ void main() {
           placeId: 'remote-place',
           placeName: '거실 정원',
           species: 'Philodendron',
-          lastWateredDate: '2026.05.25',
+          lastWateredDate: '2026-05-25',
+          registeredAt: '2026-05-20T10:30:00',
         ),
       );
       final container = ProviderContainer(
         overrides: [
           useRemoteApiProvider.overrideWithValue(true),
           plantRepositoryProvider.overrideWithValue(repository),
+          plantDetailNowProvider.overrideWithValue(() => DateTime(2026, 5, 25)),
         ],
       );
       addTearDown(container.dispose);
@@ -53,6 +55,10 @@ void main() {
       expect(detail?.placeName, '거실 정원');
       expect(detail?.species, 'Philodendron');
       expect(detail?.lastWateredDate, '2026.05.25');
+      expect(detail?.startDate, '2026.05.20');
+      expect(detail?.daysTogether, 6);
+      expect(detail?.memos, isEmpty);
+      expect(detail?.dDayLabel, isNull);
       expect(repository.fetchCalls, 1);
     });
 

--- a/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
+++ b/test/features/plant/presentation/widgets/plant_detail_widgets_test.dart
@@ -56,6 +56,34 @@ void main() {
     expect(find.text('10 Day'), findsOneWidget);
   });
 
+  testWidgets('원격 관리 정보가 없으면 지원 범위를 명확히 표시한다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        const Column(
+          children: [
+            PlantCareSummary(
+              name: '필로덴드론',
+              daysTogether: null,
+              dDayLabel: null,
+              startDate: null,
+              lastWateredDate: null,
+            ),
+            PlantInfoSection(
+              wateringCycleLabel: null,
+              plantInfo: '반양지에서 관리해 주세요.',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('필로덴드론와 함께한 기간 정보가 없어요'), findsOneWidget);
+    expect(find.text('물주기 예정 정보 없음'), findsOneWidget);
+    expect(find.text('정보 없음'), findsNWidgets(2));
+    expect(find.text('물주기 주기 정보 없음'), findsOneWidget);
+    expect(find.text('반양지에서 관리해 주세요.'), findsOneWidget);
+  });
+
   testWidgets('MemoPreviewSection은 메모를 표시하고 목록/작성으로 이동한다', (tester) async {
     const memoSection = MemoPreviewSection(
       plantId: 'plant-1',
@@ -86,6 +114,25 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('메모 작성 화면'), findsOneWidget);
+  });
+
+  testWidgets('원격 Memo는 대표 메모만 표시하고 미지원 동작을 숨긴다', (tester) async {
+    await tester.pumpWidget(
+      _buildRouterApp(
+        const MemoPreviewSection(
+          plantId: 'plant-1',
+          memos: [],
+          representativeMemo: '서버 대표 메모',
+          supportsActions: false,
+        ),
+      ),
+    );
+
+    expect(find.text('대표 메모'), findsOneWidget);
+    expect(find.text('서버 대표 메모'), findsOneWidget);
+    expect(find.text('메모 목록과 작성 API는 아직 제공되지 않아요.'), findsOneWidget);
+    expect(find.bySemanticsLabel('메모 전체보기'), findsNothing);
+    expect(find.text('작성하기'), findsNothing);
   });
 }
 


### PR DESCRIPTION
## 관련 이슈

- Closes #231
- Parent: #226

## 구현 범위

- `GET /plants/{plantId}`의 확인된 상세 필드를 Plant 상세 ViewData에 연결
- `registeredAt` 기반 시작일과 양끝 포함 함께한 일수 계산
- API 모드에서 fixture D-day, 물주기 주기, 메모 카드 제거
- `memo`는 대표 메모로만 표시하고 Memo 목록·작성 API 미지원 상태 명시
- `imageUrl`, `plantInfo`, `lastWateredDate` 표시 연결
- API-off 기존 fixture 화면과 loading/error/retry/delete 흐름 유지

## 테스트

- `fvm dart format --output=none --set-exit-if-changed .` — 270개 파일, 변경 없음
- `fvm flutter analyze` — 통과
- `fvm flutter test --reporter compact` — 285개 통과, 기존 golden skip 1개
- `git diff --check develop...HEAD` — 통과

## 리뷰 포인트

- 등록 당일을 1일로 세는 날짜 계산 계약
- Swagger에 없는 물주기 예정일·주기와 Memo CRUD를 미제공 상태로 분리한 화면 표현
- 원격 데이터와 API-off fixture가 Provider 단계에서 섞이지 않는지

## 문서

- `docs/work-history/plant-detail-api-view-231.md`

## Breaking change

- 없음
