### PR TITLE
Fix: 장소·식물 수정 이미지 보존 #248

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 
 현재 우선순위는 사용자 결정에 따라 다음과 같습니다.
 
-1. #247에서 현행 문서를 정리하고 [개발 감사·개선 체크리스트](docs/development-audit-checklist.md)를 실행 기준으로 만듭니다.
-2. 체크리스트의 동작 문제 #248~#253을 순서대로 별도 PR에서 해결합니다. 미사용 공용 위젯 5개는 보존합니다.
+1. #247 / PR #257 문서 정리는 병합 완료했으며 [개발 감사·개선 체크리스트](docs/development-audit-checklist.md)를 실행 기준으로 사용합니다.
+2. #248에서 식물의 기존 이미지 key 보존과 사진이 있는 장소의 수정 요청 차단을 구현했습니다. 사진이 있는 장소의 수정 재개는 key 조회 계약 확인 후 진행합니다. 병합 후 #249~#253을 순서대로 해결하며, 미사용 공용 위젯 5개는 보존합니다.
 3. 추가 파서·위젯·Provider 개선 #254~#256을 진행한 뒤 [화면·모델·API 연결 매트릭스](docs/screen-api-integration-plan.md)의 남은 동선을 이어갑니다.
 4. 외부 답변이 필요한 Image·Memo·검색·인증 정책은 [백엔드 질문](docs/backend-api-open-questions.md), 팀 결정은 [후속 결정 체크리스트](docs/follow-up-decision-checklist.md)로 분리합니다. 배포와 원격 E2E는 준비 조건 충족 전까지 보류합니다.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # 문서 인덱스
 
-문서 분류 기준일: 2026-08-28, `develop` PR #246 병합 기준.
+문서 분류 기준일: 2026-08-28, `develop` PR #257 병합 및 #248 작업 반영.
 
 작업 전 저장소 [README](../README.md)와 [에이전트 지침](../AGENTS.md)을 먼저 확인합니다. 현재 코드를 기준으로 판단하며, 과거 계획의 파일 수·상태·명령은 현행 지침으로 해석하지 않습니다.
 
@@ -67,6 +67,7 @@
 | Friend 수신 요청 #241 | [Friend Invitations](work-history/friend-invitations-api-241.md) |
 | Place 폼 결과 #243 | [Place Form Result](work-history/place-form-result-flow-243.md) |
 | Place 멤버 조회 #245 | [Place Members](work-history/place-members-api-245.md) |
+| Place·Plant 이미지 보존 #248 | [Form Image Preservation](work-history/form-image-preservation-248.md) |
 
 Auth #227 등 중앙 계획에 남긴 이력은 [화면·API 전환 계획의 작업 이력](screen-api-integration-plan.md#작업-이력), 문서 정리 #247은 [개발 감사 체크리스트](development-audit-checklist.md)에서 확인합니다.
 

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -49,7 +49,7 @@
 ### 2026-08-28 감사 — 이미지 수정 계약과 프론트 누락
 
 - Place/Plant의 `imageKey` 생략/null은 기존 이미지 삭제를 뜻한다. 새 파일 없이 유지하려면 기존 key를 보내야 한다.
-- Plant edit 응답의 key가 Form 상태로 전달되지 않고 Place Form도 key를 누락하므로 #248에서 수정한다. 이는 새 endpoint 변경이 아니라 기존 계약의 누락을 발견한 것이다.
+- 감사 당시 Plant edit 응답의 key가 Form 상태로 전달되지 않았고 Place Form도 key를 누락했다. #248에서 Plant key 보존과 미확인 key 차단, Place 사진 수정 요청 차단을 구현했다. 이는 새 endpoint 변경이 아니라 기존 계약 누락의 수정이다.
 - 연결 PR의 병합 상태와 실제 남은 화면 동선은 [화면·API 매트릭스](screen-api-integration-plan.md), 수정 순서는 [개발 감사 체크리스트](development-audit-checklist.md)에서 관리한다.
 
 ### 2026-08-28 장소 멤버 조회 연결
@@ -625,7 +625,7 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 | refresh token 재발급 API | 없음 | 남음 |
 | 로그아웃 API | 없음 | 남음 |
 | pagination 응답 구조와 total count | `PlantPageContent`에 `items`, `totalCount`, `page`, `size` 추가 | 해소 |
-| 이미지 key 저장 주체와 업로드 후 반환 값 | Place/Plant 도메인 수정의 유지·교체·삭제 계약은 확인, 독립 Image 응답과 Place key 조회는 미확정 | 일부 해소, 프론트 #248 수정 필요 |
+| 이미지 key 저장 주체와 업로드 후 반환 값 | Place/Plant 도메인 수정의 유지·교체·삭제 계약은 확인, 독립 Image 응답과 Place key 조회는 미확정 | #248 key 보존·안전 차단 구현, 계약 일부 미확정 |
 | 앱 flavor별 full base URL 정책 | 프론트 환경 전략은 `docs/release-workflow.md`에서 flavor와 CI/CD 주입 분리로 정리. Swagger server는 여전히 `/api/v1`만 제공 | 일부 해소 |
 
 ## API 연계 코드에 반영 가능한 부분
