### PR TITLE
Docs: Memo API 계약 경계 정리 #283

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 
 ## 현재 진행 상태와 다음 작업
 
-2026-09-01 `develop`의 PR #280 병합 상태(`c38eb61`)를 기준으로 합니다. Epic #226의 하위 이슈 20/20과 감사 #248~#256이 완료되어 Epic과 Project 상태를 `Done`으로 종료했습니다. 이는 실제 인증 E2E나 모든 화면 동선의 완성을 뜻하지 않으며, 후속 실행 범위는 [화면·모델·API 연결 계획](docs/screen-api-integration-plan.md#후속-개발-실행-순서-267)에서 관리합니다.
+2026-09-01 `develop`의 PR #282 병합 상태(`3824187`)를 기준으로 합니다. Epic #226의 하위 이슈 20/20과 감사 #248~#256이 완료되어 Epic과 Project 상태를 `Done`으로 종료했습니다. 이는 실제 인증 E2E나 모든 화면 동선의 완성을 뜻하지 않으며, 후속 실행 범위는 [화면·모델·API 연결 계획](docs/screen-api-integration-plan.md#후속-개발-실행-순서-267)에서 관리합니다.
 
 현재 우선순위는 사용자 결정에 따라 다음과 같습니다.
 
@@ -249,7 +249,8 @@ GitHub Actions에서 Flutter `3.35.7` 기준으로 아래 작업을 실행합니
 4. #275 / PR #276에서 표준 API 오류와 필드 오류를 안전하게 매핑하고, 확인된 access token 오류 `A003`·`A004`·`A009`는 현재 세션을 종료해 로그인 안내로 연결했습니다. refresh·서버 로그아웃은 백엔드 #149 계약 전까지 재시도하거나 추정하지 않습니다.
 5. #277에서 Place 멤버·Friend 쓰기 계약을 재확인했습니다. 멤버 ID·역할·변경 endpoint와 Friend 고유 대상·부분 결과가 없어 [백엔드 #150](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/150) 답변 전까지 기존 조회 전용·안전 차단을 유지합니다.
 6. #279 / PR #280에서 UX-02의 inline 상태·Snackbar·Dialog 기준을 확정하고, 반복 Snackbar만 최소 helper로 통일했습니다. 단일 목적지 삭제 결과와 전달용 getter는 제거하고 실제 분기·재사용이 있는 상태와 result는 유지했습니다.
-7. `MEMO-01~03` 계약 뒤 Memo 생성·목록·수정·삭제를 화면 상태부터 API까지 연결합니다.
+7. #281 / PR #282에서 현재 PR 본문 기준을 단일 기본 template으로 고정했습니다. 유형별 template과 metadata 자동화는 실제 반복 요구가 생기기 전까지 추가하지 않습니다.
+8. #283에서 Memo 텍스트 CRUD 계약을 재확인했습니다. live OpenAPI에는 Memo path/schema가 없고 backend #50~#55의 초안도 본문 길이·이미지 유지·작성자·pagination 계약이 충돌하거나 빠져 있어 [백엔드 #50 계약 확인](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254) 답변 전까지 로컬 화면을 유지합니다.
 
 로그인 SDK, 실제 주소 검색 서비스, 업로드 방식 변경이 필요한 이미지 흐름, 인증된 원격 E2E, 스토어·릴리즈 준비는 사용자가 다음 작업으로 보류했습니다. 기존 안전 차단과 질문·위험 기록은 유지하며 이 항목들이 위 실행 순서를 막는 전역 blocker가 되지 않게 분리합니다.
 

--- a/docs/api-swagger-reference.md
+++ b/docs/api-swagger-reference.md
@@ -630,6 +630,8 @@ TEST-02-B의 backend/frontend/CI 준비 조건과 첫 read-only probe 범위는 
 - 로그아웃 API
 - refresh token 재발급 API
 
