### PR TITLE
[Feature] 장소 목록·상세 API 실데이터 연결

### DIFF
--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -11,7 +11,7 @@
 - Swagger UI: https://commonplant-dev.okbear.dev/api/v1/swagger-ui/index.html#
 - OpenAPI JSON: https://commonplant-dev.okbear.dev/api/v1/api-docs/json
 - Swagger config: https://commonplant-dev.okbear.dev/api/v1/api-docs/json/swagger-config
-- 확인일: 2026-08-23
+- 확인일: 2026-08-25
 - 접속 결과: Swagger UI, OpenAPI JSON, Swagger config HTTP 200
 - 개발 서버 루트: HTTP 404. 루트 route가 없다는 의미이며 Swagger/API endpoint 상태와 분리한다.
 - 인증 endpoint 확인: token 없이 `GET /api/v1/users` 요청 시 HTTP 401, code `A009`로 인증 요구 응답
@@ -21,7 +21,8 @@
 - endpoint inventory: 19 paths, 27 operations
 - 기존 문서 비교 기준: `docs/api-swagger-summary-43` 브랜치의 `docs/api-swagger-reference.md` 확인일 2026-05-20
 - 코드 비교 기준: `feature/api-integration-45` 브랜치의 `lib/core/network`, `features/*/data` API 계층