@@ -675,7 +675,7 @@ Place/Plant 수정 요청의 `imageKey`는 단순 optional 장식 필드가 아�
 
 근거: [dev OpenAPI](https://commonplant-dev.okbear.dev/api/v1/api-docs/json)의 두 update schema와 backend `7d572cb`의 [PlaceServiceImpl](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/blob/7d572cbcabc81a65926738b2a09e8479d0bd0c79/src/main/java/com/commonplant/garden/place/service/PlaceServiceImpl.java), [PlantServiceImpl](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/blob/7d572cbcabc81a65926738b2a09e8479d0bd0c79/src/main/java/com/commonplant/garden/plant/service/PlantServiceImpl.java)의 `resolveUpdatedImageKey`를 대조했다. 실제 원격 삭제 요청은 실행하지 않았다.
 
-현재 Form은 기존 key를 전달하지 않으므로 [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248)에서 텍스트 수정 시 이미지가 유실되지 않도록 수정해야 한다. Plant edit 응답은 key를 제공하지만 Place 상세는 URL만 제공하므로, Place key 확보 계약은 [IMAGE-04](backend-api-open-questions.md#image-04-이미지-key-생명주기)로 남긴다. URL에서 key를 추측하지 않는다.
+[#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248)에서 Plant Form의 초기 key·URL을 보존하고 이름·날짜 수정 요청에 key를 전달한다. URL이 있지만 key가 없으면 요청을 차단한다. Place는 key를 조회할 수 없어 사진이 있는 장소의 수정 요청을 차단·안내하며 사진이 없는 장소는 기존 수정 동작을 유지한다. key 확보와 동시 수정의 조건부 보호 계약은 [IMAGE-04](backend-api-open-questions.md#image-04-이미지-key-생명주기)로 남기고, [작업 이력](work-history/form-image-preservation-248.md)에 제한을 기록한다. URL에서 key를 추측하지 않는다.
 
 독립형 Image API(`/s3/images`)는 response schema가 없어 화면에서 반환된 image key/url을 확정적으로 읽을 수 없다. 따라서 프로필, 장소, 식물, 메모 화면에서 `/s3/images` 업로드 결과를 `imageKey`, `imgUrl`, `imageUrl`로 임의 매핑하지 않는다.
 

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -29,7 +29,7 @@
 | IMAGE-01 | Image | `/s3/images` upload/download/update/delete 성공 response schema는 무엇인가? | image key/url mapper 보류 | Open |
 | IMAGE-02 | Image | 화면 이미지는 `/s3/images` 선업로드 방식인가, 도메인 multipart 직접 전송 방식인가? | 프로필/장소/식물/메모 이미지 흐름 확정 불가 | Open |
 | IMAGE-03 | Image | presigned download URL 응답 필드와 wrapper 구조는 무엇인가? | 네트워크 이미지 fallback 정책 보류 | Open |
-| IMAGE-04 | Image | 이미지 key 저장, 교체, 삭제 책임은 어느 API가 갖는가? | Place/Plant 수정 계약 확인, 기존 이미지 보존 #248과 Place key 조회 확인 필요 | Partial |
+| IMAGE-04 | Image | 이미지 key 저장, 교체, 삭제 책임은 어느 API가 갖는가? | #248 Plant key 보존·Place 사진 수정 차단 구현, Place key 조회·동시 수정 보호 계약 필요 | Partial |
 | ERROR-01 | Error | 에러 response body의 공통 `code`, `message` 필드명은 무엇인가? | 사용자 메시지 매핑 제한 | Open |
 | ERROR-02 | Error | 도메인별 에러 코드 표준과 의미는 무엇인가? | `ApiException` mapping table 보류 | Open |
 | TOKEN-01 | Token | refresh token 재발급 API가 제공되는가? | 인증 만료 복구 흐름 보류 | Open |
@@ -203,8 +203,9 @@
 - 현재 근거: 2026-08-28 dev OpenAPI의 `updatePlaceReq.imageKey`와 `UpdateRequest.imageKey`, backend `7d572cb`의 `PlaceServiceImpl`·`PlantServiceImpl` 수정 로직을 대조했다. 자세한 근거는 [Swagger 참고](api-swagger-reference.md#image-화면-연결-판단)에 있다.
 - 답변: Place/Plant 도메인 수정 API는 새 파일이 있으면 교체하고, 파일이 없으면 기존 key와 같은 값일 때 유지한다. key 생략/null은 기존 이미지 삭제를 뜻하며, 다른 key는 허용하지 않는다. 이는 독립 `/s3/images` 응답 계약이 확인됐다는 의미가 아니다.
 - 프론트 영향: 이미지 선택기가 없어도 텍스트 수정 요청에서 기존 key를 잃으면 이미지가 삭제될 수 있다. Plant edit 응답은 key를 제공하지만 Place 상세에는 `imgUrl`만 있다.
-- 확인 질문: Place의 기존 image key를 안전하게 조회하는 계약은 무엇인가? User·Memo와 독립 `/s3/images`의 생명주기 정책은 별도 확인이 필요하다.
-- 프론트 반영: 현재 Form은 key를 누락하므로 [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248)에서 보존·삭제 의도를 분리한다. URL에서 key를 추측하지 않으며, 이번 문서 변경은 코드 수정이나 원격 삭제 검증을 포함하지 않는다.
+- 확인 질문: Place의 기존 image key를 안전하게 조회하는 계약은 무엇인가? 조회 이후 다른 클라이언트가 사진을 변경한 경우의 조건부 수정·명시적 유지 동작은 어떻게 보장하는가? User·Memo와 독립 `/s3/images`의 생명주기 정책은 별도 확인이 필요하다.
+- 프론트 반영: [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248)에서 Plant의 초기 key를 상태와 요청에 보존하고 URL만 있는 불완전 정보는 차단한다. Place는 기존 사진 URL을 폼까지 전달하고 사진이 있으면 수정 API를 호출하지 않는다. 사진 없는 장소·fixture 수정은 유지하며 URL에서 key를 추측하지 않는다. 원격 삭제 검증은 실행하지 않았다.
+- 제한 해제: Place key 조회 또는 명시적 유지 계약 확인 후 별도 이슈에서 사진이 있는 장소 수정과 동시 수정 보호를 구현한다. [작업 이력](work-history/form-image-preservation-248.md)에 현재 제한과 검증을 기록했다.
 - 상태: Partial
 
 ## Error

--- a/docs/development-audit-checklist.md
+++ b/docs/development-audit-checklist.md
@@ -2,7 +2,7 @@
 
 2026-08-28 사용자 결정과 `develop`의 PR #246 병합 커밋 `2a01babb185ef5056b361c477717759194c53ec1`을 기준으로 합니다. 문서 정리는 [#247](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/247), 상위 개발 범위는 [Epic #226](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/226)입니다.
 
-문서 PR: [#257](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/257), `develop` 대상. #247과 PR은 Project 10의 `In Review`이며 사용자 병합을 기다립니다. 기본 CI 결과는 PR checks에서 확인합니다.
+문서 PR [#257](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/257)은 `develop`에 병합됐습니다(`f1331b2`). 후속 #248은 이미지 key 보존과 안전 차단 구현·로컬 검증을 완료했으며 [작업 이력](work-history/form-image-preservation-248.md)에서 범위와 제한을 확인합니다.
 
 ## 결정과 작업 경계
 
@@ -25,11 +25,11 @@
 
 ## 실행 순서
 
-표의 체크는 해당 수정 PR이 병합되고 회귀 검증이 끝났을 때만 완료합니다. 현재 #248~#256은 모두 `Backlog`이며 아직 코드 변경이 없습니다. Project의 priority는 아래 P1을 `high`, P2를 `medium`, P3를 `low`로 대응합니다.
+표의 체크는 해당 수정 PR이 병합되고 회귀 검증이 끝났을 때만 완료합니다. #248은 구현·검증 후 병합 전 상태이고 #249~#256은 `Backlog`입니다. Project의 priority는 아래 P1을 `high`, P2를 `medium`, P3를 `low`로 대응합니다.
 
 | 체크 | 순서 | 이슈 | 우선도 | 문제·완료 기준 요약 |
 | --- | --- | --- | --- | --- |
-| [ ] | AUDIT-01 | [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248) | P1 | 장소·식물의 텍스트 수정이 기존 이미지를 삭제하지 않도록 key와 사용자 의도를 보존 |
+| [ ] | AUDIT-01 | [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248) | P1 | 구현·검증 완료, 병합 전: Plant key 보존·미확인 key 차단, 사진이 있는 Place 수정은 임시 제한 |
 | [ ] | AUDIT-02 | [#249](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/249) | P1 | 로그아웃·계정 전환 후 이전 사용자 캐시와 진행 중 요청의 영향 차단 |
 | [ ] | AUDIT-03 | [#250](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/250) | P1 | 요청 중 입력 변경으로 submit 잠금이 풀리지 않도록 수정 |
 | [ ] | AUDIT-04 | [#251](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/251) | P1 | API 모드 식물 등록의 loading/error/empty에서 샘플 장소 사용 금지 |
@@ -46,10 +46,10 @@
 ### AUDIT-01 — 기존 이미지 보존
 
 - 위치: [Plant Form Controller](../lib/features/plant/presentation/providers/plant_form_controller.dart), [Place Form Controller](../lib/features/place/presentation/providers/place_form_controller.dart).
-- 재현: 기존 이미지가 있는 식물의 이름만 바꾸면 update 요청에서 `imageKey`가 누락됩니다. Place도 현재 Form에서 key를 보내지 않습니다.
+- 감사 당시 재현: 기존 이미지가 있는 식물의 이름만 바꾸면 update 요청에서 `imageKey`가 누락됐습니다. Place Form도 key를 보내지 않았습니다.
 - 계약: 새 파일이 없을 때 기존 key를 보내면 유지하고, key가 없거나 null이면 삭제합니다. [Swagger 참고](api-swagger-reference.md)의 Place/Plant 수정 계약과 backend `7d572cb`에서 확인했습니다. 원격 이미지 삭제를 실행해서 검증한 것은 아닙니다.
-- 완료: 이미지 유지·명시적 삭제·교체를 구분하고 텍스트 수정 회귀 테스트를 추가합니다.
-- 선행 확인: Plant edit 응답은 key를 제공하지만 Place 상세 응답은 URL만 제공합니다. Place key 확보가 불가능하면 데이터 유실을 막는 처리를 먼저 하고 계약 공백을 기록합니다. URL에서 key를 추측하지 않습니다. 새 파일 선택기 전체 구현과는 분리합니다.
+- #248 구현: Plant Form 초기 key·URL을 보존하고 이름·날짜 수정과 재시도에서 key를 전달합니다. URL은 있으나 key가 없는 Plant와 사진이 있는 Place는 수정 API를 호출하지 않고 안내합니다. 회귀 테스트 14개를 추가했고 전체 376개 통과·기존 skip 1개입니다.
+- 남은 확인: Place 상세 응답은 URL만 제공하므로 사진이 있는 장소 수정은 key 조회 계약 확보 후 별도 해제합니다. 새 파일 선택·삭제 UI와 동시 수정의 서버 측 보호는 별도이며, [제한·위험 기록](work-history/form-image-preservation-248.md#남은-제한과-위험)을 따릅니다.
 
 ### AUDIT-02 — 계정별 캐시 격리
 
@@ -105,6 +105,6 @@
 | --- | --- | --- |
 | `155b093` | 현행 가이드·인덱스·과거 기록 분리와 개선 체크리스트 | `git diff --check`, Markdown 37개·로컬 링크 126개·미연결 문서 0개 |
 | `6f368a8` | 화면·API 상태, 이미지 유지·삭제 계약, PR #246 병합 현황 정정 | `git diff --check`, 로컬 링크 138개·anchor 3개, 변경 파일 19개 모두 Markdown |
-| 이 문서의 최종 커밋 | PR #257·Project In Review 연결과 커밋별 이력 기록 | `git diff --check`, 이슈 #247~#256의 Type·담당자·milestone·parent·Project 필드 확인 |
+| `8066edb` | PR #257·Project In Review 연결과 커밋별 이력 기록(당시 상태) | `git diff --check`, 이슈 #247~#256의 Type·담당자·milestone·parent·Project 필드 확인 |
 
 작업 이력만 갱신하는 마지막 문서 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/docs/development-audit-checklist.md
+++ b/docs/development-audit-checklist.md
@@ -2,7 +2,7 @@
 
 2026-08-28 사용자 결정과 `develop`의 PR #246 병합 커밋 `2a01babb185ef5056b361c477717759194c53ec1`을 기준으로 합니다. 문서 정리는 [#247](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/247), 상위 개발 범위는 [Epic #226](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/226)입니다.
 
-문서 PR [#257](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/257)은 `develop`에 병합됐습니다(`f1331b2`). 후속 #248은 이미지 key 보존과 안전 차단 구현·로컬 검증을 완료했으며 [작업 이력](work-history/form-image-preservation-248.md)에서 범위와 제한을 확인합니다.
+문서 PR [#257](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/257)은 `develop`에 병합됐습니다(`f1331b2`). 후속 #248 / [PR #258](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/258)은 이미지 key 보존과 안전 차단 구현·로컬 검증을 완료했으며 [작업 이력](work-history/form-image-preservation-248.md)에서 범위와 제한을 확인합니다.
 
 ## 결정과 작업 경계
 

--- a/docs/feature-development-guide.md
+++ b/docs/feature-development-guide.md
@@ -207,7 +207,7 @@ fvm flutter run --dart-define-from-file=env/local.api.json
 
 Swagger에 성공 response body schema가 없는 API는 mapper에서 확인 가능한 필드만 사용하고, 필수 필드가 없으면 공통 API 오류로 처리합니다. 응답 구조가 확정되기 전까지 화면에서 임의 필드를 직접 읽지 않습니다.
 
-현재 코드에서 확인한 이미지 key 누락, 원격 목록의 fixture 혼입, 세션 캐시와 응답 파서 문제는 [개발 감사 체크리스트](development-audit-checklist.md)에서 추적합니다. 위 기준을 이미 모든 경로가 충족한 것으로 해석하지 않습니다.
+감사에서 확인한 이미지 key 누락은 #248에서 Plant key 보존과 Place 사진 수정의 안전 차단으로 보완했습니다. 원격 목록의 fixture 혼입, 세션 캐시와 응답 파서 문제 등은 [개발 감사 체크리스트](development-audit-checklist.md)에서 계속 추적합니다. 위 기준을 이미 모든 경로가 충족한 것으로 해석하지 않습니다.
 
 ## 작업 순서
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -58,7 +58,7 @@
 | [ ] | API-MULTIPART | Place multipart JSON part 정책 | MULTIPART-01 | Auth/User/Plant의 `application/json` encoding은 확인됐고 Place encoding은 백엔드 확인이 필요하다. | Open |
 | [ ] | API-PLACE | Place response와 식별자 정책 | PLACE-01, PLACE-02, PLACE-03, PLACE-04 | #239·#243 목록/상세/생성/수정, #245 멤버 조회 연결 완료; 멤버 변경은 보류 | Partial |
 | [ ] | API-FRIEND | Friend 요청 목록과 액션 정책 | FRIEND-01, FRIEND-02, FRIEND-03, FRIEND-04 | #241 수신 처리와 #243 발신 연결 완료, 이름 오매칭은 수용 위험으로 추적 | Partial |
-| [ ] | API-IMAGE | Image upload/download/update/delete 정책 | IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-04 | Place/Plant 수정 시 기존 key 유지·생략 시 삭제 계약은 확인했고 #248에서 반영한다. 독립 Image 응답·Place key 조회는 미확정이다. | Partial |
+| [ ] | API-IMAGE | Image upload/download/update/delete 정책 | IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-04 | #248에서 Plant key 보존·Place 사진 수정 차단을 구현했다. 독립 Image 응답·Place key 조회·동시 수정 보호 계약은 미확정이다. | Partial |
 | [ ] | API-ERROR | 공통/도메인 에러 response 정책 | ERROR-01, ERROR-02 | 사용자 메시지와 field error 매핑 | Open |
 | [ ] | API-TOKEN | refresh token과 로그아웃 정책 | TOKEN-01, TOKEN-02 | 인증 만료 복구와 세션 종료 처리 | Open |
 | [ ] | API-SEARCH | 주소/식물/사용자 검색 정책 | SEARCH-01, SEARCH-02, SEARCH-03 | 주소 검색, 식물 검색, 친구 추가 검색 UX | Open |

--- a/docs/screen-api-integration-plan.md
+++ b/docs/screen-api-integration-plan.md
@@ -2,7 +2,7 @@
 
 이 문서는 화면 퍼블리싱 이후 남아 있는 mock 흐름을 실제 상태와 API 계층으로 전환하는 순서와 완료 기준을 관리합니다. 배포 자동화와 원격 E2E 준비는 필요한 외부 조건이 충족될 때까지 유지하되, 현재 MVP 최우선 작업은 사용자 동선별 수직 슬라이스 완성입니다.
 
-2026-08-28 감사 후에는 문서 정리 #247과 [개발 감사·개선 체크리스트](development-audit-checklist.md)의 회귀 문제 해결을 먼저 진행합니다. 아래의 병합 상태는 연결 PR의 이력이며, 실제 인증 E2E나 모든 입력·오류 경로가 완료됐다는 의미는 아닙니다.
+2026-08-28 감사 후 문서 정리 #247 / PR #257은 병합됐으며 [개발 감사·개선 체크리스트](development-audit-checklist.md)의 회귀 문제를 순서대로 해결합니다. 아래의 병합 상태는 연결 PR의 이력이며, 실제 인증 E2E나 모든 입력·오류 경로가 완료됐다는 의미는 아닙니다.
 
 ## 목표
 
@@ -53,13 +53,13 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 | Place | 장소 등록 | create API와 생성 code·친구 추가 route 연결, 주소 선택 결과 미연결 | 필수 주소 전달 #253, 중복 제출 #250, 실제 이미지 | 생성 result code #243 반영, 이름 기반 요청 위험 수용 | API 계층 연결, 주소 입력 동선 미완료 |
 | Place | 주소 검색 | fixture 검색, 선택해도 결과 없이 복귀 | 선택 결과 반환·소비 #253, 실제 검색 adapter | route 결과 연결은 즉시 수정 가능, 실서비스 검색은 별도 결정 필요 | 동작 수정과 외부 결정 분리 |
 | Place | 장소 등록 중 친구 추가 | User 검색, 생성된 place code, 선택 사용자 요청 submit 연결 | 고유 사용자 식별자와 대상별 결과 검증 | `GET /users/{keyword}`, `POST /friends/request`; 동명이인 위험은 별도 등록 | #243 위험 수용 연결 |
-| Place | 장소 수정 | 상세 조회·update API와 typed 수정 결과 연결 | 기존 이미지 유지 #248, 중복 제출 #250, 주소 전달 #253 | imageKey 생략은 삭제 의미, 상세에는 key 미제공 | 연결 PR 병합, 이미지 유실 방지 필요 |
+| Place | 장소 수정 | #248에서 사진 URL을 폼에 보존하고 사진이 있으면 수정 요청 차단·안내 | key 조회 계약 후 제한 해제, 중복 제출 #250, 주소 전달 #253 | imageKey 생략은 삭제 의미, 상세에는 key 미제공 | 사진 없는 장소 수정 유지, 사진 있는 장소는 임시 제한 |
 | Place | 장소 상세 | API 장소·owner·멤버·식물 연결, fixture 병합 제거 | 서버 미제공 환경 수치와 물주기 액션 | `GET /place/{code}` source 계약 #239 반영 | #239 / PR #240 병합 완료 |
 | Place | 친구 관리 | 실제 멤버·이미지 조회, 닉네임 필터, loading/empty/error/retry 연결 | 멤버 추가·삭제·권한 변경 | `GET /place/{code}/members` 연결, 고유 member id와 변경 endpoint 없음 | #245 조회 전용 연결 |
 | Place | 장소 나가기·삭제 | API 모드는 owner 삭제만 노출 | 구성원 나가기 | delete는 owner 전용 전체 삭제, leave endpoint 없음 | 삭제 #239, 나가기 Blocked |
 | Plant | 식물 등록 검색 | fixture 검색 | 실제 검색 모델과 상태 | 식물 종 검색 endpoint 필요 | 보류 |
 | Plant | 식물 등록 | 장소·애칭·선택 날짜와 create submit 연결, 원격 장소 조회 실패·빈 목록에 fixture 혼입 | 실제 장소·비동기 상태 #251, 중복 제출 #250, 학명/이미지 | `POST /plants` 연결, 유효한 서버 장소 code 필요 | 날짜 연결 완료, 원격 장소 처리 수정 필요 |
-| Plant | 식물 수정 | edit info·날짜와 update submit 연결, imageKey 누락·placeId 없는 성공 처리 발견 | 이미지 유지 #248, 중복 제출 #250, code 검증 #252 | `GET /plants/{id}/edit`, `PUT /plants/{id}`의 실제 계약 준수 | 연결 PR 병합, 유실·거짓 성공 수정 필요 |
+| Plant | 식물 수정 | #248에서 초기 imageKey 보존·전송, URL만 있고 key가 없으면 차단 | 중복 제출 #250, code 검증 #252, 이미지 선택·삭제 UI | `GET /plants/{id}/edit`, `PUT /plants/{id}` | 이미지 보존 구현·검증, code 없는 거짓 성공은 후속 수정 |
 | Plant | 식물 상세 | detail/delete, 등록일 계산과 실제 값 연결, remote fixture 제거 | Memo CRUD·물주기 액션 | `GET/DELETE /plants/{id}` 연결; Memo·물주기 API 없음 | #231 연결 완료 |
 | Memo | 메모 작성 | 로컬 Provider 저장 | DTO, repository, submit, 실제 image file | Memo 생성 endpoint 필요 | Blocked |
 | Memo | 메모 목록·수정·삭제 | 로컬 fixture·상태 | 목록, pagination, 수정·삭제, 상세 갱신 | Memo CRUD endpoint 필요 | Blocked |
@@ -141,7 +141,7 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
   호출하고 전송 중 중복 submit과 실패 재시도를 처리합니다.
 - 이름 기반 오초대와 일괄 요청의 부분 성공 위험은
   `docs/accepted-implementation-risks.md`에 수용 상태와 중단 조건을 기록합니다.
-- 실제 주소 검색 adapter와 이미지 선택은 정책·endpoint가 준비될 때까지 분리합니다. 다만 현재 주소 선택 결과가 폼에 전달되지 않는 문제는 #253, 기존 이미지 key를 보내지 않는 문제는 #248로 별도 수정합니다.
+- 실제 주소 검색 adapter와 이미지 선택은 정책·endpoint가 준비될 때까지 분리합니다. 주소 선택 결과 전달은 #253에서 수정합니다. #248은 사진이 있는 장소의 수정 요청을 차단하며, key 조회 계약 확보 후 별도 작업에서 제한을 해제합니다.
 
 ## Friend 수신 요청 수직 슬라이스
 
@@ -214,5 +214,6 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 | #245 | `1611fd0` | 최신 API·위험·매트릭스와 전체 검증 기록 | format 294개, analyze, 전체 test 362개·기존 skip 1개 |
 | #245 | - | PR #246·Project In Review 연결 기록 | `git diff --check` |
 | #247 | - | PR #246 병합 확인(`2a01bab`), API 연결과 미완료 동선·감사 이슈 분리 | [문서 정리 이력](development-audit-checklist.md) |
+| #248 | `7aee5e8`, `cda0aa2` | Plant 이미지 key 보존·불완전 정보 차단, Place 사진 수정 요청 차단과 회귀 테스트 | [이미지 보존 이력](work-history/form-image-preservation-248.md), 전체 376개 통과·기존 skip 1개 |
 
 문서 이력만 갱신하는 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/docs/work-history/form-image-preservation-248.md
+++ b/docs/work-history/form-image-preservation-248.md
@@ -1,0 +1,57 @@
+# 장소·식물 수정 이미지 보존 이력
+
+## 작업 기준
+
+- 이슈: [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248), AUDIT-01
+- 상위 이슈: #226
+- 작업일: 2026-08-28
+- 기준 `develop`: `f1331b2e850bea19793c708c183417b1554bc172` (문서 PR #257 병합)
+- 브랜치: `fix/form-image-preservation-248`
+- 참고: [개발 감사 체크리스트](../development-audit-checklist.md), [Swagger 참고](../api-swagger-reference.md), [Feature](../feature-development-guide.md), [상태관리](../state-management-guide.md), [폼 검증](../form-validation-error-guide.md), [공용 위젯](../shared-widget-guide.md), [테스트](../testing-guide.md), [Git](../git-workflow.md) 가이드
+
+## 확인한 계약과 구현
+
+dev OpenAPI와 backend main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`를 재확인했습니다. 새 image 파일이 없으면 기존 `imageKey`는 유지, key 생략/null은 삭제를 뜻합니다. 새 파일이 있으면 교체합니다.
+
+| 상황 | 이번 처리 |
+| --- | --- |
+| Plant에 기존 key가 있음 | Form 초기값으로 보존하고 이름·날짜 변경, 실패 후 재시도에서도 같은 key 전송 |
+| Plant에 사진 URL이 있으나 key가 없거나 공백 | 수정 API를 호출하지 않고 기존 Snackbar 경로로 안내, 입력과 화면 유지 |
+| Place에 기존 사진 URL이 있음 | 유지에 필요한 key를 조회할 수 없어 수정 요청 차단·안내, 입력과 화면 유지 |
+| 조회 시 사진이 없음 | 기존 이름·날짜·주소 수정 동작 유지 |
+| API 비사용 fixture 모드 | 기존 화면 개발·smoke 동작 유지 |
+| 하위 multipart API의 명시적 삭제·새 파일 교체 | 기존 계약 유지 및 전송 body 테스트. 삭제·선택 UI는 이번에 추가하지 않음 |
+
+`initialImageKey`·`initialImageUrl`은 수정할 수 없는 초기 스냅샷입니다. 일반 입력용 `copyWith`가 이미지 의도를 변경하지 않도록 보존합니다. 기존 `FormSubmitState`와 오류 표시를 재사용했으며 공용 위젯·라우터·의존성은 변경하지 않았습니다.
+
+Place 조회의 `imgUrl`은 [PlaceFacade](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/blob/7d572cbcabc81a65926738b2a09e8479d0bd0c79/src/main/java/com/commonplant/garden/place/facade/PlaceFacade.java)가 기존 key가 없을 때 null, 있을 때 다운로드 URL로 반환합니다. [S3ServiceImpl](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/blob/7d572cbcabc81a65926738b2a09e8479d0bd0c79/src/main/java/com/commonplant/garden/s3/service/S3ServiceImpl.java)의 URL 생성은 확인했지만 URL을 key로 역변환하지 않습니다.
+
+## 남은 제한과 위험
+
+- **사진이 있는 장소의 수정은 임시 제한됩니다.** 백엔드가 기존 key 조회 또는 명시적 이미지 유지 계약을 제공하면 [IMAGE-04](../backend-api-open-questions.md#image-04-이미지-key-생명주기)를 갱신하고 별도 이슈에서 제한을 해제합니다.
+- 사진 표시 URL과 저장 key는 다른 값입니다. 임의 key 추정, URL 재다운로드 후 재업로드, 의도하지 않은 삭제로 우회하지 않습니다.
+- 조회 스냅샷 이후 다른 클라이언트가 사진을 바꾸는 동시 수정은 원자적으로 보호되지 않습니다. 특히 사진이 없던 조회 뒤 다른 클라이언트가 사진을 추가하면 null/생략 update의 삭제 의미와 충돌할 수 있습니다. 조건부 수정·버전 확인 또는 명시적 유지 동작은 백엔드 계약 확인이 필요합니다.
+- 실제 인증 dev 요청, 원격 사진 삭제·교체 검증은 실행하지 않았습니다. source와 배포 상태의 정합성은 인증 smoke 준비 후 검증합니다.
+- 이미지 파일 선택·명시적 삭제 UI, 다른 감사 항목 #249~#256, 스토어·CI 설정은 이번 범위가 아닙니다. 기존 이미지 유실을 수용 위험으로 처리한 것이 아니라 확인 가능한 요청 보존과 안전 차단을 구현한 것입니다.
+
+## 검증
+
+1. 수정 전 새 Controller 회귀 테스트 6개 실패를 확인했습니다(기존 테스트 9개 통과).
+2. 수정 후 Controller·State 테스트 26개와 Place·Plant 전체 테스트 205개가 통과했습니다.
+3. multipart 전송 body에서 기존 key 유지, null key 삭제 계약, 새 image 파일 전달을 확인했습니다. 테스트는 fake repository와 HTTP adapter를 사용합니다.
+4. `fvm dart format --output=none --set-exit-if-changed .`: 294개 파일, 변경 0개
+5. `fvm flutter analyze`: 문제 없음
+6. `fvm flutter test`: 376개 통과, 기존 non-Linux golden skip 1개
+7. `git diff --check`: 통과
+8. Markdown 38개, 로컬 링크 153개·anchor 5개 검증: 누락 링크·미연결 문서 0개
+
+기존 362개 대비 회귀 테스트 14개를 추가했습니다. Android 수동 smoke는 fixture·앱 셸·route를 바꾸지 않아 이번에는 별도로 실행하지 않습니다.
+
+## 커밋별 작업 이력
+
+| 커밋 | 변경 범위 | 검증 |
+| --- | --- | --- |
+| `7aee5e8` | Plant 이미지 초기값·submit key 보존, 불완전 이미지 정보 차단 | Plant Controller·State 15개 통과, format |
+| `cda0aa2` | Place 이미지 정보 전달·요청 차단, 화면 안내와 multipart 계약 테스트 | Place·Plant 205개, format 294개, analyze, 전체 376개 통과·기존 skip 1개 |
+
+문서·PR 이력만 기록하는 마지막 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/docs/work-history/form-image-preservation-248.md
+++ b/docs/work-history/form-image-preservation-248.md
@@ -3,6 +3,7 @@
 ## 작업 기준
 
 - 이슈: [#248](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/issues/248), AUDIT-01
+- PR: [#258](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/pull/258), `develop` 대상. 사용자 병합 전이며 이슈·PR은 Project 10의 `In Review`로 관리합니다. 기본 CI 결과는 최신 PR checks에서 확인합니다.
 - 상위 이슈: #226
 - 작업일: 2026-08-28
 - 기준 `develop`: `f1331b2e850bea19793c708c183417b1554bc172` (문서 PR #257 병합)
@@ -53,5 +54,7 @@ Place 조회의 `imgUrl`은 [PlaceFacade](https://github.com/UMC-CommonPlant/v3_
 | --- | --- | --- |
 | `7aee5e8` | Plant 이미지 초기값·submit key 보존, 불완전 이미지 정보 차단 | Plant Controller·State 15개 통과, format |
 | `cda0aa2` | Place 이미지 정보 전달·요청 차단, 화면 안내와 multipart 계약 테스트 | Place·Plant 205개, format 294개, analyze, 전체 376개 통과·기존 skip 1개 |
+| `d6340d9` | 감사·화면/API 현황, IMAGE-04의 제한과 전체 검증 기록 | `git diff --check`, Markdown 38개·로컬 링크 153개·anchor 5개, 미연결 문서 0개 |
+| 이 문서의 최종 커밋 | PR #258·Project In Review 연결과 커밋별 이력 기록 | `git diff --check`, 이슈·PR Type·담당자·milestone·parent·Project 필드 확인 |
 
 문서·PR 이력만 기록하는 마지막 커밋은 자기 자신의 해시를 생략할 수 있습니다.

--- a/lib/features/place/presentation/providers/place_form_controller.dart
+++ b/lib/features/place/presentation/providers/place_form_controller.dart
@@ -9,6 +9,8 @@ import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const String placeFormAddressRequiredMessage = '장소 주소를 입력해 주세요.';
+const String placeFormImagePreservationMessage =
+    '기존 사진을 유지할 수 없어 지금은 장소를 수정할 수 없어요.';
 
 final placeFormControllerProvider = NotifierProvider.autoDispose
     .family<PlaceFormController, PlaceFormState, String?>(
@@ -55,6 +57,7 @@ class PlaceFormController extends Notifier<PlaceFormState> {
               placeId: placeId,
               name: info.name,
               address: info.address,
+              imageUrl: info.imageUrl,
             );
           },
           error: (error, stackTrace) =>
@@ -157,6 +160,13 @@ class PlaceFormController extends Notifier<PlaceFormState> {
     var resultPlaceCode = placeId;
 
     if (ref.read(useRemoteApiProvider)) {
+      // Place 조회는 URL만 제공하므로 유지에 필요한 key를 추측하지 않는다.
+      if (state.hasExistingImage) {
+        throw const _PlaceFormValidationException(
+          placeFormImagePreservationMessage,
+        );
+      }
+
       final requiredAddress = _requiredAddress(address);
 
       final updatedPlace = await ref

--- a/lib/features/place/presentation/providers/place_form_edit_provider.dart
+++ b/lib/features/place/presentation/providers/place_form_edit_provider.dart
@@ -6,19 +6,26 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 const String placeFormDefaultEditName = '스윗 홈_ 거실';
 
 class PlaceFormEditInfo {
-  const PlaceFormEditInfo({required this.id, required this.name, this.address});
+  const PlaceFormEditInfo({
+    required this.id,
+    required this.name,
+    this.address,
+    this.imageUrl,
+  });
 
   factory PlaceFormEditInfo.fromSummary(PlaceSummary summary) {
     return PlaceFormEditInfo(
       id: summary.id,
       name: summary.name,
       address: summary.address,
+      imageUrl: summary.imageUrl,
     );
   }
 
   final String id;
   final String name;
   final String? address;
+  final String? imageUrl;
 }
 
 final placeFormEditInfoProvider =

--- a/lib/features/place/presentation/providers/place_form_state.dart
+++ b/lib/features/place/presentation/providers/place_form_state.dart
@@ -14,6 +14,7 @@ class PlaceFormState {
     required this.currentAddress,
     required this.loadStatus,
     required this.submitState,
+    this.initialImageUrl,
     this.loadErrorMessage,
   });
 
@@ -45,6 +46,7 @@ class PlaceFormState {
     required String placeId,
     required String name,
     required String? address,
+    String? imageUrl,
   }) : this(
          placeId: placeId,
          mode: PlaceFormMode.edit,
@@ -52,6 +54,7 @@ class PlaceFormState {
          currentName: name,
          initialAddress: address,
          currentAddress: address,
+         initialImageUrl: imageUrl,
          loadStatus: PlaceFormLoadStatus.ready,
          submitState: const FormSubmitState.idle(),
        );
@@ -87,6 +90,7 @@ class PlaceFormState {
   final String currentName;
   final String? initialAddress;
   final String? currentAddress;
+  final String? initialImageUrl;
   final PlaceFormLoadStatus loadStatus;
   final FormSubmitState submitState;
   final String? loadErrorMessage;
@@ -96,6 +100,8 @@ class PlaceFormState {
   bool get isSubmitting => submitState.isSubmitting;
 
   String? get submitErrorMessage => submitState.errorMessage;
+
+  bool get hasExistingImage => initialImageUrl?.trim().isNotEmpty ?? false;
 
   bool get hasChanges =>
       currentName.trim() != initialName || currentAddress != initialAddress;
@@ -119,6 +125,7 @@ class PlaceFormState {
       initialName: initialName,
       currentName: currentName ?? this.currentName,
       initialAddress: initialAddress,
+      initialImageUrl: initialImageUrl,
       currentAddress: identical(currentAddress, _unset)
           ? this.currentAddress
           : currentAddress as String?,

--- a/lib/features/plant/presentation/providers/plant_form_controller.dart
+++ b/lib/features/plant/presentation/providers/plant_form_controller.dart
@@ -9,6 +9,9 @@ import 'package:commonplant_frontend/features/plant/presentation/providers/plant
 import 'package:commonplant_frontend/shared/forms/form_submit_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+const String plantFormImagePreservationMessage =
+    '기존 사진 정보를 확인할 수 없어 수정하지 못했어요. 다시 불러와 주세요.';
+
 final plantFormControllerProvider = NotifierProvider.autoDispose
     .family<PlantFormController, PlantFormState, PlantFormArgs>(
       PlantFormController.new,
@@ -65,6 +68,8 @@ class PlantFormController extends Notifier<PlantFormState> {
                 plantId: plantId,
                 placeId: args.placeId,
                 name: info.name.trim(),
+                imageKey: info.imageKey,
+                imageUrl: info.imageUrl,
                 lastWateredDate: _normalizedLastWateredDate(
                   info.lastWateredDate,
                 ),
@@ -149,6 +154,17 @@ class PlantFormController extends Notifier<PlantFormState> {
       return null;
     }
 
+    if (state.isEdit &&
+        ref.read(useRemoteApiProvider) &&
+        state.hasUnresolvedImage) {
+      state = state.copyWith(
+        submitState: const FormSubmitState.failure(
+          plantFormImagePreservationMessage,
+        ),
+      );
+      return null;
+    }
+
     final isEdit = state.isEdit;
     state = state.copyWith(submitState: const FormSubmitState.submitting());
 
@@ -205,6 +221,7 @@ class PlantFormController extends Notifier<PlantFormState> {
           .updatePlant(
             plantId: plantId,
             placeCode: placeId,
+            imageKey: state.initialImageKey,
             nickname: plantName,
             lastWateredDate: state.currentLastWateredDate,
           );

--- a/lib/features/plant/presentation/providers/plant_form_state.dart
+++ b/lib/features/plant/presentation/providers/plant_form_state.dart
@@ -39,6 +39,8 @@ class PlantFormState {
     required this.selectedPlaceId,
     required this.loadStatus,
     required this.submitState,
+    this.initialImageKey,
+    this.initialImageUrl,
     this.loadErrorMessage,
   });
 
@@ -81,6 +83,8 @@ class PlantFormState {
     required String? placeId,
     required String name,
     required String? lastWateredDate,
+    String? imageKey,
+    String? imageUrl,
   }) : this(
          plantId: plantId,
          placeId: placeId,
@@ -89,6 +93,8 @@ class PlantFormState {
          currentName: name,
          initialLastWateredDate: lastWateredDate,
          currentLastWateredDate: lastWateredDate,
+         initialImageKey: imageKey,
+         initialImageUrl: imageUrl,
          places: const [],
          selectedPlaceId: null,
          loadStatus: PlantFormLoadStatus.ready,
@@ -138,6 +144,8 @@ class PlantFormState {
   final String currentName;
   final String? initialLastWateredDate;
   final String? currentLastWateredDate;
+  final String? initialImageKey;
+  final String? initialImageUrl;
   final List<PlantRegistrationPlace> places;
   final String? selectedPlaceId;
   final PlantFormLoadStatus loadStatus;
@@ -149,6 +157,10 @@ class PlantFormState {
   bool get isSubmitting => submitState.isSubmitting;
 
   String? get submitErrorMessage => submitState.errorMessage;
+
+  bool get hasUnresolvedImage =>
+      (initialImageUrl?.trim().isNotEmpty ?? false) &&
+      (initialImageKey?.trim().isEmpty ?? true);
 
   bool get hasChanges =>
       currentName.trim() != initialName ||
@@ -199,6 +211,8 @@ class PlantFormState {
       currentLastWateredDate: identical(currentLastWateredDate, _unset)
           ? this.currentLastWateredDate
           : currentLastWateredDate as String?,
+      initialImageKey: initialImageKey,
+      initialImageUrl: initialImageUrl,
       places: places == null ? this.places : List.unmodifiable(places),
       selectedPlaceId: identical(selectedPlaceId, _unset)
           ? this.selectedPlaceId

--- a/test/features/place/data/datasources/place_remote_data_source_test.dart
+++ b/test/features/place/data/datasources/place_remote_data_source_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:commonplant_frontend/features/place/data/datasources/place_remote_data_source.dart';
@@ -37,6 +38,28 @@ void main() {
         adapter.latestOptions.contentType,
         startsWith('multipart/form-data'),
       );
+      expect(
+        adapter.latestBody,
+        contains('"imageKey":"images/user-nano-id/garden.png"'),
+      );
+      expect(adapter.latestBody, isNot(contains('name="image"')));
+    });
+
+    test('명시적 null key는 삭제 계약대로 key와 파일을 생략한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = DioPlaceRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.updatePlace(
+        code: 'Abc123',
+        request: const UpdatePlaceRequest(
+          name: '정원',
+          address: '서울특별시',
+          imageKey: null,
+        ),
+      );
+
+      expect(adapter.latestBody, isNot(contains('"imageKey"')));
+      expect(adapter.latestBody, isNot(contains('name="image"')));
     });
 
     test('장소 생성은 optional image part를 multipart에 포함한다', () async {
@@ -70,6 +93,8 @@ void main() {
       expect(adapter.latestOptions.method, 'PUT');
       expect(adapter.latestOptions.path, '/place/update/Abc123');
       expect(formData.files.map((file) => file.key), contains('image'));
+      expect(adapter.latestBody, contains('image-bytes'));
+      expect(adapter.latestBody, contains('filename="place.png"'));
     });
   });
 }
@@ -84,6 +109,7 @@ class _CapturingAdapter implements HttpClientAdapter {
 
   final String responseBody;
   late RequestOptions latestOptions;
+  late String latestBody;
 
   @override
   void close({bool force = false}) {}
@@ -95,6 +121,9 @@ class _CapturingAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     latestOptions = options;
+    latestBody = requestStream == null
+        ? ''
+        : await utf8.decoder.bind(requestStream).join();
 
     return ResponseBody.fromString(
       responseBody,

--- a/test/features/place/presentation/pages/place_form_page_test.dart
+++ b/test/features/place/presentation/pages/place_form_page_test.dart
@@ -5,12 +5,38 @@ import 'package:commonplant_frontend/features/place/domain/entities/place_summar
 import 'package:commonplant_frontend/features/place/domain/repositories/place_repository.dart';
 import 'package:commonplant_frontend/features/place/place_repository_provider.dart';
 import 'package:commonplant_frontend/features/place/presentation/pages/place_form_page.dart';
+import 'package:commonplant_frontend/features/place/presentation/providers/place_form_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 void main() {
+  testWidgets('사진이 있는 장소 수정은 안내를 표시하고 화면과 입력을 유지한다', (tester) async {
+    final repository = _EditablePlaceRepository(
+      const PlaceSummary(
+        id: 'place-1',
+        name: '루프탑',
+        address: '서울시 성북구',
+        imageUrl: 'https://example.com/place.png',
+      ),
+    );
+    await tester.pumpWidget(_remotePlaceEditApp(repository));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '루프탑 정원');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, '완료'));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 0);
+    expect(find.text(placeFormImagePreservationMessage), findsOneWidget);
+    expect(find.text('루프탑 정원'), findsOneWidget);
+    expect(find.text('홈'), findsNothing);
+    expect(find.byType(PlaceFormPage), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('장소 수정 화면은 기존 장소 정보와 비활성 완료 버튼을 표시한다', (
     WidgetTester tester,
   ) async {
@@ -113,6 +139,7 @@ Widget _remotePlaceEditApp(PlaceRepository repository) {
       ),
     ],
   );
+  addTearDown(router.dispose);
 
   return ProviderScope(
     overrides: [

--- a/test/features/place/presentation/providers/place_form_controller_test.dart
+++ b/test/features/place/presentation/providers/place_form_controller_test.dart
@@ -173,11 +173,46 @@ void main() {
       expect(repository.latestUpdateCode, 'place-1');
       expect(repository.latestUpdateName, '루프탑');
       expect(repository.latestUpdateAddress, '서울시 성북구');
+      expect(repository.latestUpdateImageKey, isNull);
+    });
+
+    test('사진이 있는 장소의 이름·주소 수정은 기존 사진 유실을 막는다', () async {
+      final repository = _RecordingPlaceRepository(
+        imageUrl: 'https://example.com/place.png?signature=old',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          placeRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+      final provider = placeFormControllerProvider('place-1');
+      final subscription = container.listen(provider, (previous, next) {});
+      addTearDown(subscription.close);
+      await container.read(remotePlaceFormEditInfoProvider('place-1').future);
+      await container.pump();
+      final controller = container.read(provider.notifier);
+
+      controller.updateName('루프탑');
+      expect(await controller.submit(), isNull);
+      controller.updateAddress('서울시 강남구');
+      expect(await controller.submit(), isNull);
+
+      expect(repository.updateCalls, 0);
+      final state = container.read(provider);
+      expect(state.submitErrorMessage, contains('기존 사진'));
+      expect(state.currentName, '루프탑');
+      expect(state.currentAddress, '서울시 강남구');
+      expect(state.isSubmitting, isFalse);
     });
   });
 }
 
 class _RecordingPlaceRepository extends Fake implements PlaceRepository {
+  _RecordingPlaceRepository({this.imageUrl});
+
+  final String? imageUrl;
   int createCalls = 0;
   int updateCalls = 0;
   String? latestUpdateCode;
@@ -185,10 +220,16 @@ class _RecordingPlaceRepository extends Fake implements PlaceRepository {
   String? latestCreateAddress;
   String? latestUpdateName;
   String? latestUpdateAddress;
+  String? latestUpdateImageKey;
 
   @override
   Future<PlaceSummary> fetchPlace(String code) async {
-    return PlaceSummary(id: code, name: '거실', address: '서울시 성북구');
+    return PlaceSummary(
+      id: code,
+      name: '거실',
+      address: '서울시 성북구',
+      imageUrl: imageUrl,
+    );
   }
 
   @override
@@ -214,6 +255,7 @@ class _RecordingPlaceRepository extends Fake implements PlaceRepository {
     latestUpdateCode = code;
     latestUpdateName = name;
     latestUpdateAddress = address;
+    latestUpdateImageKey = imageKey;
 
     return PlaceSummary(id: code, name: name, address: address);
   }

--- a/test/features/place/presentation/providers/place_form_edit_provider_test.dart
+++ b/test/features/place/presentation/providers/place_form_edit_provider_test.dart
@@ -18,11 +18,17 @@ void main() {
       expect(info?.id, 'place-1');
       expect(info?.name, '스윗 홈_ 거실');
       expect(info?.address, isNull);
+      expect(info?.imageUrl, isNull);
     });
 
     test('remote mode는 장소 상세 summary를 수정 정보로 변환한다', () async {
       final repository = _StaticPlaceRepository(
-        const PlaceSummary(id: 'remote-place', name: '루프탑', address: '서울시 성북구'),
+        const PlaceSummary(
+          id: 'remote-place',
+          name: '루프탑',
+          address: '서울시 성북구',
+          imageUrl: 'https://example.com/place.png',
+        ),
       );
       final container = ProviderContainer(
         overrides: [
@@ -43,6 +49,7 @@ void main() {
       expect(info?.id, 'remote-place');
       expect(info?.name, '루프탑');
       expect(info?.address, '서울시 성북구');
+      expect(info?.imageUrl, 'https://example.com/place.png');
       expect(repository.fetchCalls, 1);
     });
 

--- a/test/features/place/presentation/providers/place_form_state_test.dart
+++ b/test/features/place/presentation/providers/place_form_state_test.dart
@@ -4,6 +4,24 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlaceFormState', () {
+    test('이름·주소·제출 상태가 바뀌어도 기존 이미지 여부를 보존한다', () {
+      const state = PlaceFormState.edit(
+        placeId: 'place-1',
+        name: '거실',
+        address: '서울시',
+        imageUrl: 'https://example.com/place.png',
+      );
+      final changed = state.copyWith(
+        currentName: '루프탑',
+        currentAddress: '경기도',
+        submitState: const FormSubmitState.failure('요청 실패'),
+      );
+
+      expect(changed.initialImageUrl, state.initialImageUrl);
+      expect(changed.hasExistingImage, isTrue);
+      expect(const PlaceFormState.create().hasExistingImage, isFalse);
+    });
+
     test('생성 상태는 이름이 입력되면 제출할 수 있다', () {
       const state = PlaceFormState.create();
 

--- a/test/features/plant/data/datasources/plant_remote_data_source_test.dart
+++ b/test/features/plant/data/datasources/plant_remote_data_source_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:commonplant_frontend/features/plant/data/datasources/plant_remote_data_source.dart';
@@ -7,6 +8,38 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlantRemoteDataSource', () {
+    test('사진 유지 요청은 multipart JSON에 기존 key를 보존한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.updatePlant(
+        plantId: '1',
+        placeCode: 'Abc123',
+        request: const UpdatePlantRequest(
+          nickname: '몬테라',
+          imageKey: 'images/existing.png',
+        ),
+      );
+
+      expect(adapter.latestBody, contains('"imageKey":"images/existing.png"'));
+      expect(adapter.latestBody, contains('"nickname":"몬테라"'));
+      expect(adapter.latestBody, isNot(contains('name="image"')));
+    });
+
+    test('명시적 null key는 삭제 계약대로 key와 파일을 생략한다', () async {
+      final adapter = _CapturingAdapter();
+      final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
+
+      await dataSource.updatePlant(
+        plantId: '1',
+        placeCode: 'Abc123',
+        request: const UpdatePlantRequest(nickname: '몬테라', imageKey: null),
+      );
+
+      expect(adapter.latestBody, isNot(contains('"imageKey"')));
+      expect(adapter.latestBody, isNot(contains('name="image"')));
+    });
+
     test('식물 상세 조회는 place query 없이 plantId path만 보낸다', () async {
       final adapter = _CapturingAdapter();
       final dataSource = DioPlantRemoteDataSource(_dioWith(adapter));
@@ -73,6 +106,8 @@ void main() {
       expect(adapter.latestOptions.method, 'PUT');
       expect(adapter.latestOptions.path, '/plants/1');
       expect(formData.files.map((file) => file.key), contains('image'));
+      expect(adapter.latestBody, contains('image-bytes'));
+      expect(adapter.latestBody, contains('filename="plant.png"'));
     });
 
     test('식물 삭제는 placeCode query를 보낸다', () async {
@@ -94,6 +129,7 @@ Dio _dioWith(HttpClientAdapter adapter) {
 
 class _CapturingAdapter implements HttpClientAdapter {
   late RequestOptions latestOptions;
+  late String latestBody;
 
   @override
   void close({bool force = false}) {}
@@ -105,6 +141,9 @@ class _CapturingAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     latestOptions = options;
+    latestBody = requestStream == null
+        ? ''
+        : await utf8.decoder.bind(requestStream).join();
 
     return ResponseBody.fromString(
       '{}',

--- a/test/features/plant/data/repositories/plant_repository_test.dart
+++ b/test/features/plant/data/repositories/plant_repository_test.dart
@@ -6,6 +6,24 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PlantRepository', () {
+    test('이름 수정의 기존 image key는 DTO와 datasource에 유지된다', () async {
+      final dataSource = _ImagePlantRemoteDataSource();
+      final repository = PlantRepositoryImpl(dataSource);
+
+      await repository.updatePlant(
+        plantId: 'plant-1',
+        placeCode: 'place-1',
+        nickname: '몬테라',
+        imageKey: 'images/existing.png',
+      );
+
+      expect(dataSource.latestUpdateRequest?.toJson(), {
+        'imageKey': 'images/existing.png',
+        'nickname': '몬테라',
+      });
+      expect(dataSource.latestUpdateImage, isNull);
+    });
+
     test('식물 생성은 선택된 이미지 파일을 datasource에 전달한다', () async {
       final dataSource = _ImagePlantRemoteDataSource();
       final repository = PlantRepositoryImpl(dataSource);

--- a/test/features/plant/presentation/pages/plant_form_page_test.dart
+++ b/test/features/plant/presentation/pages/plant_form_page_test.dart
@@ -6,12 +6,44 @@ import 'package:commonplant_frontend/features/plant/domain/repositories/plant_re
 import 'package:commonplant_frontend/features/plant/plant_repository_provider.dart';
 import 'package:commonplant_frontend/features/plant/presentation/fixtures/plant_registration_place_fixture.dart';
 import 'package:commonplant_frontend/features/plant/presentation/pages/plant_form_page.dart';
+import 'package:commonplant_frontend/features/plant/presentation/providers/plant_form_controller.dart';
 import 'package:commonplant_frontend/features/plant/presentation/providers/plant_registration_place_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('사진 key가 없는 식물 수정은 안내를 표시하고 API를 호출하지 않는다', (tester) async {
+    final repository = _StaticEditInfoPlantRepository(
+      const PlantEditInfo(
+        name: '몬테',
+        imageUrl: 'https://example.com/plant.png',
+      ),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(
+          home: PlantFormPage(plantId: 'plant-1', placeId: 'place-1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '몬테라');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, '완료'));
+    await tester.pumpAndSettle();
+
+    expect(repository.updateCalls, 0);
+    expect(find.text(plantFormImagePreservationMessage), findsOneWidget);
+    expect(find.text('몬테라'), findsOneWidget);
+    expect(find.byType(PlantFormPage), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('식물 등록 정보 입력 화면은 Figma 기준 필드를 표시한다', (tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: PlantFormPage())),
@@ -421,6 +453,18 @@ class _StaticEditInfoPlantRepository extends Fake implements PlantRepository {
   _StaticEditInfoPlantRepository(this.editInfo);
 
   final PlantEditInfo editInfo;
+  int updateCalls = 0;
+
+  @override
+  Future<void> updatePlant({
+    required String plantId,
+    required String placeCode,
+    String? imageKey,
+    String? nickname,
+    String? lastWateredDate,
+  }) async {
+    updateCalls++;
+  }
 
   @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {

--- a/test/features/plant/presentation/providers/plant_form_controller_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_controller_test.dart
@@ -155,11 +155,143 @@ void main() {
       expect(repository.latestUpdatePlaceCode, 'place-1');
       expect(repository.latestUpdateNickname, '몬테라');
       expect(repository.latestUpdateLastWateredDate, '2026-08-24');
+      expect(repository.updatedImageKeys, [null]);
+    });
+
+    for (final changeName in [true, false]) {
+      test('${changeName ? '이름' : '날짜'}만 수정해도 기존 이미지 key를 전달한다', () async {
+        final repository = _RecordingPlantRepository(
+          editInfo: const PlantEditInfo(
+            name: '몬테',
+            lastWateredDate: '2026-05-25',
+            imageKey: 'images/existing.png',
+            imageUrl: 'https://example.com/existing.png?signature=old',
+          ),
+        );
+        final container = ProviderContainer(
+          overrides: [
+            useRemoteApiProvider.overrideWithValue(true),
+            plantRepositoryProvider.overrideWithValue(repository),
+          ],
+        );
+        addTearDown(container.dispose);
+        const args = PlantFormArgs(plantId: 'plant-1', placeId: 'place-1');
+        final subscription = container.listen(
+          plantFormControllerProvider(args),
+          (previous, next) {},
+        );
+        addTearDown(subscription.close);
+        await container.read(remotePlantFormEditInfoProvider('plant-1').future);
+        await container.pump();
+        final controller = container.read(
+          plantFormControllerProvider(args).notifier,
+        );
+
+        if (changeName) {
+          controller.updateName('몬테라');
+        } else {
+          controller.updateLastWateredDate(DateTime(2026, 8, 24));
+        }
+        final result = await controller.submit();
+
+        expect(result?.destination, PlantFormSubmitDestination.plantDetail);
+        expect(repository.updatedImageKeys, ['images/existing.png']);
+      });
+    }
+
+    for (final imageKey in [null, '   ']) {
+      test('사진 URL만 있고 유효한 key가 없으면 수정 요청을 막는다 ($imageKey)', () async {
+        final repository = _RecordingPlantRepository(
+          editInfo: PlantEditInfo(
+            name: '몬테',
+            imageKey: imageKey,
+            imageUrl: 'https://example.com/existing.png',
+          ),
+        );
+        final container = ProviderContainer(
+          overrides: [
+            useRemoteApiProvider.overrideWithValue(true),
+            plantRepositoryProvider.overrideWithValue(repository),
+          ],
+        );
+        addTearDown(container.dispose);
+        const args = PlantFormArgs(plantId: 'plant-1', placeId: 'place-1');
+        final subscription = container.listen(
+          plantFormControllerProvider(args),
+          (previous, next) {},
+        );
+        addTearDown(subscription.close);
+        await container.read(remotePlantFormEditInfoProvider('plant-1').future);
+        await container.pump();
+        final controller = container.read(
+          plantFormControllerProvider(args).notifier,
+        );
+
+        controller.updateName('몬테라');
+        final result = await controller.submit();
+
+        expect(result, isNull);
+        expect(repository.updateCalls, 0);
+        final state = container.read(plantFormControllerProvider(args));
+        expect(state.submitErrorMessage, contains('기존 사진'));
+        expect(state.currentName, '몬테라');
+        expect(state.isSubmitting, isFalse);
+      });
+    }
+
+    test('수정 실패 후 입력을 바꿔 재시도해도 기존 이미지 key를 보존한다', () async {
+      final repository = _RecordingPlantRepository(
+        editInfo: const PlantEditInfo(
+          name: '몬테',
+          imageKey: 'images/existing.png',
+        ),
+        failFirstUpdate: true,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          useRemoteApiProvider.overrideWithValue(true),
+          plantRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+      const args = PlantFormArgs(plantId: 'plant-1', placeId: 'place-1');
+      final subscription = container.listen(
+        plantFormControllerProvider(args),
+        (previous, next) {},
+      );
+      addTearDown(subscription.close);
+      await container.read(remotePlantFormEditInfoProvider('plant-1').future);
+      await container.pump();
+      final controller = container.read(
+        plantFormControllerProvider(args).notifier,
+      );
+
+      controller.updateName('몬테라');
+      expect(await controller.submit(), isNull);
+      controller.updateLastWateredDate(DateTime(2026, 8, 24));
+      final result = await controller.submit();
+
+      expect(result?.destination, PlantFormSubmitDestination.plantDetail);
+      expect(repository.updatedImageKeys, [
+        'images/existing.png',
+        'images/existing.png',
+      ]);
     });
   });
 }
 
 class _RecordingPlantRepository extends Fake implements PlantRepository {
+  _RecordingPlantRepository({
+    this.editInfo = const PlantEditInfo(
+      name: '몬테',
+      lastWateredDate: '2026-05-25',
+    ),
+    this.failFirstUpdate = false,
+  });
+
+  final PlantEditInfo editInfo;
+  final bool failFirstUpdate;
+  final List<String?> updatedImageKeys = [];
   int createCalls = 0;
   int updateCalls = 0;
   String? latestUpdatePlantId;
@@ -173,7 +305,7 @@ class _RecordingPlantRepository extends Fake implements PlantRepository {
 
   @override
   Future<PlantEditInfo> fetchPlantEditInfo({required String plantId}) async {
-    return const PlantEditInfo(name: '몬테', lastWateredDate: '2026-05-25');
+    return editInfo;
   }
 
   @override
@@ -201,9 +333,14 @@ class _RecordingPlantRepository extends Fake implements PlantRepository {
     String? lastWateredDate,
   }) async {
     updateCalls++;
+    updatedImageKeys.add(imageKey);
     latestUpdatePlantId = plantId;
     latestUpdatePlaceCode = placeCode;
     latestUpdateNickname = nickname;
     latestUpdateLastWateredDate = lastWateredDate;
+
+    if (failFirstUpdate && updateCalls == 1) {
+      throw StateError('첫 수정 실패');
+    }
   }
 }

--- a/test/features/plant/presentation/providers/plant_form_state_test.dart
+++ b/test/features/plant/presentation/providers/plant_form_state_test.dart
@@ -10,6 +10,26 @@ void main() {
   ];
 
   group('PlantFormState', () {
+    test('이름·날짜·제출 상태가 바뀌어도 초기 이미지 정보를 보존한다', () {
+      const state = PlantFormState.edit(
+        plantId: 'plant-1',
+        placeId: 'place-1',
+        name: '몬테',
+        lastWateredDate: null,
+        imageKey: 'images/existing.png',
+        imageUrl: 'https://example.com/existing.png',
+      );
+      final changed = state.copyWith(
+        currentName: '몬테라',
+        currentLastWateredDate: '2026-08-28',
+        submitState: const FormSubmitState.failure('요청 실패'),
+      );
+
+      expect(changed.initialImageKey, state.initialImageKey);
+      expect(changed.initialImageUrl, state.initialImageUrl);
+      expect(changed.hasUnresolvedImage, isFalse);
+    });
+
     test('생성 상태는 첫 장소를 선택하고 제출할 수 있다', () {
       final state = PlantFormState.create(plantName: '몬스테라', places: places);
 


### PR DESCRIPTION
## 연결

Closes #248
Parent Epic: #226
문서 PR #257 병합 후 develop `f1331b2`에서 시작한 AUDIT-01입니다.

## 변경 사항

- Plant 수정 정보의 기존 imageKey·imageUrl을 Form 초기 상태로 보존합니다.
- 이름·날짜만 바꾸거나 실패 후 재시도할 때 같은 imageKey를 전송합니다.
- Plant 사진 URL은 있지만 key가 없거나 공백이면 요청을 차단하고 안내합니다.
- Place 기존 사진 URL을 Form까지 전달합니다. **사진이 있는 장소는 수정 요청을 임시 차단**하고 입력값과 화면을 유지합니다. 사진 없는 장소와 fixture 모드의 수정은 유지합니다.
- Controller·State·Provider·화면 및 multipart/repository 경계에 회귀 테스트 14개를 추가했습니다.
- 감사 체크리스트, 화면/API 현황, IMAGE-04와 커밋별 작업 이력을 갱신했습니다.

## 계약과 남은 제한

dev OpenAPI와 backend main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`에서 새 파일 없이 기존 key 전송은 유지, 생략/null은 삭제임을 재확인했습니다.

Place 상세 응답에는 이미지 URL만 있어 안전한 key를 확보할 수 없습니다. URL에서 key를 추측하거나 재업로드하지 않으며, Place key 조회 또는 명시적 유지 계약 확인 후 별도 이슈에서 사진이 있는 장소의 수정 제한을 해제합니다.

조회 이후 다른 클라이언트가 사진을 바꾸는 동시 수정은 서버의 조건부 수정 계약이 필요합니다. 인증된 원격 이미지 삭제·교체 요청은 실행하지 않았습니다.

자세한 근거·제한: [작업 이력](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/blob/fix/form-image-preservation-248/docs/work-history/form-image-preservation-248.md), [IMAGE-04](https://github.com/UMC-CommonPlant/v3_CommonPlant_Frontend_Repo/blob/fix/form-image-preservation-248/docs/backend-api-open-questions.md#image-04-이미지-key-생명주기).

## 검증

- 수정 전 신규 Controller 회귀 테스트 6개 실패 확인
- Place·Plant 테스트: 205개 통과
- `fvm dart format --output=none --set-exit-if-changed .`: 294개, 변경 0개
- `fvm flutter analyze`: 문제 없음
- `fvm flutter test`: 376개 통과, 기존 non-Linux golden skip 1개
- `git diff --check`: 통과
- Markdown 38개, 로컬 링크 153개·anchor 5개, 누락 링크·미연결 문서 0개

기본 CI 결과는 최신 PR checks에서 확인합니다. Android 수동 smoke는 이번 범위에서 실행하지 않았습니다.

## 범위 제외

- 미사용 공용 위젯 5개 보존
- 이미지 선택·삭제 UI와 다른 감사 항목 #249~#256
- GitHub Environment, branch protection, CI·스토어·배포 설정 변경

PR 병합은 사용자가 진행합니다.