+2026-09-01 live OpenAPI는 여전히 19개 path이며 Memo path/schema는 0개다. backend #50~#55에는 `/plants/{plantUuid}/memos` 생성·조회·수정·삭제 계획이 있지만 구현과 OpenAPI가 아니며 content 200/500자, image 생략 시 유지/삭제, 작성자·권한, pagination, 성공 wrapper가 확정되지 않았다. #283은 [backend #50 계약 확인](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254) 답변 전까지 이를 프론트 DTO 근거로 사용하지 않는다.
+
 ## 기존 확인 필요 항목 처리 현황
 
 | 기존 확인 필요 항목 | 최신 Swagger 상태 | 판단 |
@@ -733,14 +735,14 @@ Place/Plant 수정 요청의 `imageKey`는 단순 optional 장식 필드가 아�
 | Error | live/backend source와 dev 배포의 실제 인증 쓰기 오류 일치 여부 | #275 공통 사용자 메시지와 field error 매핑 완료, 원격 validation smoke 보류 |
 | Token | refresh token 재발급, 로그아웃 API 제공 여부 | #275 로컬 세션 종료 적용, backend #149 전까지 자동 복구·서버 invalidation 차단 |
 | 검색 | 주소 검색, 식물 검색 API 제공 여부와 사용자 검색 매칭 정책 | 주소 검색은 보류, 식물 검색은 백엔드 #92 대기 중이며 API mode fixture 차단 |
-| Memo | 메모 CRUD API, 이미지 첨부, 목록 response 구조 | 메모 화면 실데이터 연결 보류 |
+| Memo | backend #50~#55의 메모 CRUD, 작성자·권한·pagination·오류와 이미지 생략 정책 | #283 계약 확인과 live OpenAPI 동기화 전 텍스트 CRUD 연결 Blocked, 이미지 별도 보류 |
 | 환경 | dev URL은 확인, staging/prod full base URL과 API versioning 정책은 미확정 | dev 로컬 실행 가능, release 검증 보류 |
 
 ## 현재 후속 작업 안내
 
 초기 Auth·Home·Plant·User·Place·Friend 연결과 감사 회귀 수정 PR은 병합됐다. 현행 우선순위와 미완료 동선은 [화면·API 매트릭스](screen-api-integration-plan.md)를 따른다.
 
-소셜 SDK credential 획득, 실제 주소 검색, 이미지 파일 선택·key 조회와 Memo CRUD는 여전히 별도 준비가 필요하다. Place 멤버 변경·나가기와 Friend 고유 대상·부분 결과는 backend #150을 선행 조건으로 두며, 식물 검색은 백엔드 #92 전까지 API mode에서 비활성화한다. 이미 수용한 Friend 이름 오매칭과 Plant 장소 조회 비용은 위험 등록부로 추적하고, 새 프론트 결함을 자동으로 수용한 것으로 해석하지 않는다.
+소셜 SDK credential 획득, 실제 주소 검색과 이미지 파일 선택·key 조회는 여전히 별도 준비가 필요하다. Memo 텍스트 CRUD는 backend #50 계약 답변·구현·live OpenAPI 동기화를, Place 멤버 변경·나가기와 Friend 고유 대상·부분 결과는 backend #150을 선행 조건으로 둔다. 식물 검색은 백엔드 #92 전까지 API mode에서 비활성화한다. 이미 수용한 Friend 이름 오매칭과 Plant 장소 조회 비용은 위험 등록부로 추적하고, 새 프론트 결함을 자동으로 수용한 것으로 해석하지 않는다.
 
 ## DEV API 문서화 작업 이력
 

--- a/docs/backend-api-open-questions.md
+++ b/docs/backend-api-open-questions.md
@@ -40,9 +40,9 @@
 | SEARCH-01 | 검색 | 주소 검색 API를 백엔드가 제공하는가? | 장소 등록 주소 검색 실데이터 보류 | Open |
 | SEARCH-02 | 검색 | 식물 학명/추천 검색 API를 백엔드가 제공하는가? | 백엔드 #92 대기, #273에서 API mode fixture 차단 | Blocked |
 | SEARCH-03 | 검색 | `GET /users/{keyword}`는 부분 검색인가, exact 검색인가? | #277 친구 선택·중복 이름 UX, backend #150 답변 필요 | Open |