-- 참고: 2026-05-25의 상세 schema 비교 기록을 보존하고, 2026-08-23에는 dev 접속 정보와 현재 endpoint/schema 차이를 재검증했다.
+- 백엔드 소스 비교 기준: `UMC-CommonPlant/v3_CommonPlant_Backend_Repo` main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`
+- 참고: 2026-05-25의 상세 schema 비교 기록을 보존하고, 2026-08-25에는 live OpenAPI와 백엔드 Controller·DTO·Service를 함께 재검증했다.
 
 ## 프론트엔드 연계 원칙
 
@@ -39,9 +40,21 @@
 - `/users`, `/users/{keyword}`는 operation에 bearer 인증이 명시되어 있다.
 - 그 외 operation은 별도 security가 없으므로 전역 bearer 인증이 상속되는 것으로 본다.
 - Auth, User, Plant 일부 API는 `timeStamp`, `success`, `status`, `message`, `result` 형태의 JSON response wrapper schema가 추가되었다.
-- Place, Image, Friend API는 여전히 성공 response body schema가 없거나 `OK` 수준의 설명만 있다.
+- Place, Image, Friend API는 live OpenAPI에 여전히 성공 response body schema가 없거나 `OK` 수준의 설명만 있다.
+- Place와 Friend는 백엔드 source의 `JsonResponse.result` 반환 타입을 추가 근거로 사용한다. machine-readable Swagger가 아니라는 점과 실제 인증 응답 smoke가 남았다는 점은 구분한다.
 
 ## Swagger 변경 요약
+
+### 2026-08-25 live Swagger·백엔드 source 재확인
+
+| 구분 | 확인 내용 | 프론트 판단 |
+| --- | --- | --- |
+| Live OpenAPI | 19 paths, 27 operations이며 Place·Friend 성공 schema는 여전히 미노출 | endpoint 변화 없음 |
+| Place 목록 | `getMainPage.placeList`, `getPlaceListRes`, `getPlaceBelongUser` 확인 | #239 목록 mapper와 Home 대표 이미지 연결 |
+| Place 상세 | `getPlaceRes`가 `owner`, `userList`, `plantList`를 반환 | #239에서 remote fixture 병합 제거 가능 |
+| Place 멤버 | `getPlaceResUser`는 `name`, `image`만 반환 | 상세 표시는 가능, 멤버 고유 id·역할 기반 변경은 보류 |
+| Friend 요청 | `friendRequestListRes.requests`와 요청 PK `friendId` 확인 | 목록·수락·거절 후속 수직 슬라이스 진행 가능 |
+| Friend 전송 | receiver는 표시 이름이며 부분 검색 첫 결과를 사용 | 중복 이름 오매칭이 해결되기 전 신규 초대 전송 보류 |
 
 ### 2026-08-23 dev Swagger 재확인
 
@@ -102,13 +115,13 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | User | PUT | `/users` | 내 정보 수정 | 필요 | `UserJsonResponse` |
 | User | DELETE | `/users` | 회원 탈퇴 | 필요 | `UserDeleteJsonResponse` |
 | User | GET | `/users/{keyword}` | 사용자 이름 검색 | 필요 | `UserListJsonResponse` |
-| Place | GET | `/place/myGarden` | 내 정원 조회 | 필요 | 없음 |
-| Place | GET | `/place/user` | 소속 장소 조회 | 필요 | 없음 |
-| Place | GET | `/place/{code}` | 장소 조회 | 필요 | 없음 |
-| Place | GET | `/place/{code}/members` | 장소 멤버 목록 조회 | 필요 | 없음 |
-| Place | POST | `/place/create` | 장소 생성 | 필요 | 없음 |
-| Place | PUT | `/place/update/{code}` | 장소 수정 | 필요 | 없음 |
-| Place | DELETE | `/place/delete/{code}` | 장소 삭제 | 필요 | 없음 |
+| Place | GET | `/place/myGarden` | 내 정원 조회 | 필요 | Swagger 없음; source `getMainPage` |
+| Place | GET | `/place/user` | 소속 장소 조회 | 필요 | Swagger 없음; source `getPlaceBelongUser[]` |
+| Place | GET | `/place/{code}` | 장소 조회 | 필요 | Swagger 없음; source `getPlaceRes` |
+| Place | GET | `/place/{code}/members` | 장소 멤버 목록 조회 | 필요 | Swagger 없음; source `getPlaceResUser[]` |
+| Place | POST | `/place/create` | 장소 생성 | 필요 | Swagger 없음; source place code 문자열 |
+| Place | PUT | `/place/update/{code}` | 장소 수정 | 필요 | Swagger 없음; source `updatePlaceRes` |
+| Place | DELETE | `/place/delete/{code}` | 장소 삭제 | 필요 | Swagger 없음; source null |
 | Friend | GET | `/friends/requests` | 없음 | 필요 | 없음 |
 | Friend | POST | `/friends/request` | 없음 | 필요 | 없음 |
 | Friend | POST | `/friends/accept` | 없음 | 필요 | 없음 |
@@ -246,18 +259,37 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 #### GET `/place/myGarden`
 
 - 사용자의 정원 정보를 조회한다.
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 `JsonResponse.result`는 `getMainPage`이다.
+- `getMainPage` fields:
+  - `name`: 현재 사용자 이름
+  - `placeList`: `getPlaceListRes[]`
+- `getPlaceListRes` fields:
+  - `image`
+  - `code`
+  - `name`
+  - `member`: 문자열 멤버 수
+  - `plant`: 문자열 식물 수
 
 #### GET `/place/user`
 
 - 사용자가 속한 장소 리스트를 조회한다.
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 `JsonResponse.result`는 `getPlaceBelongUser[]`이다.
+- 항목 fields: `code`, `name`, `imgUrl`
 
 #### GET `/place/{code}`
 
 - Path parameter:
   - `code`: 장소 코드
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 `JsonResponse.result`는 `getPlaceRes`이다.
+- `getPlaceRes` fields:
+  - `name`, `code`, `address`, `imgUrl`
+  - `owner`: 현재 사용자의 장소 소유자 여부
+  - `userList`: `{ name, image }[]`
+  - `plantList`: Plant `DetailResponse[]`
+- #239는 위 계약을 별도 `PlaceDetail` 도메인 모델로 파싱하고 API 모드의 fixture 환경값·멤버·식물을 제거한다.
 - Error:
   - `403`: 장소 접근 권한 없음
   - `404`: 장소 없음
@@ -267,11 +299,12 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - 가입 순서대로 장소 멤버 목록을 조회한다.
 - Path parameter:
   - `code`: 장소 코드, required
-- 성공 response 설명은 `멤버 목록 조회 성공`이지만 body schema는 없다.
+- 성공 response 설명은 `멤버 목록 조회 성공`이지만 live Swagger body schema는 없다.
+- 백엔드 source의 result는 가입 순서의 `{ name, image }[]`이다.
 - Error:
   - `403`: 장소 접근 권한 없음
   - `404`: 장소 없음
-- 친구 관리 화면에 연결하려면 member id, 이름, 프로필 이미지, 역할 필드와 wrapper를 백엔드에 확인해야 한다.
+- 고유 member id와 역할은 제공되지 않으므로 멤버 변경·권한 UI에는 별도 endpoint 또는 응답 확장이 필요하다.
 
 #### POST `/place/create`
 
@@ -285,7 +318,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - `createPlaceReq` properties:
   - `name`: 최대 10자
   - `address`: 필수
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 성공 result는 생성된 place code 문자열이다.
 - Error:
   - `400`: 요청 값 검증 실패, 주소 누락/공백
 
@@ -304,7 +338,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
   - `imageKey`
   - `name`: 최대 10자
   - `address`
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 성공 result는 `{ code, name, address, imgUrl }`이다.
 - Error:
   - `400`: 장소 이미지 키 오류
   - `403`: 장소 접근 권한 없음
@@ -314,7 +349,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 
 - Path parameter:
   - `code`: 장소 코드
-- 성공 response body schema는 없다.
+- live Swagger 성공 response body schema는 없다.
+- 백엔드 source의 성공 result는 null이다.
 - Error:
   - `403`: 장소 접근 권한 없음
   - `404`: 장소 없음
@@ -323,8 +359,13 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 
 #### GET `/friends/requests`
 
-- 친구 요청 목록 조회로 추정되지만 Swagger summary와 response schema가 없다.
-- 성공 response 설명은 `OK`이다.
+- live Swagger summary와 response schema는 없고 성공 설명은 `OK`이다.
+- 백엔드 source의 result는 `{ requests: friendRequestItem[] }`이다.
+- `friendRequestItem` fields:
+  - `friendId`: 친구 요청 PK
+  - `senderName`, `senderImgUrl`
+  - `placeCode`, `placeName`, `placeAddress`
+  - `status`
 
 #### POST `/friends/request`
 
@@ -333,7 +374,9 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - Request properties:
   - `receiverName`: string array
   - `placeCode`: string
-- 성공 response 설명은 `OK`이고 response schema는 없다.
+- live Swagger 성공 response 설명은 `OK`이고 response schema는 없다.
+- 백엔드 source의 result는 `{ placeCode, receiverList }`이다.
+- 현재 Service는 `receiverName`을 표시 이름 부분 검색에 넣고 첫 결과를 사용하므로 중복 이름 오매칭 위험이 있다.
 
 #### POST `/friends/accept`
 
@@ -341,7 +384,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - Request schema: `friendDecisionReq`
 - Request properties:
   - `friendId`: int64
-- 성공 response 설명은 `OK`이고 response schema는 없다.
+- `friendId`는 친구 요청 PK이다.
+- 성공 result는 null이다.
 
 #### POST `/friends/decline`
 
@@ -349,7 +393,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - Request schema: `friendDecisionReq`
 - Request properties:
   - `friendId`: int64
-- 성공 response 설명은 `OK`이고 response schema는 없다.
+- `friendId`는 친구 요청 PK이다.
+- 성공 result는 null이다.
 
 ### Plant
 
@@ -521,11 +566,12 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | 프로필 설정 | `/profile/setup` | `POST /auth/register` | #216에서 multipart datasource/repository 반영 완료, 실제 image picker 파일과 submit 연결은 별도 구현 필요 |
 | 마이페이지·회원 정보 수정 | `/me`, `/me/edit` | `GET/PUT/DELETE /users` | #237에서 조회·이름 수정·회원 탈퇴 화면 흐름 연결, 실제 image picker는 별도 정책 필요 |
 | 친구 추가 | `/places/new/friends` | `GET /users/{keyword}` | 사용자 이름 검색 DTO 반영 가능 |
-| 친구 추가 | `/places/new/friends` | `POST /friends/request` | 요청 전송은 가능하나 response schema와 화면 성공 정책 확인 필요 |
-| 장소 친구 요청 | `/places/invitations` | `GET /friends/requests` | 목록 response schema가 없어 백엔드 확인 필요 |
-| 장소 친구 요청 | `/places/invitations` | `POST /friends/accept`, `POST /friends/decline` | accept/decline 요청은 가능하나 response와 갱신 정책 확인 필요 |
-| 친구 관리 | `/places/:placeId/friends` | `GET /place/{code}/members` | endpoint는 확인됐지만 목록 response schema가 없어 백엔드 확인 필요 |
-| 장소 수정 | `/places/:placeId/edit` | `PUT /place/update/{code}` | multipart 여부는 해소됐지만 성공 response schema 없음 |
+| 친구 추가 | `/places/new/friends` | `POST /friends/request` | source 응답은 확인했지만 표시 이름 중복 오매칭 위험 해결 필요 |
+| 장소 친구 요청 | `/places/invitations` | `GET /friends/requests` | source의 `requests[]` 계약으로 후속 구현 가능 |
+| 장소 친구 요청 | `/places/invitations` | `POST /friends/accept`, `POST /friends/decline` | 요청 PK와 null 성공 result 확인, 후속 구현 가능 |
+| 장소 상세 | `/places/:placeId` | `GET /place/{code}` | #239에서 장소·owner·멤버·식물 실데이터 연결 |
+| 친구 관리 | `/places/:placeId/friends` | `GET /place/{code}/members` | 이름·이미지 조회 가능, 고유 id와 멤버 변경 endpoint는 없음 |
+| 장소 수정 | `/places/:placeId/edit` | `PUT /place/update/{code}` | multipart와 수정 결과 계약 확인, image key 조회는 별도 확인 필요 |
 | 식물 등록 정보 입력 | `/plants/new/details` | `POST /plants` | `placeCode` 기준으로 현재 코드 DTO 수정 필요 |
 | 식물 상세 | `/plants/:plantId` | `GET /plants/{plantId}` | query parameter 제거 필요 |
 | 식물 수정 | `/plants/:plantId/edit` | `GET /plants/{plantId}/edit` | query parameter 제거 필요 |
@@ -550,12 +596,12 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | `/auth/register` 요청 body 구조 | `RegisterRequest`/`RegisterResponse` 분리와 `register` JSON part encoding 확인 | 해소 |
 | `/users` 조회 성공 응답 body 구조 | `UserJsonResponse`, `UserResponse` 추가 | 해소 |
 | `PUT /users` request schema 오연결 | `UserUpdateMultipartRequest`로 변경 | 해소 |
-| Place 조회/생성/수정/삭제 성공 응답 body 구조 | 여전히 schema 없음 | 남음 |
+| Place 조회/생성/수정/삭제 성공 응답 body 구조 | live Swagger schema는 없지만 backend source 반환 타입 확인 | source 기준 해소, 인증 smoke 남음 |
 | Plant 목록/상세/수정 화면 조회 성공 응답 body 구조 | 목록, 생성, 상세, 수정 정보, 삭제 schema 추가 | 해소 |
 | Image 업로드/조회/수정/삭제 성공 응답 body 구조 | 여전히 schema 없음 | 남음 |
 | `PUT /place/update/{code}` multipart 여부 | `multipart/form-data`로 변경 | 해소 |
 | multipart 요청 JSON part content type | Auth/User/Plant는 `application/json` 명시, Place create/update는 encoding 미표기 | 일부 남음 |
-| 장소 멤버 목록 API | `GET /place/{code}/members` 추가, 성공 response schema 없음 | endpoint 확인, schema 확인 필요 |
+| 장소 멤버 목록 API | source에서 `{ name, image }[]` 확인 | 표시 계약 해소, 고유 id·변경 API 남음 |
 | Place create/update required와 validation | `name`, `address` required와 `name` maxLength 확인 | 일부 해소 |
 | Plant create/update validation과 nullable 정책 | 문자열 maxLength와 date format 확인 | 일부 해소 |
 | 에러 응답 body 구조와 code/message 필드명 | 성공 wrapper는 있으나 에러 body schema 없음 | 남음 |
@@ -585,6 +631,9 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - 반영: `GET /users/{keyword}`는 사용자 검색 datasource/repository 후보로 추가했다.
 - 반영: `POST /place/create`와 `PUT /place/update/{code}`는 optional `image` part를 datasource/repository 경계에서 전달할 수 있도록 보강했다.
 - 반영: `PUT /place/update/{code}`는 multipart 전송 datasource/repository를 추가했다.
+- 반영: #239에서 `GET /place/myGarden`의 `result.placeList`와 대표 이미지를 Home 장소 카드에 연결했다.
+- 반영: #239에서 `GET /place/{code}`를 `PlaceDetail`로 파싱하고 owner·멤버·식물·이미지·날짜를 상세 화면에 연결했다.
+- 반영: #239 remote 상세에서는 서버가 주지 않는 햇빛·습도와 fixture 멤버·식물을 표시하지 않는다.
 - 반영: `POST /plants`와 `PUT /plants/{plantId}`는 optional `image` part를 datasource/repository 경계에서 전달할 수 있도록 보강했다.
 - 반영: Auth login DTO는 Swagger의 `newUser` 필드명을 명시적으로 보존한다.
 - 반영: Friend 요청 목록/전송/수락/거절 endpoint는 response schema가 없으므로 raw 또는 void 경계로 datasource/repository만 추가했다.
@@ -611,8 +660,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | --- | --- | --- |
 | Auth | `POST /auth/register` response example의 `isNewUser`와 schema `newUser` 불일치 | 회원가입 응답 DTO의 실제 필드 확인 필요 |
 | 공통 Multipart | JSON part의 `Content-Type: application/json` 필요 여부 | Auth/Place/Plant/User multipart 전송 정책 정합성 |
-| Place | 조회/생성/수정/삭제 성공 response, 목록/상세/멤버 wrapper와 필드명 | 장소 mapper와 실데이터 화면 정책 제한 |
-| Friend | 요청 목록/전송/수락/거절 response, `receiverName`, `friendId` 의미 | 친구 요청 화면과 액션 payload 확정 불가 |
+| Place | dev 배포가 backend source `7d572cb` 계약과 일치하는지 인증 smoke | #239 mapper의 실제 환경 검증 필요 |
+| Friend | 표시 이름 receiver의 중복 오매칭, 멤버 변경 endpoint 부재 | 신규 초대 전송과 친구 관리 변경 보류 |
 | Image | `/s3/images` 성공 response, image key/url 필드, 업로드 흐름 | 프로필/장소/식물/메모 이미지 key/url 매핑 보류 |
 | Error | 에러 body의 `code`, `message`, field error 구조 | 공통 사용자 메시지와 field error 매핑 보류 |
 | Token | refresh token 재발급, 로그아웃 API 제공 여부 | 인증 만료 복구와 세션 종료 정책 보류 |

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -5,7 +5,7 @@
 ## 관리 기준
 
 - 상태는 `Open`, `Answered`, `Blocked`, `Done` 중 하나로 관리한다.
-- 백엔드 답변을 받으면 `답변`과 `프론트 반영` 칸을 갱신한다.
+- 백엔드 답변 또는 배포 기준과 일치하는 백엔드 Controller·DTO·Service 근거를 확인하면 `답변`과 `프론트 반영` 칸을 갱신한다.
 - Swagger가 갱신되면 `docs/api-swagger-reference.md`의 최신 명세와 이 문서를 함께 갱신한다.
 - 구현은 이 문서의 질문이 `Answered`가 된 뒤 별도 이슈에서 진행한다.
 
@@ -16,14 +16,15 @@
 | AUTH-01 | Auth | `POST /auth/register` request part의 실제 schema는 무엇인가? | #216 multipart datasource/repository 반영 완료 | Done |
 | AUTH-02 | Auth | 회원가입은 이미지가 없어도 항상 multipart로 보내야 하는가? | #216 image optional 전송 기준 반영 완료 | Done |
 | MULTIPART-01 | 공통 | multipart JSON part의 `Content-Type`은 `application/json`이 필수인가? | Auth/Place/Plant/User multipart 일관성 확인 필요 | Open |
-| PLACE-01 | Place | Place 조회/생성/수정/삭제 성공 response body 구조는 무엇인가? | Place mapper와 화면 성공 정책 제한 | Open |
-| PLACE-02 | Place | `/place/myGarden`, `/place/user`, `/place/{code}`의 wrapper와 필드명은 무엇인가? | 장소 목록/상세 실데이터 신뢰도 제한 | Open |
-| PLACE-03 | Place | `placeCode`, `placeId`, `code` 중 화면/요청에서 표준으로 쓸 식별자는 무엇인가? | route query와 API 요청 이름 혼재 가능성 | Open |
-| PLACE-04 | Place | `GET /place/{code}/members` 성공 response schema는 무엇인가? | 친구 관리 화면 멤버 목록 API 연결 보류 | Open |
-| FRIEND-01 | Friend | `GET /friends/requests` response schema는 무엇인가? | 장소 친구 요청 화면 API 연결 보류 | Open |
-| FRIEND-02 | Friend | 친구 요청 전송/수락/거절 성공 response와 화면 갱신 정책은 무엇인가? | 친구 요청 액션 성공 처리 제한 | Open |
-| FRIEND-03 | Friend | `sendFriendReq.receiverName`은 display name인가, 고유 user id인가? | 친구 추가 요청 payload 확정 불가 | Open |
-| FRIEND-04 | Friend | `friendDecisionReq.friendId`는 요청 id인가, 사용자 id인가? | 수락/거절 payload 확정 불가 | Open |
+| PLACE-01 | Place | Place 조회/생성/수정/삭제 성공 response body 구조는 무엇인가? | #239 목록·상세 반영, 생성·수정 결과 소비는 후속 | Answered |
+| PLACE-02 | Place | `/place/myGarden`, `/place/user`, `/place/{code}`의 wrapper와 필드명은 무엇인가? | #239 목록·상세 mapper와 화면 반영 | Done |
+| PLACE-03 | Place | `placeCode`, `placeId`, `code` 중 화면/요청에서 표준으로 쓸 식별자는 무엇인가? | API 경계는 `code`, 기존 route 모델명은 `id` 유지 | Answered |
+| PLACE-04 | Place | `GET /place/{code}/members` 성공 response schema는 무엇인가? | 멤버 목록 계약 확인, 친구 관리 연결은 후속 | Answered |
+| PLACE-05 | Place | owner가 아닌 구성원의 장소 나가기 endpoint는 무엇인가? | #239 API mode에서 member 나가기 action 숨김 | Blocked |
+| FRIEND-01 | Friend | `GET /friends/requests` response schema는 무엇인가? | 요청 목록 수직 슬라이스 진행 가능 | Answered |
+| FRIEND-02 | Friend | 친구 요청 전송/수락/거절 성공 response와 화면 갱신 정책은 무엇인가? | 성공 result 확인, invalidate 정책은 화면 작업에서 결정 | Answered |
+| FRIEND-03 | Friend | `sendFriendReq.receiverName`은 display name인가, 고유 user id인가? | 표시 이름 사용 확인, 중복 이름 오매칭 위험은 백엔드 확인 필요 | Answered |
+| FRIEND-04 | Friend | `friendDecisionReq.friendId`는 요청 id인가, 사용자 id인가? | 요청 PK 사용 확인, 수락·거절 연결 가능 | Answered |
 | IMAGE-01 | Image | `/s3/images` upload/download/update/delete 성공 response schema는 무엇인가? | image key/url mapper 보류 | Open |
 | IMAGE-02 | Image | 화면 이미지는 `/s3/images` 선업로드 방식인가, 도메인 multipart 직접 전송 방식인가? | 프로필/장소/식물/메모 이미지 흐름 확정 불가 | Open |
 | IMAGE-03 | Image | presigned download URL 응답 필드와 wrapper 구조는 무엇인가? | 네트워크 이미지 fallback 정책 보류 | Open |
@@ -81,77 +82,86 @@
 
 ### PLACE-01. Place 성공 response body 구조
 
-- 현재 근거: Swagger의 Place 조회/생성/수정/삭제 성공 response body schema가 없다.
-- 프론트 영향: create/update/delete는 `void` 경계로만 처리하고, 조회 mapper는 넓은 fallback에 의존한다.
-- 확인 질문: 각 API의 성공 response wrapper와 `result` 구조는 무엇인가?
-- 프론트 반영: schema가 확정되면 `PlaceSummary` mapper와 화면 success/empty 정책을 좁힌다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 2026-08-25 dev Swagger의 machine-readable schema는 여전히 없지만, 백엔드 `7d572cb`의 `PlaceController`와 `PlaceDto`가 각 성공 응답을 `JsonResponse.result`로 반환한다.
+- 프론트 영향: 조회 mapper를 실제 필드로 좁힐 수 있고 생성 code, 수정 결과, 삭제 null 계약을 구분할 수 있다.
+- 확인 질문: 해결됨. 단, dev 배포와 백엔드 main commit의 동기화는 실제 인증 smoke 전까지 별도 검증한다.
+- 프론트 반영: #239에서 목록·상세 응답을 실제 도메인 모델로 연결했다. 생성 code와 수정 결과 소비는 친구 추가·수정 후속 이슈에서 연결한다.
+- 답변: 생성은 place code 문자열, 상세는 `getPlaceRes`, 수정은 `updatePlaceRes`, 삭제는 null이며 모두 공통 `JsonResponse.result`에 담긴다.
+- 상태: Answered
 
 ### PLACE-02. Place 목록/상세 필드명
 
-- 현재 근거: `/place/myGarden`, `/place/user`, `/place/{code}`의 list/object wrapper와 필드명이 명시되지 않았다.
-- 프론트 영향: 장소 목록, 식물 등록 장소 선택, 장소 상세의 실데이터 표시가 제한된다.
-- 확인 질문: 장소 id/code, 이름, 주소, 대표 이미지, 멤버/역할 정보의 정확한 필드명은 무엇인가?
-- 프론트 반영: 답변 후 repository mapper와 상태 UI를 보강한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 백엔드 `PlaceDto`에서 `getMainPage`, `getPlaceListRes`, `getPlaceBelongUser`, `getPlaceRes` 필드를 확인했다.
+- 프론트 영향: Home 장소 목록과 장소 상세가 fixture 없이 서버 필드를 사용할 수 있다.
+- 확인 질문: 해결됨.
+- 프론트 반영: #239에서 `result.placeList`와 `result.userList`, `result.plantList`, `owner`를 목록·상세 mapper와 화면 상태에 반영했다.
+- 답변: myGarden은 `{ name, placeList[] }`, user는 장소 배열, 상세는 `{ name, code, address, imgUrl, owner, userList[], plantList[] }`이다.
+- 상태: Done
 
 ### PLACE-03. Place 식별자 명칭
 
-- 현재 근거: Swagger와 기존 코드에서 `placeCode`, `placeId`, `code`가 함께 등장한다.
-- 프론트 영향: route parameter, query parameter, request DTO 이름이 섞일 수 있다.
-- 확인 질문: 프론트가 저장하고 전달해야 하는 표준 식별자는 `placeCode`인가, `placeId`인가?
-- 프론트 반영: 표준이 확정되면 route helper, provider key, request DTO naming을 정리한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 백엔드 Place DTO와 모든 Place path parameter는 문자열 `code`를 사용하고 Plant 요청은 `placeCode`로 같은 값을 전달한다.
+- 프론트 영향: API 경계에서는 정수 Place ID를 만들지 않고 code 문자열을 보존해야 한다.
+- 확인 질문: 해결됨.
+- 프론트 반영: #239의 `PlaceDetail.code`와 `PlaceSummary.id`는 서버 code 문자열을 저장한다. 기존 route의 `placeId` 이름 변경은 별도 routing 정리 범위로 남긴다.
+- 답변: Place의 외부 식별자는 code 문자열이며 요청 JSON에서는 `placeCode`, Place path에서는 `code`로 표현한다.
+- 상태: Answered
 
 ### PLACE-04. 장소 멤버 목록 response schema
 
-- 현재 근거: dev Swagger에 `GET /place/{code}/members`가 추가됐고 가입 순서대로 멤버를 조회한다고 설명하지만 성공 response body schema는 없다.
-- 프론트 영향: `/places/:placeId/friends`의 fixture 멤버를 remote response로 안전하게 바꿀 수 없다.
-- 확인 질문: wrapper와 member id, 이름, 프로필 이미지, 역할, 가입일 필드명은 무엇인가?
-- 프론트 반영: 답변 후 Place datasource/repository와 친구 관리 상태를 연결한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 백엔드 Controller는 `List<PlaceDto.getPlaceResUser>`를 `JsonResponse.result`로 반환한다.
+- 프론트 영향: 이름과 프로필 이미지는 연결할 수 있지만 member id, 역할, 가입일은 응답에 없어 삭제·권한 UI에 사용할 수 없다.
+- 확인 질문: 부분 해결됨. 멤버 변경 endpoint와 고유 member id가 필요하면 백엔드 확장이 필요하다.
+- 프론트 반영: #239 상세 화면은 `/place/{code}`에 포함된 동일 멤버 타입을 표시한다. 친구 관리 화면의 조회·변경은 후속 이슈로 남긴다.
+- 답변: 멤버 항목은 `{ name, image }`이며 가입 순서 배열이다.
+- 상태: Answered
+
+### PLACE-05. 구성원 장소 나가기 endpoint
+
+- 현재 근거: 백엔드 `PlaceServiceImpl.deletePlace`는 owner만 허용하고 장소와 식물·메모·Belong을 모두 삭제한다. 구성원 leave endpoint는 Controller에 없다.
+- 프론트 영향: owner 전체 삭제와 구성원 나가기를 같은 action으로 호출하면 구성원은 403이 발생하고 owner는 파괴 범위를 오해할 수 있다.
+- 확인 질문: owner가 아닌 구성원이 Belong만 제거하고 장소에서 나가는 endpoint가 제공되는가?
+- 프론트 반영: #239 API 모드는 owner에게만 전체 삭제 action과 경고를 표시하고 구성원 나가기는 숨긴다.
+- 답변: 현재 제공 endpoint 없음.
+- 상태: Blocked
 
 ## Friend
 
 ### FRIEND-01. 친구 요청 목록 response schema
 
-- 현재 근거: `GET /friends/requests`는 Swagger summary와 response schema가 없다.
-- 프론트 영향: 장소 친구 요청 화면을 raw response 없이 연결할 수 없다.
-- 확인 질문: 요청 id, 요청자, 대상 장소, 상태, 생성일, 프로필 이미지 필드가 포함되는가?
-- 프론트 반영: 답변 후 초대 요청 목록 Provider와 empty/error/success UI를 연결한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 백엔드 `7d572cb`의 `FriendController`, `FriendDto`, `FriendServiceImpl`에서 목록 응답과 생성 로직을 확인했다.
+- 프론트 영향: 장소 친구 요청 화면의 DTO와 loading/empty/error/success 상태를 확정할 수 있다.
+- 확인 질문: 해결됨. 생성일은 응답에 포함되지 않는다.
+- 프론트 반영: 별도 Friend 수직 슬라이스에서 요청 목록 Provider와 화면을 연결한다.
+- 답변: `result.requests[]` 항목은 `friendId`, `senderName`, `senderImgUrl`, `placeCode`, `placeName`, `placeAddress`, `status`를 가진다.
+- 상태: Answered
 
 ### FRIEND-02. 친구 요청 액션 성공 response와 갱신 정책
 
-- 현재 근거: `POST /friends/request`, `/friends/accept`, `/friends/decline` 성공 response 설명은 `OK`뿐이다.
-- 프론트 영향: 액션 후 snackbar, 목록 remove, 재조회 중 어떤 정책을 적용할지 확정할 수 없다.
-- 확인 질문: 성공 시 body가 있는가? 없다면 액션 후 목록 재조회가 권장되는가?
-- 프론트 반영: 답변 후 액션 Controller와 목록 invalidate 정책을 확정한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 백엔드 Controller에서 전송은 `sendFriendRes`, 수락·거절은 null을 `JsonResponse.result`로 반환한다.
+- 프론트 영향: 수락·거절 성공은 HTTP 성공 후 해당 요청을 로컬 목록에서 제거하고 목록 Provider를 invalidate하는 정책으로 구현할 수 있다.
+- 확인 질문: response 구조는 해결됨. 화면 갱신은 프론트 수직 슬라이스에서 optimistic remove 후 invalidate로 검증한다.
+- 프론트 반영: 별도 Friend 수직 슬라이스에서 Controller와 목록 재조회 정책을 구현한다.
+- 답변: 전송 result는 `{ placeCode, receiverList }`, 수락·거절 result는 null이다.
+- 상태: Answered
 
 ### FRIEND-03. `receiverName` 의미
 
-- 현재 근거: `sendFriendReq.receiverName`은 string array로만 명시되어 있다.
-- 프론트 영향: 사용자 검색 결과의 display name을 보낼지, user id를 보낼지 불명확하다.
-- 확인 질문: `receiverName`은 사용자 표시 이름 배열인가, 고유 user id 배열인가? 중복 이름은 어떻게 처리하는가?
-- 프론트 반영: 답변 후 친구 추가 선택 모델과 request DTO를 조정한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: `FriendServiceImpl`은 `receiverName`의 각 문자열을 사용자 이름 검색에 넣고 첫 결과를 receiver로 사용한다.
+- 프론트 영향: payload 타입은 확정됐지만 표시 이름이 중복되면 잘못된 사용자가 선택될 수 있어 신규 초대 전송을 안전하게 완료할 수 없다.
+- 확인 질문: receiver를 고유 user id로 바꾸거나 exact unique name을 보장할지 백엔드 결정이 필요하다.
+- 프론트 반영: 요청 DTO는 표시 이름 배열로 유지하되, 중복 이름 정책이 해결되기 전 실제 전송 화면 연결은 보류한다.
+- 답변: 현재 구현은 사용자 표시 이름 배열이며 부분 검색 결과의 첫 사용자를 선택한다.
+- 상태: Answered
 
 ### FRIEND-04. `friendId` 의미
 
-- 현재 근거: `friendDecisionReq.friendId`는 int64로만 명시되어 있다.
-- 프론트 영향: 수락/거절 payload에 요청 id를 넣어야 하는지 사용자 id를 넣어야 하는지 알 수 없다.
-- 확인 질문: `friendId`는 친구 요청 id인가, 요청자 user id인가, 친구 관계 id인가?
-- 프론트 반영: 답변 후 초대 요청 entity의 id 필드를 확정한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: `FriendServiceImpl`은 `findByFriendIdxAndReceiver(friendId, currentUserName)`로 요청을 찾는다.
+- 프론트 영향: 요청 목록의 `friendId`를 그대로 수락·거절 payload에 넣을 수 있다.
+- 확인 질문: 해결됨.
+- 프론트 반영: 별도 Friend 수직 슬라이스의 요청 entity id와 action request에 반영한다.
+- 답변: `friendId`는 친구 요청 테이블의 `friendIdx`, 즉 요청 PK이다.
+- 상태: Answered
 
 ## Image
 

--- a/docs/screen-api-integration-plan.md
+++ b/docs/screen-api-integration-plan.md
@@ -18,7 +18,7 @@
 - 화면 위젯은 JSON 파싱이나 Dio 호출을 직접 수행하지 않습니다.
 - API 사용 여부는 기존 `COMMONPLANT_USE_API` 환경값으로 분리합니다.
 - API 비사용 모드는 화면 개발과 Android smoke의 결정적 mock 흐름을 유지합니다.
-- Swagger에 response schema가 없는 기능은 화면 모델을 추측해 연결하지 않습니다.
+- Swagger에 response schema가 없는 기능은 화면 모델을 추측하지 않고, 배포 기준과 일치하는 백엔드 Controller·DTO·Service 근거까지 확인한 뒤 연결합니다.
 - loading, success, empty, error 상태를 해당 화면과 Controller 테스트에서 함께 검증합니다.
 
 ## 우선순위
@@ -28,11 +28,12 @@
 | P0 | Auth 로그인·회원가입 | 로그인 화면, 인증 세션, 프로필 등록, route redirect, `/auth/login`, `/auth/register` | #227 / PR #228 병합 완료 |
 | P1 | Home 초기 데이터 | 인증 사용자 정보와 장소·식물 요약을 화면 상태로 연결 | #232 / PR #233 병합 완료 |
 | P2 | Plant 핵심 동선 | 목록, 상세, 생성, 수정 API와 각 화면 상태 연결 | #229, #231 병합 완료 |
-| P3 | User 프로필 | 내 정보 조회·수정과 프로필 화면 연결 | #237 / PR #238 In Review, 이미지 파일 선택 정책과 분리 |
-| 제한 | Place | response schema가 확인된 동선부터 연결 | 목록·상세 schema 확인 필요 |
-| 보류 | Friend, Image, Memo | 성공 response 또는 endpoint가 불충분한 영역 | 백엔드 확인 필요 |
+| P3 | User 프로필 | 내 정보 조회·수정과 프로필 화면 연결 | #237 / PR #238 병합 완료, 이미지 파일 선택 정책과 분리 |
+| P4 | Place 목록·상세 | Home 장소 목록, 상세 owner·멤버·식물 실데이터 연결 | #239 진행 중 |
+| P5 후보 | Friend 요청 | 요청 목록, 수락, 거절 API와 화면 상태 연결 | 백엔드 source 계약 확인, #239 이후 진행 가능 |
+| 보류 | Image, Memo | 성공 response 또는 endpoint가 불충분한 영역 | 백엔드 확인 필요 |
 
-P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기준으로 합니다. 다만 Place 성공 response schema가 없으므로, 먼저 schema가 있는 `GET /users`와 `GET /plants`를 사용하고 Place 데이터는 확인된 필드만 별도 작업으로 추가합니다.
+P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기준으로 했습니다. #239는 live Swagger에 누락된 Place schema를 백엔드 main `7d572cb`의 Controller·DTO와 대조해 목록·상세 응답 계약을 확인한 뒤 후속 연결합니다.
 
 ## 화면 연결 매트릭스
 
@@ -40,16 +41,16 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 
 | 도메인 | 화면·route | 현재 상태 | 남은 연결 | API·선행 조건 | 판정 |
 | --- | --- | --- | --- | --- | --- |
-| Home | Home `/` | Place·Plant 목록 API 모드 연결, 사용자명·초대 수 고정 | 현재 사용자 Provider, hero 상태, 목록 재시도 정책, 고정값 제거 | `GET /users`, `GET /plants`; Place·Friend response schema 확인 필요 | #232 즉시 진행 |
-| User | 마이페이지 `/me`, 설정 `/me/settings`, 회원 정보 수정 `/me/edit` | 조회·이름 수정·탈퇴 Controller와 세 화면 연결 | 실제 이미지 파일 선택, 알림 설정 영속화 | `GET/PUT/DELETE /users` 연결, Image·알림 API/정책 필요 | #237 / PR #238 In Review |
-| Place | 장소 친구 요청 | fixture 목록과 로컬 수락·거절 | 목록 DTO, loading/empty/error, 수락·거절 submit | Friend response schema와 `friendId` 의미 확인 | 제한 |
-| Place | 장소 등록 | 이름·주소 create API 연결 | 생성된 장소 code, 실제 이미지, 친구 추가 후속 흐름 | `POST /place/create` response schema 필요 | 부분 연결 |
+| Home | Home `/` | User·Place·Plant 목록 API 모드 연결, Place 대표 이미지 표시 | 초대 수 API 연결, 목록 재시도 정책 | Friend 요청 목록 source 계약 확인 | #232, #239 연결 |
+| User | 마이페이지 `/me`, 설정 `/me/settings`, 회원 정보 수정 `/me/edit` | 조회·이름 수정·탈퇴 Controller와 세 화면 연결 | 실제 이미지 파일 선택, 알림 설정 영속화 | `GET/PUT/DELETE /users` 연결, Image·알림 API/정책 필요 | #237 / PR #238 병합 완료 |
+| Place | 장소 친구 요청 | fixture 목록과 로컬 수락·거절 | 목록 DTO, loading/empty/error, 수락·거절 submit | backend source에서 `requests[]`, 요청 PK, accept/decline null result 확인 | P5 후보 |
+| Place | 장소 등록 | 이름·주소 create API 연결 | 생성된 place code 소비, 실제 이미지, 친구 추가 후속 흐름 | source에서 생성 result code 확인, receiver 이름 중복 정책 필요 | 부분 연결 |
 | Place | 주소 검색 | fixture 검색 | 검색 adapter와 선택 결과 | 백엔드 endpoint 또는 외부 주소 서비스 결정 필요 | 보류 |
 | Place | 장소 등록 중 친구 추가 | User 검색만 API 모드 연결 | 선택 사용자 요청 submit, 장소 초대와 친구 요청 관계 | `GET /users/{keyword}`, `POST /friends/request`; 도메인 관계 확인 | 제한 |
-| Place | 장소 수정 | 상세 조회와 update API 연결 | 전체 수정 필드, image key/file, 응답 후 갱신 | `GET /place/{code}`, `PUT /place/update/{code}` response schema 필요 | 부분 연결 |
-| Place | 장소 상세 | API의 이름·주소와 fixture 상세를 혼합 | 역할, 환경 정보, 멤버, 장소 식물 목록 | Place detail/members schema와 장소별 식물 조회 기준 필요 | 제한 |
-| Place | 친구 관리 | fixture 검색·선택·삭제 | 멤버 목록과 추가·삭제 submit | members response와 멤버 변경 endpoint 필요 | 보류 |
-| Place | 장소 나가기·삭제 | delete 호출 연결 | 소유자 삭제와 구성원 나가기 분리 | `DELETE /place/delete/{code}` 의미 확인 | 제한 |
+| Place | 장소 수정 | 상세 조회와 update API 연결 | image key/file, 수정 결과 즉시 반영 | source에서 update result 확인, 상세에는 image key 미제공 | 부분 연결 |
+| Place | 장소 상세 | API 장소·owner·멤버·식물 연결, fixture 병합 제거 | 서버 미제공 환경 수치와 물주기 액션 | `GET /place/{code}` source 계약 #239 반영 | #239 진행 중 |
+| Place | 친구 관리 | fixture 검색·선택·삭제 | 멤버 목록 조회, 추가·삭제 submit | `{ name, image }[]` 확인, 고유 member id와 변경 endpoint 없음 | 보류 |
+| Place | 장소 나가기·삭제 | API 모드는 owner 삭제만 노출 | 구성원 나가기 | delete는 owner 전용 전체 삭제, leave endpoint 없음 | 삭제 #239, 나가기 Blocked |
 | Plant | 식물 등록 검색 | fixture 검색 | 실제 검색 모델과 상태 | 식물 종 검색 endpoint 필요 | 보류 |
 | Plant | 식물 등록 | create API 부분 연결, 물주기 날짜 고정 | 날짜 상태·request, 학명/별칭 분리, image file | `POST /plants` 사용 가능; 검색·이미지 정책 별도 | #229 즉시 진행 |
 | Plant | 식물 수정 | edit info와 update API 부분 연결 | 기존/변경 물주기 날짜, image key/file | `GET /plants/{id}/edit`, `PUT /plants/{id}` 사용 가능 | #229 즉시 진행 |
@@ -104,6 +105,18 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 - 알림 설정 endpoint가 없어 토글은 설정 화면이 유지되는 동안의 로컬 Provider 상태로 둡니다.
 - 프로필 이미지는 기존 optional multipart 경계를 유지하지만, 파일 선택기와 플랫폼 권한 정책이 확정되지 않아 현재 이미지와 카메라 진입 안내까지만 제공합니다.
 
+## Place 목록·상세 수직 슬라이스
+
+#239는 live Swagger에 노출되지 않은 Place 성공 타입을 백엔드 main `7d572cb`의 Controller·DTO와 대조한 뒤, Home 장소 목록과 장소 상세의 remote fixture 병합을 제거합니다.
+
+- Home 장소 목록은 `GET /place/myGarden`의 `result.placeList`에서 code, 이름, 대표 이미지, 멤버 수, 식물 수를 파싱합니다.
+- 장소 상세는 `GET /place/{code}`를 별도 `PlaceDetail` 도메인 모델로 변환하고 owner, 멤버, 식물을 화면 ViewData로 연결합니다.
+- API 모드에서는 서버가 제공하지 않는 햇빛·습도, 물주기 예정값, fixture 멤버·식물을 표시하지 않습니다.
+- 마지막 물주기 날짜가 있으면 확인 가능한 이력으로 표시하고, 물주기 action은 endpoint가 없어 활성화하지 않습니다.
+- `DELETE /place/delete/{code}`는 owner 전용 전체 삭제이므로 owner에게만 삭제 문구와 영향 범위 경고를 표시합니다.
+- 구성원 leave endpoint가 없어 API 모드의 구성원에게는 동작하지 않는 나가기 action을 노출하지 않습니다.
+- API 비사용 모드는 Android smoke와 화면 개발을 위해 기존 fixture 흐름을 유지합니다.
+
 ## 완료 기준
 
 각 수직 슬라이스는 아래 항목을 모두 충족해야 완료로 판단합니다.
@@ -126,5 +139,7 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 | #230 | - | 남은 화면 연결 매트릭스, 병렬 workstream과 파일 소유권 문서화 | `git diff --check` |
 | #237 | `684d55b` | 마이페이지·설정·회원 정보 수정 UI와 User 조회·수정·탈퇴 상태 연결 | format 284개, analyze, 전체 test 314개·기존 skip 1개 |
 | #237 | `3063230` | Figma frame map, route, Swagger 연결 상태와 User 구현 경계 문서화 | `git diff --check` |
+| #239 | `893d201` | Place 목록·상세 모델, mapper, Provider와 remote 실데이터 UI 연결 | Place test 81개, analyze |
+| #239 | `7ac4bc1` | owner 전체 삭제와 구성원 나가기 미지원 경계 분리 | format 286개, analyze, 전체 test 321개·기존 skip 1개 |
 
 문서 이력만 갱신하는 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/docs/work-history/place-list-detail-api-239.md
+++ b/docs/work-history/place-list-detail-api-239.md
@@ -1,0 +1,53 @@
+# Place 목록·상세 API 연결 이력
+
+## 작업 기준
+
+- 이슈: #239 `[Feature] 장소 목록·상세 API 실데이터 연결`
+- 상위 이슈: #226 `[Epic] MVP 화면·API 실연동 전환`
+- 작업일: 2026-08-25
+- 브랜치: `feature/place-list-detail-api-239`
+- 참고 문서:
+  - `docs/screen-api-integration-plan.md`
+  - `docs/api-swagger-reference.md`
+  - `docs/backend-api-open-questions.md`
+  - `docs/feature-development-guide.md`
+  - `docs/state-management-guide.md`
+  - `docs/screen-publishing-rules.md`
+  - `docs/design-token-rules.md`
+  - `docs/shared-widget-guide.md`
+  - `docs/testing-guide.md`
+  - `docs/git-workflow.md`
+
+## API 계약 근거
+
+- 2026-08-25 live OpenAPI는 19 paths, 27 operations이며 Place·Friend 성공 response schema가 여전히 노출되지 않았습니다.
+- 백엔드 저장소 `UMC-CommonPlant/v3_CommonPlant_Backend_Repo` main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`의 Controller·DTO·Service를 추가 근거로 사용했습니다.
+- Place 목록은 `getMainPage.placeList`, 상세는 `getPlaceRes`, 멤버는 `getPlaceResUser`, 식물은 `PlantResponse.DetailResponse` 계약을 따릅니다.
+- `DELETE /place/delete/{code}`는 owner 전용 전체 삭제이며 장소와 식물·메모·멤버 관계를 함께 정리합니다. 구성원 leave endpoint는 없습니다.
+
+## 구현 범위
+
+- `GET /place/myGarden`의 `result.placeList`에서 code, 이름, 이미지, 멤버 수, 식물 수를 파싱합니다.
+- Home의 장소 카드는 응답 대표 이미지가 있으면 네트워크 이미지를 표시합니다.
+- 장소 상세를 `PlaceDetail`, `PlaceMember`, `PlacePlant` 도메인 모델로 분리했습니다.
+- API 모드는 owner 여부, 멤버 이름·이미지, 식물 학명·이미지·설명·마지막 물주기 날짜를 실제 응답에서 표시합니다.
+- 서버가 제공하지 않는 햇빛·습도, 물주기 예정값, fixture 멤버·식물은 API 모드에서 표시하지 않습니다.
+- 멤버와 식물이 비어 있는 상태, loading, error, retry를 기존 `AsyncValue` 흐름에서 유지합니다.
+- owner는 API 모드에서만 장소 삭제 action과 전체 삭제 경고를 확인할 수 있고, 구성원에게는 동작하지 않는 나가기 action을 노출하지 않습니다.
+- API 비사용 모드는 기존 fixture 화면과 장소 나가기 UI를 유지합니다.
+
+## 보류 경계와 다음 후보
+
+- 구성원 장소 나가기는 백엔드 leave endpoint가 없어 Blocked입니다.
+- 장소 환경 수치와 물주기 action은 응답·endpoint가 없어 추가하지 않았습니다.
+- 친구 관리의 멤버 고유 id와 변경 endpoint는 제공되지 않습니다.
+- Friend source에서 요청 목록과 수락·거절 계약을 확인했으므로, 다음 수직 슬라이스 후보는 장소 친구 요청 목록·수락·거절입니다.
+- 신규 친구 요청 전송은 백엔드가 표시 이름 부분 검색의 첫 사용자를 선택하므로 중복 이름 오매칭 정책이 해결될 때까지 보류합니다.
+
+## 커밋과 검증
+
+| 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- |
+| `893d201` | Place 목록·상세 도메인 모델, mapper, repository, Provider, remote UI와 테스트 | Place test 81개, analyze 통과 |
+| `7ac4bc1` | owner 삭제와 member 나가기 권한·문구 분리 | 상세·FAB·삭제 Controller test 통과 |
+| 이 문서 후속 커밋 | API 계약 문서, 우선순위, PR·Project 연결 이력 | format 286개, analyze, 전체 test 321개 통과·기존 golden 1개 skip |