-| MEMO-01 | Memo | 메모 생성, 목록, 수정, 삭제 API 제공 계획은 무엇인가? | 메모 화면 실데이터 연결 보류 | Open |
-| MEMO-02 | Memo | 메모 이미지 첨부는 어떤 API와 필드로 연결하는가? | 메모 사진 업로드 흐름 보류 | Open |
-| MEMO-03 | Memo | 메모 목록 response의 작성자, 이미지, 작성일, pagination 구조는 무엇인가? | 메모 목록 mapper와 카드 상태 보류 | Open |
+| MEMO-01 | Memo | 메모 생성, 목록, 수정, 삭제 API 제공 계획은 무엇인가? | backend #50 계약 답변·구현·OpenAPI 전 텍스트 CRUD 연결 보류 | Blocked |
+| MEMO-02 | Memo | 메모 이미지 첨부는 어떤 API와 필드로 연결하는가? | 사용자 보류 범위, 텍스트 CRUD와 분리 | Blocked |
+| MEMO-03 | Memo | 메모 목록 response의 작성자, 이미지, 작성일, pagination 구조는 무엇인가? | backend #50 계약 답변·OpenAPI schema 전 mapper 보류 | Blocked |
 | TESTENV-01 | 테스트 환경 | CI가 개인 소셜 계정 없이 매 run 인증을 발급받는 방법은 무엇인가? | authenticated probe와 UI E2E 보류 | Open |
 | TESTENV-02 | 테스트 환경 | 테스트 token의 TTL, 갱신·재발급·폐기 정책은 무엇인가? | 장시간 run과 만료 복구 보류 | Open |
 | TESTENV-03 | 테스트 환경 | backend 소유 fixture 사용자와 run별 데이터 격리 기준은 무엇인가? | 병렬 실행과 CRUD E2E 보류 | Open |
@@ -310,30 +310,30 @@
 
 ### MEMO-01. Memo API 제공 계획
 