--- a/docs/work-history/place-list-detail-api-239.md
+++ b/docs/work-history/place-list-detail-api-239.md
@@ -3,6 +3,7 @@
 ## 작업 기준
 
 - 이슈: #239 `[Feature] 장소 목록·상세 API 실데이터 연결`
+- PR: #240 `[Feature] 장소 목록·상세 API 실데이터 연결`
 - 상위 이슈: #226 `[Epic] MVP 화면·API 실연동 전환`
 - 작업일: 2026-08-25
 - 브랜치: `feature/place-list-detail-api-239`
@@ -50,4 +51,5 @@
 | --- | --- | --- |
 | `893d201` | Place 목록·상세 도메인 모델, mapper, repository, Provider, remote UI와 테스트 | Place test 81개, analyze 통과 |
 | `7ac4bc1` | owner 삭제와 member 나가기 권한·문구 분리 | 상세·FAB·삭제 Controller test 통과 |
-| 이 문서 후속 커밋 | API 계약 문서, 우선순위, PR·Project 연결 이력 | format 286개, analyze, 전체 test 321개 통과·기존 golden 1개 skip |
+| `972a6ae` | API 계약 문서, 우선순위, 작업 이력 | format 286개, analyze, 전체 test 321개 통과·기존 golden 1개 skip |
+| 이 문서 후속 커밋 | PR #240과 Project 10 In Review 연결 기록 | `git diff --check` |