-- 현재 근거: Swagger에 메모 생성, 목록, 수정, 삭제 API가 없다.
-- 프론트 영향: 메모 화면은 로컬 상태만 사용할 수 있다.
-- 확인 질문: 메모 CRUD endpoint, request, response, 권한 정책은 어떻게 제공되는가?
-- 프론트 반영: 답변 후 memo data/repository/provider 계층을 추가한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 2026-09-01 live OpenAPI 19개 path에 Memo path/schema가 없고 backend main `7d572cb`에도 Memo 구현 파일이 없다. backend [#50](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50)~#55는 모두 Open인 구현 계획이다.
+- 프론트 영향: 계획의 `/plants/{plantUuid}/memos`를 배포 endpoint로 간주할 수 없다. 생성 #51과 validation #55의 content 최대 길이는 200/500자로 충돌하고 성공 wrapper·멱등·오류 계약도 없다.
+- 확인 질문: plant 식별자, 장소 구성원/작성자 권한, 이미지 없는 생성 request part, 생성·수정 result, 삭제 status, validation·오류 code는 무엇인가?
+- 프론트 반영: #283은 [backend #50 계약 확인](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254) 답변과 live OpenAPI 동기화 전까지 로컬 Memo 화면을 유지하고 data/repository/provider 계층을 추가하지 않는다.
+- 답변: backend #50 답변 대기
+- 상태: Blocked
 
 ### MEMO-02. 메모 이미지 첨부 정책
 
-- 현재 근거: 메모 작성 화면에는 사진 UI가 있으나 Memo API와 Image API 연결 방식이 없다.
-- 프론트 영향: 메모 사진 업로드와 목록 표시를 확정할 수 없다.
-- 확인 질문: 메모 이미지는 `/s3/images` key를 참조하는가, Memo API multipart part로 직접 받는가?
-- 프론트 반영: 답변 후 메모 작성 Controller와 이미지 업로드 순서를 확정한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: 메모 작성 화면에는 사진 UI가 있고 backend #51·#53 계획은 Memo multipart의 direct image part를 제안하지만 구현과 OpenAPI가 없다. #53은 image 생략 시 기존 이미지 삭제와 null field 미갱신을 함께 적어 동작이 충돌한다.
+- 프론트 영향: 텍스트만 수정해도 기존 이미지를 잃을 수 있으므로 image 없는 update 정책 없이는 요청을 만들 수 없다.
+- 확인 질문: image 생략은 유지인지 삭제인지, 교체·명시적 삭제 part와 실패 시 정리 책임은 무엇인가?
+- 프론트 반영: 이미지 첨부는 사용자 보류 범위로 유지한다. 텍스트 CRUD는 image를 보내지 않아도 생성 가능하고 수정 시 기존 이미지를 보존한다는 계약만 선행 확인한다.
+- 답변: backend #50 답변 대기, 이미지 UI 연결은 사용자 재개 결정 필요
+- 상태: Blocked
 
 ### MEMO-03. 메모 목록 response 구조
 
-- 현재 근거: 메모 목록 화면은 작성자, 본문, 이미지, 삭제 액션을 표시한다.
-- 프론트 영향: 메모 카드 mapper와 pagination 정책을 정할 수 없다.
-- 확인 질문: 메모 id, 작성자, 작성일, 이미지 url/key, 권한, pagination 필드는 무엇인가?
-- 프론트 반영: 답변 후 memo list provider와 삭제/수정 액션을 API mode로 연결한다.
-- 답변: 미확인
-- 상태: Open
+- 현재 근거: backend #52 계획은 `memoIdx`, `content`, `imgUrl`, `createdAt`, `updatedAt`만 제안하고 pagination은 명시하지 않는다. 현재 화면은 작성자 이름·프로필과 수정·삭제 메뉴를 표시한다.
+- 프론트 영향: 작성자 식별자·표시값·권한·목록 page 계약 없이 첫 항목, 표시 이름이나 임의 page wrapper로 mapper를 만들 수 없다.
+- 확인 질문: 안정적인 memo/author ID, 작성자 이름·프로필, `canEdit`/`canDelete` 또는 권한 판단 기준, 날짜 timezone, 정렬, empty, page/cursor 구조는 무엇인가?
+- 프론트 반영: backend #50 답변과 OpenAPI schema 뒤 memo list 상태와 mapper를 추가한다. 부분 항목을 버리거나 로컬 fixture와 병합하지 않는다.
+- 답변: backend #50 답변 대기
+- 상태: Blocked
 
 ## 테스트 환경
 

--- a/docs/follow-up-decision-checklist.md
+++ b/docs/follow-up-decision-checklist.md
@@ -77,7 +77,7 @@
 | [x] | API-ERROR | 공통/도메인 에러 response 정책 | ERROR-01, ERROR-02 | #275 typed 오류·field error·안전 메시지 연결. 인증 쓰기 validation smoke는 원격 E2E 보류 범위 | Done |
 | [ ] | API-TOKEN | refresh token과 로그아웃 정책 | TOKEN-01, TOKEN-02 | #275 확인 code의 로컬 세션 종료 완료. refresh·server invalidation은 backend #149 대기 | Partial |
 | [ ] | API-SEARCH | 주소/식물/사용자 검색 정책 | SEARCH-01, SEARCH-02, SEARCH-03 | 주소 검색, 식물 검색, 친구 추가 검색 UX | Open |
-| [ ] | API-MEMO | Memo CRUD와 이미지 첨부 정책 | MEMO-01, MEMO-02, MEMO-03 | 메모 화면 실데이터 연결 | Open |
+| [ ] | API-MEMO | Memo CRUD와 이미지 첨부 정책 | MEMO-01, MEMO-02, MEMO-03 | #283에서 backend #50에 텍스트 CRUD 계약을 요청했다. 구현·OpenAPI 전까지 원격 연결 금지, 이미지는 사용자 보류 | Blocked |
 | [x] | API-ENV-DEV | dev 서버 환경값과 Swagger | ENV-01-A | #213에서 dev origin, API base URL과 문서 endpoint를 확인했다. | Decided |
 | [ ] | API-TESTENV | remote integration 테스트 환경 | TESTENV-01~05 | #220에서 최소 준비 계약을 정리했다. 백엔드 인증·fixture·cleanup 답변과 저장소 설정 승인 전까지 TEST-02-B를 보류한다. | Blocked |
 | [ ] | API-ENV-RELEASE | staging/prod 환경값과 versioning | ENV-01-B | staging/prod release 검증은 백엔드 답변 전까지 미확정이다. | Open |

--- a/docs/screen-api-integration-plan.md
+++ b/docs/screen-api-integration-plan.md
@@ -34,9 +34,11 @@
 | 3 | #273 Plant 소속 장소 code·식물 검색 잔여 동선 | `PLANT-01`, `SEARCH-02` 확인 | Place API의 정확한 plant ID로 Home 진입 code 복원 완료. 검색은 backend #92까지 API mode 차단·미연결 안내 |
 | 4 | #275 공통 API 오류 메시지·토큰 만료 처리 | `ERROR-01~02` 확인, `TOKEN-01~02` endpoint 부재 확인 | 표준 오류·field 메시지와 `A003/A004/A009` 로컬 세션 종료 완료. refresh·서버 logout은 backend #149 대기 |
 | 5 | #277 Place 멤버·Friend 식별자 기반 쓰기 | `PLACE-05~06`, `FRIEND-05`, 멤버 고유 ID·변경 endpoint, Friend 고유 대상·부분 결과 계약 | backend #150 답변 전 Blocked. 조회 전용·member 나가기 숨김·이름 기반 위험 수용 경계 유지 |
-| 6 | Memo CRUD·목록 상태 API 연결 | `MEMO-01~03` 답변. 이번 순서에서는 이미지 첨부 제외 | 생성·목록·수정·삭제, pagination과 loading/empty/error/success를 수직 연결 |
+| 6 | #283 Memo 텍스트 CRUD·목록 상태 API 연결 | backend #50~#55 구현·OpenAPI 동기화와 `MEMO-01`, `MEMO-03` 답변. 이미지 첨부 제외 | backend #50 계약 확인 답변 전 Blocked. 로컬 화면 유지, 추정 DTO·pagination·권한 모델 추가 금지 |
 
 선행 계약이 없는 단계는 편의를 위해 fixture·첫 항목·표시 이름을 원격 값으로 사용하지 않습니다. 답변 대기 중인 사실을 기록하고 다음 단계의 계약 확인을 병행할 수는 있지만, 순서를 완료한 것으로 표시하지 않습니다.
+
+2026-09-01 #283에서 live OpenAPI 19개 path와 backend main `7d572cb`를 다시 확인했으며 Memo path/schema와 구현 파일은 없었습니다. backend #50~#55는 endpoint 초안이지만 본문 최대 200/500자, 이미지 생략 시 유지/삭제, 작성자·권한, pagination, 성공 wrapper가 확정되지 않았습니다. [backend #50 계약 확인 코멘트](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254)의 텍스트 CRUD 조건과 live OpenAPI가 일치한 뒤 별도 Feature 이슈를 생성합니다.
 
 ### 사용자 보류 범위
 
@@ -64,7 +66,7 @@ P0~P7은 기존 구현 순서를 보존한 표입니다. 다음 작업 순서는
 | P5 | Friend 수신 요청 | 요청 목록, 수락, 거절 API와 화면 상태 연결 | #241 / PR #242 병합 완료 |
 | P6 | Place 생성·수정 후속 흐름 | 생성 code·수정 결과와 친구 요청 전송 연결 | #243 / PR #244 병합 완료 |
 | P7 | Place 친구 관리 조회 | 실제 멤버 목록·이미지·닉네임 필터와 상태 UI | #245 / PR #246 병합 완료 |
-| 후속 | Memo | 텍스트 CRUD·목록 상태를 화면부터 API까지 연결 | #267 순서 6, `MEMO-01~03` 답변 필요 |
+| 후속 | Memo | 텍스트 CRUD·목록 상태를 화면부터 API까지 연결 | #283 계약 경계 정리, backend #50 답변·구현 전 Blocked |
 | 보류 | Image | 새 업로드 방식이 필요한 프로필·Place·Plant·Memo 이미지 흐름 | 사용자 재개 결정과 새 계약 필요 |
 
 P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기준으로 했습니다. #239는 live Swagger에 누락된 Place schema를 백엔드 main `7d572cb`의 Controller·DTO와 대조해 목록·상세 응답 계약을 연결했고, #241은 같은 source에서 확인한 Friend 수신 요청 계약을 화면까지 연결합니다.
@@ -89,8 +91,8 @@ P1은 Home 화면이 실제 로그인 직후 첫 진입점이라는 점을 기�
 | Plant | 식물 등록 | 장소·애칭·날짜와 create submit 연결, #250 잠금·#251 실제 장소·loading/error/empty·재시도·제출 보호 병합 | 학명/이미지·장소 사진 | `GET /place/user`, `POST /plants`; 실제 목록 code만 사용 | #251 / PR #261 병합, 인증 E2E 별도 |
 | Plant | 식물 수정 | #248 이미지 key 보존·#250 제출 잠금, #252 code 누락 차단, #273 Home 진입 code 복원 | 이미지 선택·삭제 UI | `GET /plants/{id}/edit`, `PUT /plants/{id}?placeCode=...`; route·Plant code 우선, 없으면 Place 상세 plant ID 대조 | 실제 code 복원·미발견 차단 회귀 검증 완료 |
 | Plant | 식물 상세 | detail/delete, 등록일 계산·실제 값, #273 code resolver loading/error/missing/success·재시도 연결 | Memo CRUD·물주기 액션, resolver N+1 최적화 | `GET/DELETE /plants/{id}`, `GET /place/user`, `GET /place/{code}`; Memo·물주기 API 없음 | #231 상세 연결, #273 code 복원 |
-| Memo | 메모 작성 | 로컬 Provider 저장 | DTO, repository, submit, 실제 image file | Memo 생성 endpoint 필요 | Blocked |
-| Memo | 메모 목록·수정·삭제 | 로컬 fixture·상태 | 목록, pagination, 수정·삭제, 상세 갱신 | Memo CRUD endpoint 필요 | Blocked |
+| Memo | 메모 작성 | 로컬 Provider 저장 | 텍스트 DTO, repository, async submit. 이미지는 별도 보류 | backend #50·#51 구현과 OpenAPI request/response·200자 validation 계약 필요 | #283 Blocked |
+| Memo | 메모 목록·수정·삭제 | 로컬 fixture·상태 | 작성자·권한·pagination, 수정·삭제, 상세 갱신 | backend #50·#52~#55 구현과 OpenAPI schema·오류 계약 필요 | #283 Blocked |
 | Onboarding | 온보딩 | 정적 화면 완료 | 필요 시 최초 실행 여부 로컬 저장 | 서버 API 불필요 | 연결 제외 |
 
 ## 병렬 작업 설계
@@ -256,6 +258,26 @@ resolver는 식물 상세의 loading·오류·미발견·성공과 재시도에 
 백엔드 #92도 `Open / Backlog`입니다. API 모드는 fixture를 원격 결과로 사용하지
 않고 미연결 안내와 선택 차단을 표시합니다. API 비사용 모드의 로컬 검색·empty·선택
 동작은 유지하며 실제 검색 상태 연결은 백엔드 #92 완료 후 별도 이슈로 진행합니다.
+
+## Memo API 계약 경계 #283
+
+2026-09-01 live OpenAPI에는 Memo path와 schema가 없고 backend main `7d572cb`에도
+Memo 구현 파일이 없습니다. backend #50~#55는 생성·조회·수정·삭제·validation의
+계획 이슈이며 배포 계약으로 사용하지 않습니다.
+
+- 생성 #51의 content 최대 200자와 validation #55의 최대 500자가 충돌합니다.
+- 수정 #53은 이미지 생략 시 삭제와 null이 아닌 필드만 갱신한다는 문구가 충돌합니다.
+- 조회 #52의 draft response에는 목록 화면에 필요한 작성자 식별자·이름·프로필,
+  수정·삭제 권한과 pagination이 없습니다.
+- 삭제 #54의 `204 No Content`가 현재 공통 `JsonResponse` 방식과 같은지 미확정입니다.
+- 이미지 흐름은 사용자 보류 범위이므로 텍스트 CRUD 선행 조건과 분리합니다.
+
+[backend #50](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254)에
+식별자·권한, 이미지 없는 multipart 요청, response wrapper, pagination·날짜,
+텍스트 수정 시 기존 이미지 유지, validation·오류 code를 요청했습니다. 답변과 구현이
+live OpenAPI에 반영되기 전에는 Memo DTO, repository, 원격 Provider와 임의
+pagination/result wrapper를 추가하지 않습니다. 현재 API 비사용 로컬 화면과 사진
+상태만 유지합니다.
 
 ## 공통 API 오류와 인증 만료 #275
 


### PR DESCRIPTION
## 관련 이슈

Closes #283

Backend dependency: [#50 계약 확인 코멘트](https://github.com/UMC-CommonPlant/v3_CommonPlant_Backend_Repo/issues/50#issuecomment-5488630254)

## 구현 범위

- 2026-09-01 live OpenAPI와 backend main·Memo #48~#55 재감사
- Memo 텍스트 CRUD의 현재 Blocked 경계와 구현 시작 조건 문서화
- README·실행 계획·백엔드 질문·Swagger 참고·후속 체크리스트 동기화
- Memo 코드, fixture, DTO/repository/Provider 구현은 제외

## 주요 변경사항

- live OpenAPI의 Memo path/schema 0개와 backend main의 구현 부재 기록
- backend #51·#55 content 200/500자, #53 image 생략 유지/삭제 충돌 기록
- 작성자 식별자·권한·pagination·날짜·wrapper·오류 code 필요 조건 명시
- 사용자 보류인 이미지 흐름과 선행 가능한 텍스트 CRUD 계약 분리
- backend 구현과 live OpenAPI가 일치하기 전 추정 DTO·pagination·권한 모델 추가 금지

## 테스트

- [ ] `fvm dart format --output=none --set-exit-if-changed .`
- [ ] `fvm flutter analyze`
- [ ] `fvm flutter test`
- [x] `git diff --check`
- 미실행 항목 및 이유: Markdown 문서만 변경해 로컬 Flutter 검증은 생략했습니다.

추가 확인:

- live OpenAPI HTTP 200, 전체 path 19개, Memo path/schema 0개
- backend main `7d572cbcabc81a65926738b2a09e8479d0bd0c79`
- backend Memo #48, #50~#55 모두 Open, Memo 구현 파일 0개

## 리뷰 포인트

- backend 계획 이슈를 배포 계약으로 오인하지 않는 경계가 명확한지
- 텍스트 CRUD 시작 조건과 사용자 보류 이미지 흐름이 충분히 분리됐는지
- backend #50 답변 전 프론트 Feature 이슈와 추상화를 만들지 않는 판단이 적절한지

## 문서 반영

- `README.md`
- `docs/screen-api-integration-plan.md`
- `docs/backend-api-open-questions.md`
- `docs/api-swagger-reference.md`
- `docs/follow-up-decision-checklist.md`

## Breaking change

- 없음