--- a/lib/core/network/api_response_parser.dart
+++ b/lib/core/network/api_response_parser.dart
@@ -88,6 +88,28 @@ int? readOptionalInt(JsonMap json, List<String> keys) {
   return null;
 }
 
+bool? readOptionalBool(JsonMap json, List<String> keys) {
+  for (final key in keys) {
+    final value = json[key];
+
+    if (value is bool) {
+      return value;
+    }
+
+    if (value is String) {
+      final normalized = value.toLowerCase();
+      if (normalized == 'true') {
+        return true;
+      }
+      if (normalized == 'false') {
+        return false;
+      }
+    }
+  }
+
+  return null;
+}
+
 Object? _normalizeResponseData(Object? data) {
   if (data is String && data.isNotEmpty) {
     return jsonDecode(data);

--- a/lib/features/home/presentation/widgets/home_body.dart
+++ b/lib/features/home/presentation/widgets/home_body.dart
@@ -71,6 +71,9 @@ class HomeBody extends ConsumerWidget {
                     for (final place in places) ...[
                       CommonPlaceCard(
                         title: place.name,
+                        imageProvider: place.imageUrl == null
+                            ? null
+                            : NetworkImage(place.imageUrl!),
                         onTap: () => context.push(
                           AppRoutePaths.placeDetailLocation(place.id),
                         ),

--- a/lib/features/place/data/mappers/place_mapper.dart
+++ b/lib/features/place/data/mappers/place_mapper.dart
@@ -1,7 +1,24 @@
+import 'package:commonplant_frontend/core/network/api_exception.dart';
 import 'package:commonplant_frontend/core/network/api_response_parser.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 
 List<PlaceSummary> placeSummariesFromResponse(Object? data) {
+  final response = jsonObjectFromResponse(data, context: '장소 목록 조회');
+  final result = response['result'];
+
+  if (result is JsonMap) {
+    final placeList = result['placeList'];
+    if (placeList is List) {
+      return [
+        for (final (index, item) in placeList.indexed)
+          placeSummaryFromJson(
+            _requireJsonMap(item, context: '장소 목록 ${index + 1}번째 항목'),
+          ),
+      ];
+    }
+  }
+
   final items = jsonListFromResponse(data, context: '장소 목록 조회');
 
   return [for (final item in items) placeSummaryFromJson(item)];
@@ -29,5 +46,81 @@ PlaceSummary placeSummaryFromJson(JsonMap json, {String? fallbackId}) {
         readRequiredString(json, const ['nanoId'], '장소 ID'),
     name: readRequiredString(json, const ['name', 'placeName'], '장소 이름'),
     address: readOptionalString(json, const ['address', 'placeAddress']),
+    imageUrl: readOptionalString(json, const ['image', 'imgUrl', 'imageUrl']),
+    memberCount: readOptionalInt(json, const ['member', 'memberCount']),
+    plantCount: readOptionalInt(json, const ['plant', 'plantCount']),
   );
+}
+
+PlaceDetail placeDetailFromResponse(
+  Object? data, {
+  required String fallbackCode,
+}) {
+  final json = unwrapJsonObject(data, context: '장소 상세 조회');
+  final members = _readObjectList(json, key: 'userList', context: '장소 멤버 목록');
+  final plants = _readObjectList(json, key: 'plantList', context: '장소 식물 목록');
+
+  return PlaceDetail(
+    code: readOptionalString(json, const ['code', 'placeCode']) ?? fallbackCode,
+    name: readRequiredString(json, const ['name', 'placeName'], '장소 이름'),
+    address: readOptionalString(json, const ['address', 'placeAddress']) ?? '',
+    imageUrl: readOptionalString(json, const ['imgUrl', 'imageUrl', 'image']),
+    isOwner: readOptionalBool(json, const ['owner', 'isOwner']) ?? false,
+    members: [for (final member in members) placeMemberFromJson(member)],
+    plants: [for (final plant in plants) placePlantFromJson(plant)],
+  );
+}
+
+PlaceMember placeMemberFromJson(JsonMap json) {
+  return PlaceMember(
+    name: readRequiredString(json, const ['name'], '장소 멤버 이름'),
+    imageUrl: readOptionalString(json, const ['image', 'imgUrl', 'imageUrl']),
+  );
+}
+
+PlacePlant placePlantFromJson(JsonMap json) {
+  return PlacePlant(
+    id: readRequiredString(json, const ['plantId', 'id'], '장소 식물 ID'),
+    scientificNameKo: readRequiredString(json, const [
+      'scientificNameKo',
+      'nickname',
+      'name',
+    ], '장소 식물 이름'),
+    scientificNameEn: readOptionalString(json, const ['scientificNameEn']),
+    registeredAt: readOptionalString(json, const ['registeredAt']),
+    lastWateredDate: readOptionalString(json, const ['lastWateredDate']),
+    imageUrl: readOptionalString(json, const ['imageUrl', 'imgUrl']),
+    memo: readOptionalString(json, const ['memo']),
+    placeName: readOptionalString(json, const ['placeName']),
+    description: readOptionalString(json, const ['plantInfo', 'description']),
+  );
+}
+
+List<JsonMap> _readObjectList(
+  JsonMap json, {
+  required String key,
+  required String context,
+}) {
+  final value = json[key];
+
+  if (value == null) {
+    return const [];
+  }
+
+  if (value is! List) {
+    throw ApiException(message: '$context 응답이 목록 형식이 아닙니다.');
+  }
+
+  return [
+    for (final (index, item) in value.indexed)
+      _requireJsonMap(item, context: '$context ${index + 1}번째 항목'),
+  ];
+}
+
+JsonMap _requireJsonMap(Object? value, {required String context}) {
+  if (value is JsonMap) {
+    return value;
+  }
+
+  throw ApiException(message: '$context 응답이 JSON object 형식이 아닙니다.');
 }

--- a/lib/features/place/data/repositories/place_repository.dart
+++ b/lib/features/place/data/repositories/place_repository.dart
@@ -1,6 +1,7 @@
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
 import 'package:commonplant_frontend/features/place/data/dtos/place_requests.dart';
 import 'package:commonplant_frontend/features/place/data/mappers/place_mapper.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:dio/dio.dart';
@@ -29,6 +30,13 @@ class PlaceRepositoryImpl implements PlaceRepository {
     final data = await _remoteDataSource.getPlace(code);
 
     return placeSummaryFromResponse(data, fallbackId: code);
+  }
+
+  @override
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
+    final data = await _remoteDataSource.getPlace(code);
+
+    return placeDetailFromResponse(data, fallbackCode: code);
   }
 
   @override

--- a/lib/features/place/domain/entities/place_detail.dart
+++ b/lib/features/place/domain/entities/place_detail.dart
@@ -1,0 +1,50 @@
+class PlaceDetail {
+  const PlaceDetail({
+    required this.code,
+    required this.name,
+    required this.address,
+    required this.isOwner,
+    required this.members,
+    required this.plants,
+    this.imageUrl,
+  });
+
+  final String code;
+  final String name;
+  final String address;
+  final String? imageUrl;
+  final bool isOwner;
+  final List<PlaceMember> members;
+  final List<PlacePlant> plants;
+}
+
+class PlaceMember {
+  const PlaceMember({required this.name, this.imageUrl});
+
+  final String name;
+  final String? imageUrl;
+}
+
+class PlacePlant {
+  const PlacePlant({
+    required this.id,
+    required this.scientificNameKo,
+    this.scientificNameEn,
+    this.registeredAt,
+    this.lastWateredDate,
+    this.imageUrl,
+    this.memo,
+    this.placeName,
+    this.description,
+  });
+
+  final String id;
+  final String scientificNameKo;
+  final String? scientificNameEn;
+  final String? registeredAt;
+  final String? lastWateredDate;
+  final String? imageUrl;
+  final String? memo;
+  final String? placeName;
+  final String? description;
+}

--- a/lib/features/place/domain/entities/place_summary.dart
+++ b/lib/features/place/domain/entities/place_summary.dart
@@ -1,15 +1,35 @@
 class PlaceSummary {
-  const PlaceSummary({required this.id, required this.name, this.address});
+  const PlaceSummary({
+    required this.id,
+    required this.name,
+    this.address,
+    this.imageUrl,
+    this.memberCount,
+    this.plantCount,
+  });
 
   final String id;
   final String name;
   final String? address;
+  final String? imageUrl;
+  final int? memberCount;
+  final int? plantCount;
 
-  PlaceSummary copyWith({String? id, String? name, String? address}) {
+  PlaceSummary copyWith({
+    String? id,
+    String? name,
+    String? address,
+    String? imageUrl,
+    int? memberCount,
+    int? plantCount,
+  }) {
     return PlaceSummary(
       id: id ?? this.id,
       name: name ?? this.name,
       address: address ?? this.address,
+      imageUrl: imageUrl ?? this.imageUrl,
+      memberCount: memberCount ?? this.memberCount,
+      plantCount: plantCount ?? this.plantCount,
     );
   }
 }

--- a/lib/features/place/domain/repositories/place_repository.dart
+++ b/lib/features/place/domain/repositories/place_repository.dart
@@ -1,3 +1,4 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 
 abstract interface class PlaceRepository {
@@ -6,6 +7,8 @@ abstract interface class PlaceRepository {
   Future<List<PlaceSummary>> fetchUserPlaces();
 
   Future<PlaceSummary> fetchPlace(String code);
+
+  Future<PlaceDetail> fetchPlaceDetail(String code);
 
   Future<void> createPlace({required String name, required String address});
 

--- a/lib/features/place/presentation/fixtures/place_detail_fixture.dart
+++ b/lib/features/place/presentation/fixtures/place_detail_fixture.dart
@@ -37,6 +37,7 @@ PlaceDetailViewData placeDetailFixture(
         dDayLabel: 'D-3',
         dateLabel: '2022.11.20',
         canWater: true,
+        imageAsset: AppImageAssets.placeDetailMonstera,
       ),
       PlaceDetailPlantItem(
         id: 'plant-2',
@@ -45,6 +46,7 @@ PlaceDetailViewData placeDetailFixture(
         description: '일주일에 x번 물주는 거 잊지 않기',
         dDayLabel: 'D-5',
         dateLabel: '2022.11.20',
+        imageAsset: AppImageAssets.placeDetailMonstera,
       ),
       PlaceDetailPlantItem(
         id: 'plant-3',
@@ -53,6 +55,7 @@ PlaceDetailViewData placeDetailFixture(
         description: '일주일에 x번 물주는 거 잊지 않기',
         dDayLabel: 'D-5',
         dateLabel: '2022.11.20',
+        imageAsset: AppImageAssets.placeDetailMonstera,
       ),
       PlaceDetailPlantItem(
         id: 'plant-4',
@@ -61,6 +64,7 @@ PlaceDetailViewData placeDetailFixture(
         description: '일주일에 x번 물주는 거 잊지 않기',
         dDayLabel: 'D-5',
         dateLabel: '2022.11.20',
+        imageAsset: AppImageAssets.placeDetailMonstera,
       ),
     ],
   );

--- a/lib/features/place/presentation/mappers/place_detail_view_mapper.dart
+++ b/lib/features/place/presentation/mappers/place_detail_view_mapper.dart
@@ -1,21 +1,67 @@
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_view_data.dart';
 
-PlaceDetailViewData? mapPlaceSummaryToDetailViewData({
-  required PlaceDetailViewData fallback,
-  required PlaceSummary summary,
-}) {
-  if (summary.name.trim().isEmpty) {
+PlaceDetailViewData? mapPlaceDetailToViewData(PlaceDetail detail) {
+  if (detail.name.trim().isEmpty) {
     return null;
   }
 
   return PlaceDetailViewData(
-    role: fallback.role,
-    name: summary.name,
-    address: summary.address ?? fallback.address,
-    sunlightLabel: fallback.sunlightLabel,
-    humidityLabel: fallback.humidityLabel,
-    friends: fallback.friends,
-    plants: fallback.plants,
+    role: detail.isOwner ? PlaceDetailRole.leader : PlaceDetailRole.member,
+    name: detail.name,
+    address: detail.address,
+    friends: [
+      for (final (index, member) in detail.members.indexed)
+        PlaceDetailFriendItem(
+          id: 'member-${index + 1}',
+          name: member.name,
+          imageUrl: _nonBlank(member.imageUrl),
+        ),
+    ],
+    plants: [for (final plant in detail.plants) _mapPlant(plant)],
   );
+}
+
+PlaceDetailPlantItem _mapPlant(PlacePlant plant) {
+  final lastWateredDate = _formatDate(plant.lastWateredDate);
+  final registeredAt = _formatDate(plant.registeredAt);
+  final dateLabel = lastWateredDate ?? registeredAt;
+  final dateTypeLabel = lastWateredDate != null
+      ? '마지막 물주기'
+      : registeredAt != null
+      ? '등록일'
+      : null;
+
+  return PlaceDetailPlantItem(
+    id: plant.id,
+    name: plant.scientificNameKo,
+    species: _nonBlank(plant.scientificNameEn) ?? plant.scientificNameKo,
+    description:
+        _nonBlank(plant.description) ?? _nonBlank(plant.memo) ?? '등록된 설명이 없어요',
+    dDayLabel: dateTypeLabel,
+    dateLabel: dateLabel,
+    imageUrl: _nonBlank(plant.imageUrl),
+  );
+}
+
+String? _formatDate(String? value) {
+  final normalized = _nonBlank(value);
+  if (normalized == null) {
+    return null;
+  }
+
+  final parsed = DateTime.tryParse(normalized);
+  if (parsed == null) {
+    return normalized;
+  }
+
+  return '${parsed.year.toString().padLeft(4, '0')}.'
+      '${parsed.month.toString().padLeft(2, '0')}.'
+      '${parsed.day.toString().padLeft(2, '0')}';
+}
+
+String? _nonBlank(String? value) {
+  final normalized = value?.trim();
+  return normalized == null || normalized.isEmpty ? null : normalized;
 }

--- a/lib/features/place/presentation/models/place_detail_view_data.dart
+++ b/lib/features/place/presentation/models/place_detail_view_data.dart
@@ -6,17 +6,17 @@ class PlaceDetailViewData {
     required this.role,
     required this.name,
     required this.address,
-    required this.sunlightLabel,
-    required this.humidityLabel,
     required this.friends,
     required this.plants,
+    this.sunlightLabel,
+    this.humidityLabel,
   });
 
   final PlaceDetailRole role;
   final String name;
   final String address;
-  final String sunlightLabel;
-  final String humidityLabel;
+  final String? sunlightLabel;
+  final String? humidityLabel;
   final List<PlaceDetailFriendItem> friends;
   final List<PlaceDetailPlantItem> plants;
 }
@@ -26,16 +26,23 @@ class PlaceDetailFriendItem {
     required this.id,
     required this.name,
     this.imageAsset,
+    this.imageUrl,
     this.isOwner = false,
   });
 
   final String id;
   final String name;
   final String? imageAsset;
+  final String? imageUrl;
   final bool isOwner;
 
   PlaceFriendProfile toProfile() {
-    return PlaceFriendProfile(id: id, name: name, imageAsset: imageAsset);
+    return PlaceFriendProfile(
+      id: id,
+      name: name,
+      imageAsset: imageAsset,
+      imageUrl: imageUrl,
+    );
   }
 }
 
@@ -48,13 +55,17 @@ class PlaceDetailPlantItem {
     required this.dDayLabel,
     required this.dateLabel,
     this.canWater = false,
+    this.imageAsset,
+    this.imageUrl,
   });
 
   final String id;
   final String name;
   final String species;
   final String description;
-  final String dDayLabel;
-  final String dateLabel;
+  final String? dDayLabel;
+  final String? dateLabel;
   final bool canWater;
+  final String? imageAsset;
+  final String? imageUrl;
 }

--- a/lib/features/place/presentation/models/place_friend_profile.dart
+++ b/lib/features/place/presentation/models/place_friend_profile.dart
@@ -3,9 +3,11 @@ class PlaceFriendProfile {
     required this.id,
     required this.name,
     this.imageAsset,
+    this.imageUrl,
   });
 
   final String id;
   final String name;
   final String? imageAsset;
+  final String? imageUrl;
 }

--- a/lib/features/place/presentation/pages/place_detail_page.dart
+++ b/lib/features/place/presentation/pages/place_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/app/router/route_paths.dart';
 import 'package:commonplant_frontend/core/assets/app_icon_assets.dart';
+import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
@@ -27,13 +28,18 @@ class PlaceDetailPage extends ConsumerWidget {
   final String placeId;
   final PlaceDetailRole? role;
 
-  void _showExitDialog(BuildContext context, WidgetRef ref) {
+  void _showExitDialog(
+    BuildContext context,
+    WidgetRef ref, {
+    required PlaceRemovalMode mode,
+  }) {
     final isExiting = ref.read(placeExitControllerProvider).isSubmitting;
 
     unawaited(
       showPlaceExitDialog(
         context: context,
         isExiting: isExiting,
+        mode: mode,
         onConfirm: () => _handleExitConfirmed(context, ref),
       ),
     );
@@ -121,6 +127,13 @@ class PlaceDetailPage extends ConsumerWidget {
     WidgetRef ref,
     PlaceDetailViewData detail,
   ) {
+    final usesRemoteApi = ref.watch(useRemoteApiProvider);
+    final isOwner = detail.role == PlaceDetailRole.leader;
+    final canRemove = !usesRemoteApi || isOwner;
+    final removalMode = usesRemoteApi
+        ? PlaceRemovalMode.delete
+        : PlaceRemovalMode.leave;
+
     return CommonScaffold(
       title: 'My place',
       navigationTitleStyle: AppTextStyles.size18Medium.copyWith(
@@ -130,8 +143,13 @@ class PlaceDetailPage extends ConsumerWidget {
       bodyPadding: EdgeInsets.zero,
       floatingActionButton: PlaceDetailFab(
         placeId: placeId,
-        canEditPlace: detail.role == PlaceDetailRole.leader,
-        onExit: () => _showExitDialog(context, ref),
+        canEditPlace: isOwner,
+        removalLabel: removalMode == PlaceRemovalMode.delete
+            ? '장소 삭제하기'
+            : '장소 나가기',
+        onRemove: canRemove
+            ? () => _showExitDialog(context, ref, mode: removalMode)
+            : null,
       ),
       child: SizedBox(
         width: double.infinity,

--- a/lib/features/place/presentation/providers/place_detail_remote_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_remote_provider.dart
@@ -1,8 +1,14 @@
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final placeDetailProvider = FutureProvider.family<PlaceSummary, String>(
+final placeDetailProvider = FutureProvider.family<PlaceDetail, String>(
+  (ref, code) => ref.watch(placeRepositoryProvider).fetchPlaceDetail(code),
+  retry: (retryCount, error) => null,
+);
+
+final placeSummaryProvider = FutureProvider.family<PlaceSummary, String>(
   (ref, code) => ref.watch(placeRepositoryProvider).fetchPlace(code),
   retry: (retryCount, error) => null,
 );

--- a/lib/features/place/presentation/providers/place_detail_view_provider.dart
+++ b/lib/features/place/presentation/providers/place_detail_view_provider.dart
@@ -33,15 +33,11 @@ final placeRemoteDetailViewProvider =
       ref,
       request,
     ) async {
-      final fallback = ref.watch(placeLocalDetailViewProvider(request));
-      final summary = await ref.watch(
+      final detail = await ref.watch(
         placeDetailProvider(request.placeId).future,
       );
 
-      return mapPlaceSummaryToDetailViewData(
-        fallback: fallback,
-        summary: summary,
-      );
+      return mapPlaceDetailToViewData(detail);
     }, retry: (retryCount, error) => null);
 
 void invalidatePlaceDetailView(WidgetRef ref, PlaceDetailViewRequest request) {

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -42,6 +42,7 @@ class PlaceExitController extends Notifier<FormSubmitState> {
     try {
       await ref.read(placeRepositoryProvider).deletePlace(placeId);
       ref.invalidate(placeDetailProvider(placeId));
+      ref.invalidate(placeSummaryProvider(placeId));
       ref.invalidate(remotePlaceListProvider);
       ref.invalidate(userPlaceSummariesProvider);
       state = const FormSubmitState.idle();

--- a/lib/features/place/presentation/providers/place_exit_controller.dart
+++ b/lib/features/place/presentation/providers/place_exit_controller.dart
@@ -49,7 +49,7 @@ class PlaceExitController extends Notifier<FormSubmitState> {
 
       return const PlaceExitResult.home();
     } catch (_) {
-      state = const FormSubmitState.failure('장소 나가기에 실패했어요');
+      state = const FormSubmitState.failure('장소 삭제에 실패했어요');
 
       return null;
     }

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -92,7 +92,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
       return;
     }
 
-    ref.invalidate(placeDetailProvider(placeId));
+    ref.invalidate(placeSummaryProvider(placeId));
     ref.invalidate(remotePlaceFormEditInfoProvider(placeId));
   }
 
@@ -158,6 +158,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
           .read(placeRepositoryProvider)
           .updatePlace(code: placeId, name: name, address: requiredAddress);
       ref.invalidate(placeDetailProvider(placeId));
+      ref.invalidate(placeSummaryProvider(placeId));
       ref.invalidate(remotePlaceListProvider);
       ref.invalidate(userPlaceSummariesProvider);
     } else {

--- a/lib/features/place/presentation/providers/place_form_edit_provider.dart
+++ b/lib/features/place/presentation/providers/place_form_edit_provider.dart
@@ -34,7 +34,7 @@ final placeFormEditInfoProvider =
 
 final remotePlaceFormEditInfoProvider =
     FutureProvider.family<PlaceFormEditInfo?, String>((ref, placeId) async {
-      final summary = await ref.watch(placeDetailProvider(placeId).future);
+      final summary = await ref.watch(placeSummaryProvider(placeId).future);
 
       if (summary.name.trim().isEmpty) {
         return null;

--- a/lib/features/place/presentation/widgets/place_detail_fab.dart
+++ b/lib/features/place/presentation/widgets/place_detail_fab.dart
@@ -12,12 +12,14 @@ class PlaceDetailFab extends StatelessWidget {
     super.key,
     required this.placeId,
     required this.canEditPlace,
-    required this.onExit,
+    this.removalLabel = '장소 나가기',
+    this.onRemove,
   });
 
   final String placeId;
   final bool canEditPlace;
-  final VoidCallback onExit;
+  final String removalLabel;
+  final VoidCallback? onRemove;
 
   @override
   Widget build(BuildContext context) {
@@ -47,17 +49,18 @@ class PlaceDetailFab extends StatelessWidget {
             onPressed: () =>
                 context.push(AppRoutePaths.placeEditLocation(placeId)),
           ),
-        CommonFabDialAction(
-          label: '장소 나가기',
-          icon: const CommonSvgIcon(
-            AppIconAssets.exit,
-            width: AppSizes.iconMedium,
-            height: AppSizes.iconMedium,
-            color: AppColors.textStrong,
-            semanticsLabel: '장소 나가기',
+        if (onRemove case final onRemove?)
+          CommonFabDialAction(
+            label: removalLabel,
+            icon: CommonSvgIcon(
+              AppIconAssets.exit,
+              width: AppSizes.iconMedium,
+              height: AppSizes.iconMedium,
+              color: AppColors.textStrong,
+              semanticsLabel: removalLabel,
+            ),
+            onPressed: onRemove,
           ),
-          onPressed: onExit,
-        ),
       ],
       child: const CommonSvgIcon(
         AppIconAssets.shape,

--- a/lib/features/place/presentation/widgets/place_detail_header.dart
+++ b/lib/features/place/presentation/widgets/place_detail_header.dart
@@ -26,8 +26,8 @@ class PlaceDetailHeader extends StatelessWidget {
   final String placeId;
   final String name;
   final String address;
-  final String sunlightLabel;
-  final String humidityLabel;
+  final String? sunlightLabel;
+  final String? humidityLabel;
   final List<PlaceDetailFriendItem> friends;
 
   @override
@@ -58,11 +58,13 @@ class PlaceDetailHeader extends StatelessWidget {
                 Expanded(
                   child: _PlaceTitleBlock(name: name, address: address),
                 ),
-                const SizedBox(width: AppSpacing.x12),
-                _PlaceMetricStrip(
-                  sunlightLabel: sunlightLabel,
-                  humidityLabel: humidityLabel,
-                ),
+                if (sunlightLabel != null || humidityLabel != null) ...[
+                  const SizedBox(width: AppSpacing.x12),
+                  _PlaceMetricStrip(
+                    sunlightLabel: sunlightLabel,
+                    humidityLabel: humidityLabel,
+                  ),
+                ],
               ],
             ),
             const SizedBox(height: AppSpacing.x24),
@@ -114,8 +116,8 @@ class _PlaceMetricStrip extends StatelessWidget {
     required this.humidityLabel,
   });
 
-  final String sunlightLabel;
-  final String humidityLabel;
+  final String? sunlightLabel;
+  final String? humidityLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -123,17 +125,20 @@ class _PlaceMetricStrip extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _PlaceMetric(
-          icon: AppIconAssets.tagSunlight,
-          label: sunlightLabel,
-          semanticsLabel: '햇빛',
-        ),
-        const SizedBox(width: AppSpacing.x16),
-        _PlaceMetric(
-          icon: AppIconAssets.tagHumidity,
-          label: humidityLabel,
-          semanticsLabel: '습도',
-        ),
+        if (sunlightLabel case final label?)
+          _PlaceMetric(
+            icon: AppIconAssets.tagSunlight,
+            label: label,
+            semanticsLabel: '햇빛',
+          ),
+        if (sunlightLabel != null && humidityLabel != null)
+          const SizedBox(width: AppSpacing.x16),
+        if (humidityLabel case final label?)
+          _PlaceMetric(
+            icon: AppIconAssets.tagHumidity,
+            label: label,
+            semanticsLabel: '습도',
+          ),
       ],
     );
   }
@@ -181,16 +186,18 @@ class _PlaceFriendStrip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        for (final friend in friends)
-          _PlaceFriendMark(friend: friend, profile: friend.toProfile()),
-        _FriendManagementShortcut(
-          onPressed: () =>
-              context.push(AppRoutePaths.friendManagementLocation(placeId)),
-        ),
-      ],
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (final friend in friends)
+            _PlaceFriendMark(friend: friend, profile: friend.toProfile()),
+          _FriendManagementShortcut(
+            onPressed: () =>
+                context.push(AppRoutePaths.friendManagementLocation(placeId)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/place/presentation/widgets/place_exit_dialog.dart
+++ b/lib/features/place/presentation/widgets/place_exit_dialog.dart
@@ -2,16 +2,23 @@ import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/shared/widgets/common_dialog.dart';
 import 'package:flutter/material.dart';
 
+enum PlaceRemovalMode { leave, delete }
+
 Future<void> showPlaceExitDialog({
   required BuildContext context,
   required bool isExiting,
   required VoidCallback onConfirm,
+  PlaceRemovalMode mode = PlaceRemovalMode.leave,
 }) async {
+  final isDelete = mode == PlaceRemovalMode.delete;
+
   await showCommonDialog<void>(
     context: context,
     child: CommonDialogCard(
-      title: '장소를 나가시겠어요?',
-      message: '나가면 더 이상 식물을 관리할 수 없어요.',
+      title: isDelete ? '장소를 삭제하시겠어요?' : '장소를 나가시겠어요?',
+      message: isDelete
+          ? '삭제하면 장소의 식물과 메모도 함께 사라져요.'
+          : '나가면 더 이상 식물을 관리할 수 없어요.',
       actions: [
         CommonDialogActionButton(
           label: '취소',
@@ -19,7 +26,7 @@ Future<void> showPlaceExitDialog({
           onPressed: () => Navigator.of(context).pop(),
         ),
         CommonDialogActionButton.confirm(
-          label: '나가기',
+          label: isDelete ? '삭제' : '나가기',
           foregroundColor: AppColors.danger,
           onPressed: isExiting ? null : onConfirm,
         ),

--- a/lib/features/place/presentation/widgets/place_friend_avatar.dart
+++ b/lib/features/place/presentation/widgets/place_friend_avatar.dart
@@ -18,23 +18,35 @@ class PlaceFriendAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final imageUrl = friend.imageUrl?.trim();
+
     return SizedBox.square(
       dimension: dimension,
       child: ClipOval(
-        child: friend.imageAsset == null
-            ? ColoredBox(
-                color: AppColors.borderDefault,
-                child: Center(
-                  child: CommonSvgIcon(
-                    AppIconAssets.addPerson,
-                    width: dimension * 0.7,
-                    height: dimension * 0.7,
-                    color: AppColors.white,
-                    semanticsLabel: '기본 프로필',
-                  ),
-                ),
+        child: imageUrl != null && imageUrl.isNotEmpty
+            ? Image.network(
+                imageUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => _fallback(),
               )
+            : friend.imageAsset == null
+            ? _fallback()
             : Image.asset(friend.imageAsset!, fit: BoxFit.cover),
+      ),
+    );
+  }
+
+  Widget _fallback() {
+    return ColoredBox(
+      color: AppColors.borderDefault,
+      child: Center(
+        child: CommonSvgIcon(
+          AppIconAssets.addPerson,
+          width: dimension * 0.7,
+          height: dimension * 0.7,
+          color: AppColors.white,
+          semanticsLabel: '기본 프로필',
+        ),
       ),
     );
   }

--- a/lib/features/place/presentation/widgets/place_plant_list.dart
+++ b/lib/features/place/presentation/widgets/place_plant_list.dart
@@ -1,5 +1,4 @@
 import 'package:commonplant_frontend/app/router/route_paths.dart';
-import 'package:commonplant_frontend/core/assets/app_image_assets.dart';
 import 'package:commonplant_frontend/core/theme/app_colors.dart';
 import 'package:commonplant_frontend/core/theme/app_spacing.dart';
 import 'package:commonplant_frontend/core/theme/app_text_styles.dart';
@@ -30,18 +29,26 @@ class PlacePlantList extends StatelessWidget {
       ),
       child: Column(
         children: [
+          if (plants.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.x32),
+              child: Text(
+                '등록된 식물이 없어요',
+                style: AppTextStyles.size16Medium.copyWith(
+                  color: AppColors.textBody,
+                ),
+              ),
+            ),
           for (final plant in plants) ...[
             CommonPlacePlantCard(
               width: double.infinity,
               name: plant.name,
               species: plant.species,
               description: plant.description,
-              imageProvider: const AssetImage(
-                AppImageAssets.placeDetailMonstera,
-              ),
-              action: CommonWateringButton(
-                onPressed: plant.canWater ? () {} : null,
-              ),
+              imageProvider: _imageProvider(plant),
+              action: plant.canWater
+                  ? CommonWateringButton(onPressed: () {})
+                  : null,
               trailing: _PlantDueInfo(
                 dDayLabel: plant.dDayLabel,
                 dateLabel: plant.dateLabel,
@@ -57,6 +64,20 @@ class PlacePlantList extends StatelessWidget {
       ),
     );
   }
+
+  ImageProvider<Object>? _imageProvider(PlaceDetailPlantItem plant) {
+    final imageUrl = plant.imageUrl?.trim();
+    if (imageUrl != null && imageUrl.isNotEmpty) {
+      return NetworkImage(imageUrl);
+    }
+
+    final imageAsset = plant.imageAsset;
+    if (imageAsset != null) {
+      return AssetImage(imageAsset);
+    }
+
+    return null;
+  }
 }
 
 class _PlantDueInfo extends StatelessWidget {
@@ -66,8 +87,8 @@ class _PlantDueInfo extends StatelessWidget {
     required this.isPrimary,
   });
 
-  final String dDayLabel;
-  final String dateLabel;
+  final String? dDayLabel;
+  final String? dateLabel;
   final bool isPrimary;
 
   @override
@@ -76,16 +97,22 @@ class _PlantDueInfo extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Text(
-          dDayLabel,
-          style: AppTextStyles.size16Bold.copyWith(
-            color: isPrimary ? AppColors.brandPrimary : AppColors.iconInactive,
+        if (dDayLabel case final label?)
+          Text(
+            label,
+            style: AppTextStyles.size16Bold.copyWith(
+              color: isPrimary
+                  ? AppColors.brandPrimary
+                  : AppColors.iconInactive,
+            ),
           ),
-        ),
-        Text(
-          dateLabel,
-          style: AppTextStyles.size12Medium.copyWith(color: AppColors.textBody),
-        ),
+        if (dateLabel case final label?)
+          Text(
+            label,
+            style: AppTextStyles.size12Medium.copyWith(
+              color: AppColors.textBody,
+            ),
+          ),
       ],
     );
   }

--- a/test/features/place/data/mappers/place_mapper_test.dart
+++ b/test/features/place/data/mappers/place_mapper_test.dart
@@ -3,25 +3,44 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('placeSummariesFromResponse', () {
-    test('wrapper 응답에서 장소 요약 목록을 만든다', () {
+    test('myGarden wrapper의 placeList를 장소 요약 목록으로 만든다', () {
       final summaries = placeSummariesFromResponse({
         'result': {
-          'content': {
-            'items': [
-              {
-                'placeCode': 'place-nano-id',
-                'placeName': '거실 정원',
-                'placeAddress': '서울시 성북구',
-              },
-            ],
-          },
+          'name': '커먼이',
+          'placeList': [
+            {
+              'image': 'https://example.com/garden.png',
+              'code': 'place-nano-id',
+              'name': '거실 정원',
+              'member': '2',
+              'plant': '3',
+            },
+          ],
         },
       });
 
       expect(summaries, hasLength(1));
       expect(summaries.single.id, 'place-nano-id');
       expect(summaries.single.name, '거실 정원');
-      expect(summaries.single.address, '서울시 성북구');
+      expect(summaries.single.imageUrl, 'https://example.com/garden.png');
+      expect(summaries.single.memberCount, 2);
+      expect(summaries.single.plantCount, 3);
+    });
+
+    test('소속 장소의 result 배열도 장소 요약 목록으로 만든다', () {
+      final summaries = placeSummariesFromResponse({
+        'result': [
+          {
+            'code': 'place-2',
+            'name': '작업실',
+            'imgUrl': 'https://example.com/studio.png',
+          },
+        ],
+      });
+
+      expect(summaries.single.id, 'place-2');
+      expect(summaries.single.name, '작업실');
+      expect(summaries.single.imageUrl, 'https://example.com/studio.png');
     });
   });
 
@@ -56,6 +75,58 @@ void main() {
 
       expect(summary.id, 'fallback-place');
       expect(summary.name, '루프탑');
+    });
+  });
+
+  group('placeDetailFromResponse', () {
+    test('백엔드 Place 상세 계약을 멤버와 식물까지 매핑한다', () {
+      final detail = placeDetailFromResponse({
+        'result': {
+          'name': '거실 정원',
+          'code': 'ABCabc',
+          'address': '서울시 노원구',
+          'imgUrl': 'https://example.com/garden.png',
+          'owner': true,
+          'userList': [
+            {'name': '커먼맘', 'image': 'https://example.com/user.png'},
+          ],
+          'plantList': [
+            {
+              'plantId': 1,
+              'scientificNameKo': '몬스테라',
+              'scientificNameEn': 'Monstera deliciosa',
+              'registeredAt': '2026-06-30T16:55:51.387461',
+              'lastWateredDate': '2026-06-29',
+              'imageUrl': 'https://example.com/plant.png',
+              'memo': '새 잎이 올라옴',
+              'placeName': '거실 정원',
+              'plantInfo': '창가에서 키우는 식물',
+            },
+          ],
+        },
+      }, fallbackCode: 'fallback');
+
+      expect(detail.code, 'ABCabc');
+      expect(detail.name, '거실 정원');
+      expect(detail.address, '서울시 노원구');
+      expect(detail.isOwner, isTrue);
+      expect(detail.members.single.name, '커먼맘');
+      expect(detail.members.single.imageUrl, 'https://example.com/user.png');
+      expect(detail.plants.single.id, '1');
+      expect(detail.plants.single.scientificNameKo, '몬스테라');
+      expect(detail.plants.single.lastWateredDate, '2026-06-29');
+      expect(detail.plants.single.description, '창가에서 키우는 식물');
+    });
+
+    test('목록이 없는 상세 응답은 빈 멤버와 식물 목록을 사용한다', () {
+      final detail = placeDetailFromResponse({
+        'result': {'name': '옥상', 'address': '서울시'},
+      }, fallbackCode: 'fallback');
+
+      expect(detail.code, 'fallback');
+      expect(detail.isOwner, isFalse);
+      expect(detail.members, isEmpty);
+      expect(detail.plants, isEmpty);
     });
   });
 }

--- a/test/features/place/data/repositories/place_repository_test.dart
+++ b/test/features/place/data/repositories/place_repository_test.dart
@@ -6,6 +6,55 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlaceRepository', () {
+    test('myGarden 응답의 장소 목록을 반환한다', () async {
+      final repository = PlaceRepositoryImpl(
+        _ResponsePlaceRemoteDataSource(
+          myGardenResponse: {
+            'result': {
+              'name': '커먼이',
+              'placeList': [
+                {'code': 'place-1', 'name': '거실', 'member': '2'},
+              ],
+            },
+          },
+        ),
+      );
+
+      final places = await repository.fetchMyGardenPlaces();
+
+      expect(places.single.id, 'place-1');
+      expect(places.single.name, '거실');
+      expect(places.single.memberCount, 2);
+    });
+
+    test('장소 상세 응답을 멤버와 식물 도메인 모델로 반환한다', () async {
+      final repository = PlaceRepositoryImpl(
+        _ResponsePlaceRemoteDataSource(
+          placeResponse: {
+            'result': {
+              'code': 'place-1',
+              'name': '거실',
+              'address': '서울시',
+              'owner': true,
+              'userList': [
+                {'name': '커먼맘'},
+              ],
+              'plantList': [
+                {'plantId': 1, 'scientificNameKo': '몬스테라'},
+              ],
+            },
+          },
+        ),
+      );
+
+      final detail = await repository.fetchPlaceDetail('place-1');
+
+      expect(detail.code, 'place-1');
+      expect(detail.isOwner, isTrue);
+      expect(detail.members.single.name, '커먼맘');
+      expect(detail.plants.single.id, '1');
+    });
+
     test('장소 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlaceRemoteDataSource();
       final repository = PlaceRepositoryImpl(dataSource);
@@ -49,6 +98,20 @@ void main() {
       });
     });
   });
+}
+
+class _ResponsePlaceRemoteDataSource extends Fake
+    implements PlaceRemoteDataSource {
+  _ResponsePlaceRemoteDataSource({this.myGardenResponse, this.placeResponse});
+
+  final Object? myGardenResponse;
+  final Object? placeResponse;
+
+  @override
+  Future<Object?> getMyGarden() async => myGardenResponse;
+
+  @override
+  Future<Object?> getPlace(String code) async => placeResponse;
 }
 
 class _ImagePlaceRemoteDataSource extends Fake

--- a/test/features/place/presentation/mappers/place_detail_view_mapper_test.dart
+++ b/test/features/place/presentation/mappers/place_detail_view_mapper_test.dart
@@ -1,24 +1,45 @@
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
-import 'package:commonplant_frontend/features/place/presentation/fixtures/place_detail_fixture.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/presentation/mappers/place_detail_view_mapper.dart';
+import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('remote summary를 ViewData에 적용하고 fallback 보조 정보는 유지한다', () {
-    final detail = mapPlaceSummaryToDetailViewData(
-      fallback: placeDetailFixture('place-1'),
-      summary: const PlaceSummary(
-        id: 'remote-place',
+  test('remote 상세를 fixture 없이 ViewData로 변환한다', () {
+    final detail = mapPlaceDetailToViewData(
+      const PlaceDetail(
+        code: 'remote-place',
         name: '옥상 정원',
         address: '서울시 성북구',
+        isOwner: true,
+        members: [
+          PlaceMember(name: '커먼맘', imageUrl: 'https://example.com/user.png'),
+        ],
+        plants: [
+          PlacePlant(
+            id: '1',
+            scientificNameKo: '몬스테라',
+            scientificNameEn: 'Monstera deliciosa',
+            registeredAt: '2026-06-30T16:55:51',
+            lastWateredDate: '2026-06-29',
+            imageUrl: 'https://example.com/plant.png',
+            memo: '새 잎',
+          ),
+        ],
       ),
     );
 
     expect(detail?.name, '옥상 정원');
     expect(detail?.address, '서울시 성북구');
-    expect(detail?.sunlightLabel, '9.3 / 5');
-    expect(detail?.humidityLabel, '69%');
-    expect(detail?.friends, hasLength(3));
-    expect(detail?.plants, hasLength(4));
+    expect(detail?.role, PlaceDetailRole.leader);
+    expect(detail?.sunlightLabel, isNull);
+    expect(detail?.humidityLabel, isNull);
+    expect(detail?.friends.single.name, '커먼맘');
+    expect(detail?.friends.single.imageUrl, 'https://example.com/user.png');
+    expect(detail?.plants.single.name, '몬스테라');
+    expect(detail?.plants.single.species, 'Monstera deliciosa');
+    expect(detail?.plants.single.description, '새 잎');
+    expect(detail?.plants.single.dDayLabel, '마지막 물주기');
+    expect(detail?.plants.single.dateLabel, '2026.06.29');
+    expect(detail?.plants.single.imageUrl, 'https://example.com/plant.png');
   });
 }

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:commonplant_frontend/core/config/app_environment.dart';
 import 'package:commonplant_frontend/core/theme/app_sizes.dart';
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
@@ -151,7 +151,14 @@ void main() {
           useRemoteApiProvider.overrideWithValue(true),
           placeRepositoryProvider.overrideWithValue(
             _StaticPlaceRepository(
-              const PlaceSummary(id: 'empty-place', name: ''),
+              const PlaceDetail(
+                code: 'empty-place',
+                name: '',
+                address: '',
+                isOwner: false,
+                members: [],
+                plants: [],
+              ),
             ),
           ),
         ],
@@ -163,6 +170,79 @@ void main() {
     expect(find.text('장소 정보를 찾을 수 없어요'), findsOneWidget);
     expect(find.text('다시 장소 목록에서 선택해 주세요'), findsOneWidget);
     expect(find.text('스윗 홈_거실'), findsNothing);
+  });
+
+  testWidgets('remote 상세는 API 멤버와 식물만 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(
+            _StaticPlaceRepository(
+              const PlaceDetail(
+                code: 'remote-place',
+                name: 'API 정원',
+                address: '서울시 성북구',
+                isOwner: false,
+                members: [PlaceMember(name: 'API 멤버')],
+                plants: [
+                  PlacePlant(
+                    id: '10',
+                    scientificNameKo: '고무나무',
+                    scientificNameEn: 'Ficus elastica',
+                    lastWateredDate: '2026-08-24',
+                    memo: 'API 메모',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: PlaceDetailPage(placeId: 'remote-place'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('API 정원'), findsOneWidget);
+    expect(find.text('API 멤버'), findsOneWidget);
+    expect(find.text('고무나무'), findsOneWidget);
+    expect(find.text('Ficus elastica'), findsOneWidget);
+    expect(find.text('API 메모'), findsOneWidget);
+    expect(find.text('마지막 물주기'), findsOneWidget);
+    expect(find.text('2026.08.24'), findsOneWidget);
+    expect(find.text('스윗 홈_거실'), findsNothing);
+    expect(find.text('9.3 / 5'), findsNothing);
+    expect(find.text('69%'), findsNothing);
+  });
+
+  testWidgets('remote 식물 목록이 비어 있으면 empty 안내를 표시한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(
+            _StaticPlaceRepository(
+              const PlaceDetail(
+                code: 'remote-place',
+                name: 'API 정원',
+                address: '서울시 성북구',
+                isOwner: true,
+                members: [],
+                plants: [],
+              ),
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: PlaceDetailPage(placeId: 'remote-place'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('등록된 식물이 없어요'), findsOneWidget);
   });
 
   testWidgets('remote error 상태는 재시도 후 상세 정보를 표시한다', (tester) async {
@@ -193,10 +273,13 @@ void main() {
 
   testWidgets('remote 장소 나가기 확인은 삭제 API를 호출하고 홈으로 이동한다', (tester) async {
     final repository = _DeletablePlaceRepository(
-      const PlaceSummary(
-        id: 'remote-place',
+      const PlaceDetail(
+        code: 'remote-place',
         name: '옥상 정원',
         address: '서울시 노원구 광운로 20',
+        isOwner: true,
+        members: [],
+        plants: [],
       ),
     );
 
@@ -242,22 +325,22 @@ Widget _remotePlaceDetailApp(PlaceRepository repository) {
 }
 
 class _PendingPlaceRepository extends Fake implements PlaceRepository {
-  final Completer<PlaceSummary> _completer = Completer<PlaceSummary>();
+  final Completer<PlaceDetail> _completer = Completer<PlaceDetail>();
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) {
+  Future<PlaceDetail> fetchPlaceDetail(String code) {
     return _completer.future;
   }
 }
 
 class _StaticPlaceRepository extends Fake implements PlaceRepository {
-  _StaticPlaceRepository(this.summary);
+  _StaticPlaceRepository(this.detail);
 
-  final PlaceSummary summary;
+  final PlaceDetail detail;
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) async {
-    return summary;
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
+    return detail;
   }
 }
 
@@ -265,31 +348,34 @@ class _RetryPlaceRepository extends Fake implements PlaceRepository {
   int fetchCalls = 0;
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) async {
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
     fetchCalls++;
 
     if (fetchCalls == 1) {
       throw Exception('network');
     }
 
-    return const PlaceSummary(
-      id: 'retry-place',
+    return const PlaceDetail(
+      code: 'retry-place',
       name: '옥상 정원',
       address: '서울시 노원구 광운로 20',
+      isOwner: true,
+      members: [],
+      plants: [],
     );
   }
 }
 
 class _DeletablePlaceRepository extends Fake implements PlaceRepository {
-  _DeletablePlaceRepository(this.summary);
+  _DeletablePlaceRepository(this.detail);
 
-  final PlaceSummary summary;
+  final PlaceDetail detail;
   int deleteCalls = 0;
   String? latestDeleteCode;
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) async {
-    return summary;
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
+    return detail;
   }
 
   @override

--- a/test/features/place/presentation/pages/place_detail_page_test.dart
+++ b/test/features/place/presentation/pages/place_detail_page_test.dart
@@ -215,6 +215,12 @@ void main() {
     expect(find.text('스윗 홈_거실'), findsNothing);
     expect(find.text('9.3 / 5'), findsNothing);
     expect(find.text('69%'), findsNothing);
+
+    await tester.tap(find.bySemanticsLabel('장소 상세 메뉴'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('장소 나가기'), findsNothing);
+    expect(find.text('장소 삭제하기'), findsNothing);
   });
 
   testWidgets('remote 식물 목록이 비어 있으면 empty 안내를 표시한다', (tester) async {
@@ -271,7 +277,7 @@ void main() {
     expect(find.text('장소 정보를 불러오지 못했어요'), findsNothing);
   });
 
-  testWidgets('remote 장소 나가기 확인은 삭제 API를 호출하고 홈으로 이동한다', (tester) async {
+  testWidgets('remote owner 장소 삭제는 경고 후 삭제 API를 호출한다', (tester) async {
     final repository = _DeletablePlaceRepository(
       const PlaceDetail(
         code: 'remote-place',
@@ -288,9 +294,13 @@ void main() {
 
     await tester.tap(find.bySemanticsLabel('장소 상세 메뉴'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('장소 나가기'));
+    await tester.tap(find.text('장소 삭제하기'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('나가기'));
+
+    expect(find.text('장소를 삭제하시겠어요?'), findsOneWidget);
+    expect(find.text('삭제하면 장소의 식물과 메모도 함께 사라져요.'), findsOneWidget);
+
+    await tester.tap(find.text('삭제'));
     await tester.pumpAndSettle();
 
     expect(repository.deleteCalls, 1);

--- a/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_remote_provider_test.dart
@@ -1,4 +1,4 @@
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/providers/place_detail_remote_provider.dart';
@@ -9,34 +9,41 @@ void main() {
   group('placeDetailProvider', () {
     test('장소 상세 조회를 repository에 위임한다', () async {
       final repository = _StaticPlaceRepository(
-        const PlaceSummary(id: 'place-1', name: '거실', address: '서울시 성북구'),
+        const PlaceDetail(
+          code: 'place-1',
+          name: '거실',
+          address: '서울시 성북구',
+          isOwner: true,
+          members: [],
+          plants: [],
+        ),
       );
       final container = ProviderContainer(
         overrides: [placeRepositoryProvider.overrideWithValue(repository)],
       );
       addTearDown(container.dispose);
 
-      final summary = await container.read(
+      final detail = await container.read(
         placeDetailProvider('place-1').future,
       );
 
-      expect(summary.id, 'place-1');
-      expect(summary.name, '거실');
-      expect(summary.address, '서울시 성북구');
+      expect(detail.code, 'place-1');
+      expect(detail.name, '거실');
+      expect(detail.address, '서울시 성북구');
       expect(repository.lastCode, 'place-1');
     });
   });
 }
 
 class _StaticPlaceRepository extends Fake implements PlaceRepository {
-  _StaticPlaceRepository(this.summary);
+  _StaticPlaceRepository(this.detail);
 
-  final PlaceSummary summary;
+  final PlaceDetail detail;
   String? lastCode;
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) async {
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
     lastCode = code;
-    return summary;
+    return detail;
   }
 }

--- a/test/features/place/presentation/providers/place_detail_view_provider_test.dart
+++ b/test/features/place/presentation/providers/place_detail_view_provider_test.dart
@@ -1,5 +1,5 @@
 import 'package:commonplant_frontend/core/config/app_environment.dart';
-import 'package:commonplant_frontend/features/place/domain/entities/place_summary.dart';
+import 'package:commonplant_frontend/features/place/domain/entities/place_detail.dart';
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/models/place_detail_role.dart';
@@ -25,12 +25,15 @@ void main() {
       expect(detail?.role, PlaceDetailRole.member);
     });
 
-    test('remote mode는 summary를 fixture 상세에 병합한다', () async {
+    test('remote mode는 API 상세만 ViewData로 변환한다', () async {
       final repository = _StaticPlaceRepository(
-        const PlaceSummary(
-          id: 'remote-place',
+        const PlaceDetail(
+          code: 'remote-place',
           name: '옥상 정원',
           address: '서울시 노원구 광운로 20',
+          isOwner: false,
+          members: [PlaceMember(name: '커먼맘')],
+          plants: [],
         ),
       );
       final container = ProviderContainer(
@@ -50,13 +53,24 @@ void main() {
 
       expect(detail?.name, '옥상 정원');
       expect(detail?.address, '서울시 노원구 광운로 20');
-      expect(detail?.role, PlaceDetailRole.leader);
+      expect(detail?.role, PlaceDetailRole.member);
+      expect(detail?.friends.single.name, '커먼맘');
+      expect(detail?.plants, isEmpty);
+      expect(detail?.sunlightLabel, isNull);
+      expect(detail?.humidityLabel, isNull);
       expect(repository.fetchCalls, 1);
     });
 
     test('remote mode에서 빈 summary는 null data로 표시한다', () async {
       final repository = _StaticPlaceRepository(
-        const PlaceSummary(id: 'empty-place', name: ''),
+        const PlaceDetail(
+          code: 'empty-place',
+          name: '',
+          address: '',
+          isOwner: false,
+          members: [],
+          plants: [],
+        ),
       );
       final container = ProviderContainer(
         overrides: [
@@ -78,14 +92,14 @@ void main() {
 }
 
 class _StaticPlaceRepository extends Fake implements PlaceRepository {
-  _StaticPlaceRepository(this.summary);
+  _StaticPlaceRepository(this.detail);
 
-  final PlaceSummary summary;
+  final PlaceDetail detail;
   int fetchCalls = 0;
 
   @override
-  Future<PlaceSummary> fetchPlace(String code) async {
+  Future<PlaceDetail> fetchPlaceDetail(String code) async {
     fetchCalls++;
-    return summary;
+    return detail;
   }
 }

--- a/test/features/place/presentation/providers/place_exit_controller_test.dart
+++ b/test/features/place/presentation/providers/place_exit_controller_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlaceExitController', () {
-    test('remote 장소 나가기는 repository를 호출하고 홈 이동 결과를 반환한다', () async {
+    test('remote 장소 삭제는 repository를 호출하고 홈 이동 결과를 반환한다', () async {
       final repository = _RecordingPlaceRepository();
       final container = ProviderContainer(
         overrides: [
@@ -32,7 +32,7 @@ void main() {
       );
     });
 
-    test('remote 장소 나가기 실패는 사용자 메시지 상태를 남긴다', () async {
+    test('remote 장소 삭제 실패는 사용자 메시지 상태를 남긴다', () async {
       final repository = _FailingPlaceRepository();
       final container = ProviderContainer(
         overrides: [
@@ -51,7 +51,7 @@ void main() {
       expect(repository.deleteCalls, 1);
       expect(
         container.read(placeExitControllerProvider),
-        const FormSubmitState.failure('장소 나가기에 실패했어요'),
+        const FormSubmitState.failure('장소 삭제에 실패했어요'),
       );
     });
 

--- a/test/features/place/presentation/widgets/place_detail_widgets_test.dart
+++ b/test/features/place/presentation/widgets/place_detail_widgets_test.dart
@@ -71,7 +71,11 @@ void main() {
   testWidgets('PlaceDetailFab는 권한에 따라 장소 수정 액션을 표시한다', (tester) async {
     await tester.pumpWidget(
       _buildRouterApp(
-        PlaceDetailFab(placeId: 'place-1', canEditPlace: false, onExit: () {}),
+        PlaceDetailFab(
+          placeId: 'place-1',
+          canEditPlace: false,
+          onRemove: () {},
+        ),
       ),
     );
 


### PR DESCRIPTION
## 요약

- `GET /place/myGarden`의 `result.placeList`를 Home 장소 목록과 대표 이미지에 연결했습니다.
- `GET /place/{code}`를 `PlaceDetail` 도메인 모델로 파싱해 owner·멤버·식물 실데이터를 상세 화면에 연결했습니다.
- API 모드에서 햇빛·습도와 fixture 멤버·식물 혼합을 제거하고 빈 식물 상태를 추가했습니다.
- owner 전용 전체 삭제와 구성원 나가기 미지원 경계를 분리했습니다.

## 계약 근거

- 2026-08-25 live OpenAPI: 19 paths, 27 operations, Place 성공 schema 미노출
- Backend main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`의 `PlaceController`, `PlaceDto`, `PlaceServiceImpl`
- `DELETE /place/delete/{code}`는 owner 전용이며 장소·식물·메모·멤버 관계를 함께 삭제

## 검증

- `fvm dart format --output=none --set-exit-if-changed .` — 286개 파일 통과
- `fvm flutter analyze` — 통과
- `fvm flutter test` — 321개 통과, 기존 golden 1개 skip

## 보류

- 구성원 장소 나가기 endpoint
- 장소 환경 수치와 물주기 action API
- 친구 관리의 고유 member id·변경 endpoint
- 표시 이름 중복 시 친구 요청 receiver 오매칭 정책

Closes #239